### PR TITLE
Architecture foundation: design docs, ADRs 0001-0004, SPEC-0001

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+.sdd/
+
+# Local Claude Code settings — machine-specific, not shared.
+.claude/settings.local.json
+
+# Design handoff deliverables — contents are extracted into docs/design/.
+nms-design*.zip
+nmsbaseplannermocks.zip
+
+# No Man's Sky save files — personal game state, never commit (ADR-0002).
+# Includes decoded/decompressed dumps produced while working on the save parser.
+*.hg
+save*.hg
+mf_save*.hg
+**/HelloGames/**
+*.save.json
+*-decoded.json
+testdata/saves/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+## Architecture Context
+
+This project uses the [SDD plugin](https://github.com/joestump/claude-plugin-sdd) for architecture governance.
+
+- Architecture Decision Records are in `docs/adrs/`
+- Specifications are in `docs/openspec/specs/`
+
+### qmd Dependency
+
+Starting with SDD plugin v5.0.0, [qmd](https://github.com/tobi/qmd) is a hard dependency — `/sdd:init` enforces qmd presence at setup, and every qmd-aware consumer skill (`/sdd:prime`, `/sdd:check`, `/sdd:audit`, `/sdd:discover`, `/sdd:adr`, `/sdd:spec`, `/sdd:plan`, `/sdd:work`, `/sdd:review`) MAY assume qmd is installed and MUST NOT include conditional fallback paths. If a skill needs to handle "qmd installed but this repo not yet indexed", it routes to `/sdd:index` rather than silently degrading. This invariant lets every skill be designed for hybrid retrieval rather than around its absence.
+
+### SDD Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `/sdd:adr` | Create a new Architecture Decision Record (ADR) using MADR format |
+| `/sdd:spec` | Create a specification with requirements, scenarios, and design rationale |
+| `/sdd:list` | List all architecture decisions and specs with their status |
+| `/sdd:status` | Change the status of an ADR or spec (e.g., proposed to accepted, draft to… |
+| `/sdd:docs` | Generate a documentation site from your ADRs and specs |
+| `/sdd:init` | Set up CLAUDE.md with SDD plugin references for architecture-aware sessions |
+| `/sdd:prime` | Load ADR and spec context into the session for architecture-aware responses |
+| `/sdd:check` | Quick-check code against ADRs and specs for drift |
+| `/sdd:audit` | Comprehensive audit of design artifact alignment across the project |
+| `/sdd:discover` | Discover implicit architectural decisions and spec-worthy subsystems in an… |
+| `/sdd:plan` | Break an existing spec into trackable issues in your issue tracker |
+| `/sdd:organize` | Retroactively group existing issues into tracker-native projects |
+| `/sdd:enrich` | Retroactively add branch naming and PR convention sections to existing issue… |
+| `/sdd:work` | Pick up tracker issues and implement them in parallel using git worktrees |
+| `/sdd:review` | Review and merge PRs produced by /sdd:work using reviewer-responder agent pairs |
+| `/sdd:graph` | Build and query the SDD artifact graph |
+| `/sdd:index` | Index a repository's ADRs, OpenSpec specs, and source code into qmd collections… |
+| `/sdd:report-friction` | File a feedback issue against the SDD plugin (joestump/claude-plugin-sdd) when… |
+| `/sdd:respond` | Respond to review feedback on a PR — gather review comments, requested changes… |
+| `/sdd:search` | Unified semantic exploration skill combining qmd hybrid retrieval with cgg call… |
+
+Run `/sdd:prime [topic]` at the start of a session to load relevant ADRs and specs into context.
+
+### Governing Comments
+
+When implementing code governed by ADRs or specs, leave comments referencing the governing artifacts:
+
+```
+// Governing: ADR-0001 (chose JWT over sessions), SPEC-0003 REQ "Token Validation"
+```
+
+These comments help future sessions (and `/sdd:check`) trace implementation back to decisions.
+
+### Workflow
+
+1. **Decide**: `/sdd:adr` — record the architectural decision
+2. **Specify**: `/sdd:spec` — formalize requirements with RFC 2119 language
+3. **Plan**: `/sdd:plan` — break the spec into trackable issues in your tracker
+4. **Enrich**: `/sdd:organize` and `/sdd:enrich` — add projects and branch conventions
+5. **Build**: `/sdd:work` — pick up issues and implement in parallel using git worktrees
+6. **Review**: `/sdd:review` — review and merge PRs with spec-aware code review
+7. **Validate**: `/sdd:check` and `/sdd:audit` to catch drift
+
+### Session Coordination
+
+When orchestrating multiple SDD plugin skills in a single session (e.g., running `/sdd:work` on several issues), use `TeamCreate` to coordinate agents. Do not spawn ad-hoc background agents for work that requires coordination — `SendMessage` only works within a Team, and isolated agents cannot see sibling file claims or type creations.

--- a/docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md
+++ b/docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md
@@ -1,0 +1,156 @@
+---
+status: proposed
+date: 2026-08-17
+decision-makers: [Jon Stump]
+---
+
+# ADR-0001: Two-tier NMS game data ingestion via Go and MBINCompiler
+
+## Context and Problem Statement
+
+The base planner is driven entirely by No Man's Sky game data: a crafting/refining/cooking dependency graph (to render the tree canvas) and a set of base-economy constants — crop yields, biodome capacity, extractor rates, generator output in kPs (to compute the per-base build checklists). The design handoffs are explicit that the prototypes' numbers are illustrative and that *"production reads real game data"*, and they already anticipate that sources disagree — the `unverified` badge exists precisely because refiner-variant ratios differ between community sources.
+
+Where does that data come from, in what form does it reach the app, and under what license?
+
+## Decision Drivers
+
+* **No copyleft contamination.** The app must not inherit GPL-3.0 obligations from its data source.
+* **Refreshable per game update.** NMS ships frequent updates that change recipes; ingestion must be re-runnable, not hand-maintained.
+* **Provenance must be representable.** `unverified` is a designed UI affordance, so confidence has to be a property of the data, not a hardcoded list.
+* **Client-side shippable.** Plan state lives in the URL hash and the rollup engine runs in the browser (see the Overview in `docs/design/README.md`); the dataset must ship as a static artifact, not a runtime query.
+* **Verifiable against the design.** The handoffs specify a real 34-node Stasis Device tree, which gives us an exact acceptance test for any ingestion path.
+* **Learning goal.** The maintainer wants substantive Go in this project.
+
+## Considered Options
+
+* **A. Vendor AssistantNMS's extracted JSON** — copy `assets/json/en/*.json` from the AssistantNMS app repo
+* **B. Call the AssistantNMS public API at runtime**
+* **C. Direct extraction: Go pipeline invoking MBINCompiler as a subprocess** — with a second, hand-curated tier for economy constants
+* **D. Full Go reimplementation of MBIN decoding**
+* **E. Scrape the NMS community wikis**
+
+## Decision Outcome
+
+Chosen option: **C, direct extraction with a two-tier data model**, because it is the only option that gets the recipe graph under a permissive footing while keeping the refresh cycle under our control — and because the constants that extraction cannot supply turn out to be a small curated set rather than a second pipeline.
+
+**Tier 1 — extracted.** A Go CLI locates the game's `.pak` archives, extracts them, shells out to MBINCompiler to convert `.MBIN` → `.EXML`, then parses and normalizes the XML in Go into a version-stamped artifact: the recipe graph (products, substances, refinery, nutrient processor), item metadata, the biome→gas mapping from `GcGeneratorUnitComponentData.BiomeGasRewards`, the extractor taxonomy, and the base parts catalog. Regenerated per game version; never hand-edited.
+
+**Tier 2 — curated.** A hand-maintained YAML file of base-economy constants (generator outputs, power draws, extractor rates per class, biodome capacity, crop yields), each entry carrying a `source` and a `verified` date, feeding the same `unverified` badge convention the tree canvas uses.
+
+MBINCompiler is invoked as a **subprocess**, never linked. It is LGPL-3.0, and a license governs a program rather than its output, so the extracted artifact carries no copyleft obligation. AssistantNMS is retained as a **cross-check** on Tier 1 correctness — read, compared against, never vendored.
+
+Extraction takes **structure and quantities only**. In-game `Description` text and icon assets are Hello Games' creative expression and are excluded, consistent with the design bundle's own rule that *"No game assets or trade dress are used or should be."*
+
+### Consequences
+
+* Good, because the recipe graph is derived from the maintainer's own game files rather than copied from a GPL-3.0 repository, removing the copyleft question entirely.
+* Good, because the refresh cycle depends only on MBINCompiler's release cadence, not on a third party's decision to keep publishing JSON.
+* Good, because splitting extracted from curated data makes confidence explicit — Tier 2 entries are individually attributable and individually stale-able, which is exactly what the `unverified` badge renders.
+* Good, because the substantial engineering (normalization, graph construction, provenance, artifact emission) is pure Go, satisfying the learning goal without contorting the frontend.
+* Bad, because ingestion requires a local NMS install, so it cannot run in CI. It is a developer-local step producing a committed artifact.
+* Bad, because a game update invalidates the artifact and may require waiting for an MBINCompiler release before re-extraction is possible.
+* Bad, because Tier 2 is manual labour that must be re-verified after balance changes, and nothing automatically detects when it has gone stale.
+* Neutral, because MBINCompiler becomes a vendored build-time dependency with a .NET 8 runtime requirement on developer machines.
+
+### Confirmation
+
+The pipeline is correct when it reproduces the Stasis Device tree from `docs/design/tree-canvas/handoff.md` exactly, from `prod80`:
+
+* 34 distinct nodes across the Quantum Processor, Cryogenic Chamber, and Iridesite branches
+* Each gas product costing 250 gas + 50 Condensed Carbon
+* At quantity ×1: 500 each of Sulphurine / Nitrogen / Radon, and 300 Condensed Carbon
+
+This has already been verified by hand against extracted data and is the acceptance test for the Go implementation.
+
+Tier 2 is confirmed differently: every entry must carry a `source` and `verified` date, and any entry lacking one must render with the `unverified` badge rather than silently presenting as fact.
+
+## Pros and Cons of the Options
+
+### A. Vendor AssistantNMS's extracted JSON
+
+Copy the ~1.5 MB of `Products` / `RawMaterials` / `Refinery` / `NutrientProcessor` JSON out of the AssistantNMS app repository.
+
+* Good, because the data is clean, normalized, multilingual, and verified working — walking it reproduces the design's 34-node tree exactly.
+* Good, because it requires no game install, no .NET runtime, and no extraction step.
+* Bad, because the repository is **GPL-3.0**, and copying data files out of a copyleft work carries a real argument that the app inherits those obligations.
+* Bad, because it does not close the constants gap — their `Buildings.lang.json` schema has no power or yield fields, so Tier 2 would still be needed.
+* Bad, because the refresh cadence belongs to someone else.
+
+### B. Call the AssistantNMS public API at runtime
+
+* Good, because it sidesteps vendoring the files.
+* Bad, because it makes a fully client-side app depend on a third-party service at runtime, contradicting the offline-capable, URL-hash-shareable design.
+* Bad, because the terms of use are unestablished and the app would break if the API changed or went away.
+* Bad, because it still does not supply the economy constants.
+
+### C. Direct extraction via Go + MBINCompiler (chosen)
+
+* Good, because MBINCompiler is **LGPL-3.0** and used as a subprocess, so neither the tool nor its output imposes obligations on this project.
+* Good, because the maintainer controls the whole cycle and the artifact is provably derived from their own game files.
+* Good, because macOS is supported — a prebuilt `osx-arm64` archive ships each release, requiring the .NET 8 runtime.
+* Good, because the game data contains useful structure beyond recipes (`BiomeGasRewards`, the extractor taxonomy, `GcLinkNetworkTypes` modelling power and plant-growth networks) that a JSON re-publisher may not expose.
+* Bad, because it requires a local game install and a .NET runtime, and cannot run in CI.
+* Bad, because MBINCompiler version must match the game version or decompilation fails.
+* Neutral, because it does not close the Tier 2 gap either — but nothing does.
+
+### D. Full Go reimplementation of MBIN decoding
+
+* Good, because it would remove the .NET dependency and make the pipeline a single Go binary.
+* Bad, because MBIN files are serialized C# structs and are not self-describing. libMBIN's value is roughly a thousand hand-maintained struct definitions keyed per game version — which is why it needs a release after every patch.
+* Bad, because reimplementing that means maintaining a parallel libMBIN indefinitely. That is a larger project than the planner itself.
+
+### E. Scrape the community wikis
+
+* Good, because the wikis document the economy constants that game-file extraction does not appear to expose.
+* Bad, because wiki content is generally CC-BY-SA, which carries its own share-alike considerations for prose (though the numeric facts themselves do not).
+* Bad, because scraping is brittle against page restructuring and gives worse provenance than a hand-curated file with explicit sources.
+* Neutral, because the wikis remain a legitimate *source* for Tier 2 entries — the rejection is of automated scraping as an architecture, not of the wikis as a reference.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    A["NMS install<br/>GAMEDATA/PCBANKS/*.pak"] -->|PSARC extract| B[".MBIN files"]
+    B -->|"MBINCompiler subprocess<br/>(LGPL-3.0)"| C[".EXML files"]
+    C -->|"Go: encoding/xml"| D["Normalizer<br/>(graph build, ID resolution, provenance)"]
+    D --> E["Tier 1 artifact<br/>recipe graph + metadata<br/>version-stamped"]
+    F["Tier 2 YAML<br/>economy constants<br/>source + verified per entry"] --> G
+    E --> G["Merged plan dataset<br/>(static asset)"]
+    G --> H["Client-side rollup engine"]
+    H --> I["Tree canvas"]
+    H --> J["Base planner"]
+    K["AssistantNMS JSON<br/>GPL-3.0 — not vendored"] -.->|cross-check only| D
+```
+
+## More Information
+
+**Operational: extraction runs on Linux, the artifact crosses via git.** Ingestion needs a local NMS install, so it runs on the maintainer's Linux gaming PC, not the macOS development machine. This is the intended split, not a workaround — the Consequences section already records that ingestion is a developer-local step producing a committed artifact.
+
+* **Game data** lives in the ordinary Steam library; Proton virtualizes the Windows environment, not the install: `~/.steam/steam/steamapps/common/No Man's Sky/GAMEDATA/PCBANKS/*.pak`
+* **Save files** (for ADR-0002) live inside the Proton prefix, NMS being Steam app ID `275850`: `~/.steam/steam/steamapps/compatdata/275850/pfx/drive_c/users/steamuser/AppData/Roaming/HelloGames/NMS/st_<steamid>/`
+* **MBINCompiler ships first-class Linux binaries** — release `v6.45.0-pre1` publishes `MBINCompiler-linux`, `MBINCompiler-linux-dotnet6`, `libMBIN-linux.so`, and `libMBIN-linux-dotnet6.so`. It requires the .NET 8 runtime and does not need mono. Notably that release publishes **no macOS asset at all**, despite the README stating one accompanies every release — a further reason extraction belongs on Linux.
+* **Flow:** Linux PC extracts, normalizes, and commits the artifact; the Mac pulls and develops against it. The development machine never needs .NET, MBINCompiler, or the game installed.
+
+**Never commit a real save file.** The Tier 1 artifact is game data and is safe to commit. A save file is *player* data — discovered systems, base locations, platform UID — and committing one would defeat ADR-0002's privacy rationale permanently, since git history preserves it. Test fixtures MUST be either gitignored, drawn from a throwaway playthrough, or synthesized from a scrubbed `PersistentPlayerBases` subtree. The synthetic option is preferred: smaller, readable, and free of personal data.
+
+**Tier 2 rests on a provisional finding.** A search of libMBIN's struct definitions — every numeric field matching `Consumption|Production|Supply|Demand|Grid|Wattage|Output|Generation|Extract|Yield|Growth|Mine`, all 208 entries of `GcStatsTypes`, plus `GcBuildingGlobals` and `GcMaintenanceComponentData` — found no field corresponding to generator kPs, extractor rate per class, biodome capacity, crop yield, or C/B/A/S class multipliers.
+
+This is a *searched hard, did not find it* result, **not proof of absence**. libMBIN exposes field names and types, not values; the constants could live in a generically-named field, in a table not yet identified, or be compiled into the executable. **This ADR should not be marked `accepted` until the finding is confirmed by decompiling actual MBIN files and inspecting them.** If the constants turn out to be extractable, Tier 2 shrinks or disappears and this decision should be revised rather than superseded.
+
+Supporting signal that Tier 2 matches the design's intent: `docs/design/base-planner/handoff.md` already specifies these values as tweakable parameters — *"`emOutput` (kPs, default 110): base EM generator output at class B — swap in real game data without touching code."* The mock's tweaks panel is the curated-constants file in prototype form.
+
+**On Hello Games' position.** No explicit written policy permitting data extraction was found. What is established: Hello Games officially supports modding, and a large extraction ecosystem has operated openly for years without enforcement action. This is *tolerated in practice, not granted in writing*. The EULA governs and has not been reviewed. Taking structure rather than expression, and shipping no game assets, is the mitigation — and it aligns with the design bundle's own rule.
+
+**Open questions deferred to later ADRs.**
+
+1. Frontend stack — deliberately independent; any stack consumes the same artifact.
+2. Whether a backend is introduced later for screenshot storage, plan persistence, or sync. The Tier 1 artifact schema is the contract such an API would serve, so it should be designed as if it will be served.
+3. Tier 1 artifact format (JSON vs. something more compact) and whether it ships whole or is split per target item.
+
+**References.**
+
+* `docs/design/README.md` — data fidelity and no-game-assets rule
+* `docs/design/tree-canvas/handoff.md` — the 34-node Stasis Device tree used as the acceptance test
+* `docs/design/base-planner/handoff.md` — the economy constants, specified as tweaks
+* [MBINCompiler](https://github.com/monkeyman192/MBINCompiler) — LGPL-3.0, `v6.45.0-pre1` (June 2026)
+* [AssistantNMS/App](https://github.com/AssistantNMS/App) — GPL-3.0, cross-check reference only

--- a/docs/adrs/ADR-0002-client-side-save-import.md
+++ b/docs/adrs/ADR-0002-client-side-save-import.md
@@ -1,0 +1,161 @@
+---
+status: proposed
+date: 2026-08-17
+decision-makers: [Jon Stump]
+extends: [ADR-0001]
+---
+
+# ADR-0002: Client-side save file import for base bootstrapping
+
+## Context and Problem Statement
+
+Starting a plan currently means the player types everything by hand: base names, a 12-glyph portal address per base, biome and hazard notes, and which producers already exist. That is the worst part of onboarding, and all of it already exists in the player's No Man's Sky save file.
+
+Saves are readable — `.hg` files are sequential 16-byte block headers with magic `0xFEEDA1E5` followed by LZ4 payloads, unencrypted in modern formats (2002+, post-Frontiers), decompressing to JSON with obfuscated three-character keys. The deobfuscation table ships as `mapping.json` with MBINCompiler, which ADR-0001 already commits us to.
+
+Should the planner import saves, and if so, where does parsing run?
+
+## Decision Drivers
+
+* **Onboarding friction** — hand-entering 12 portal glyphs per base is the single worst step in the current flow.
+* **Privacy** — a save is the player's entire game state: discovered systems, inventory, platform UID, every base location. It is far more than the planner needs.
+* **Safety** — a planning tool that can corrupt a save is a planning tool nobody trusts.
+* **Dependency reuse** — `mapping.json` and the base-parts catalog are already required by ADR-0001; save import is largely a join away.
+* **Platform reach** — console players cannot readily extract save files, so this cannot be the only onboarding path.
+* **Learning goal** — the maintainer wants substantive Go in this project.
+
+## Considered Options
+
+* **A. No save import** — manual entry only
+* **B. Server-side parsing** — user uploads the save, backend parses and returns base records
+* **C. Client-side parsing, Go compiled to WASM**
+* **D. Client-side parsing, reimplemented in TypeScript**
+* **E. Wrap an existing save tool** (NomNom, goatfungus, NMSSaveExplorer)
+
+## Decision Outcome
+
+Chosen option: **C, client-side parsing with Go compiled to WASM**, with import **strictly read-only** and delivered in stages.
+
+The privacy driver eliminates B outright and is the load-bearing part of this decision: **the save file must never leave the browser.** That narrows the field to C or D. Between those, the engineering case is close — LZ4 plus JSON is not hard in TypeScript either, and if the frontend turns out to be TypeScript, D is arguably the simpler shipping choice. C wins on two grounds that are honest to name as partly non-technical: the parsing and normalization logic is shared with the ADR-0001 ingestion CLI rather than written twice in two languages, and it serves the maintainer's stated goal of writing real Go. **This is a judgment call weighted by project goals, not a claim that WASM is technically superior.** If WASM tooling proves painful in the spike, falling back to D costs little and should not be treated as a failure of this ADR.
+
+**Import is read-only.** The application MUST contain no code path that writes a save file. Import parses, extracts, and discards.
+
+**Staged scope:**
+
+1. **Identity** — `Name`, `GalacticAddress` (from which the portal address derives), `BaseType`. This alone removes manual glyph entry and is worth shipping on its own.
+2. **Built inventory** — `Objects[].ObjectID` joined against the ADR-0001 parts catalog, yielding counts of biodomes, extractors, generators and panels per base. Feeds pre-checked BUILD TODO items and lets the POWER block compute *existing* generation and draw instead of assuming a blank site.
+3. **Storage** — container inventories feeding the v2 stocked-vs-needed bars. **Speculative** — not yet confirmed reachable in the save.
+
+Manual base entry remains a first-class path, since console players cannot use import at all.
+
+### Consequences
+
+* Good, because the worst onboarding step disappears for PC and Mac players, and the data arrives more accurately than hand transcription would produce.
+* Good, because the save never leaves the user's machine, so the app takes on no custody of sensitive player data and needs no upload endpoint, retention policy, or deletion story.
+* Good, because it reuses `mapping.json` and the parts catalog already required by ADR-0001 — one dependency serving two features.
+* Good, because staging means stage 1 ships independently and delivers most of the onboarding benefit.
+* Bad, because it is PC/Mac only. Console players get no benefit, so every import-fed field needs a manual equivalent and the UI must not imply import is required.
+* Bad, because save formats drift across game updates; `BaseVersion` exists precisely because the structure changes. Import must fail legibly on an unrecognized version rather than silently producing wrong bases.
+* Bad, because Go/WASM adds build complexity and harder cross-boundary debugging relative to a native TypeScript parser.
+* Neutral, because `mapping.json` is fetched at ingestion time rather than vendored, keeping MBINCompiler's LGPL-3.0 redistribution question out of the repository.
+
+### Confirmation
+
+* **Privacy is verifiable, not aspirational.** The import path MUST issue no network request. A test asserts that no `fetch`/`XHR`/WebSocket call occurs during parse, and review treats any network call added to that path as a defect.
+* **Read-only is structural.** The codebase contains no save-writing function. Absence is confirmed by grep in review, not by convention.
+* **Round-trip correctness.** A fixture save parses to a known set of base names, galactic addresses, and part counts.
+* **Version failure is graceful.** A save with an unrecognized `BaseVersion` or a `mapping.json` version mismatch produces a clear user-facing message and imports nothing, rather than partially populating.
+
+## Pros and Cons of the Options
+
+### A. No save import
+
+* Good, because it is zero work and carries no privacy surface at all.
+* Good, because it treats every platform identically — console players are not second-class.
+* Bad, because it leaves the worst onboarding step in place, and hand-transcribing 12-glyph portal addresses is both tedious and error-prone.
+* Bad, because it discards data the player already has, for no benefit.
+
+### B. Server-side parsing
+
+Upload the save; a backend parses it and returns base records.
+
+* Good, because parsing runs in one well-controlled environment with no WASM toolchain and easy debugging.
+* Good, because it would work identically on any client, including mobile.
+* Bad, because it requires the user to hand over their complete game state — discovered systems, inventory, platform UID — to obtain base names and addresses. Grossly disproportionate to the benefit.
+* Bad, because it creates data-custody obligations (retention, deletion, breach exposure) that a planning tool has no business taking on.
+* Bad, because it forces a backend into an otherwise client-side app, contradicting the deployment model.
+
+### C. Client-side parsing, Go compiled to WASM (chosen)
+
+* Good, because the save never leaves the browser — the privacy problem is solved structurally rather than by policy.
+* Good, because parsing and normalization logic is shared with the ADR-0001 ingestion CLI instead of being maintained twice in two languages.
+* Good, because Go handles this format natively — LZ4 block decompression via a BSD-3-Clause library plus `encoding/json`, with no subprocess and no .NET runtime. This is a genuine contrast with MBIN, which is not tractable in Go.
+* Good, because it advances the maintainer's Go learning goal on a real problem.
+* Bad, because WASM adds build tooling and makes debugging across the JS boundary harder.
+* Bad, because it ships a WASM payload the user downloads whether or not they use import — mitigable by loading it lazily.
+* Neutral, because the engineering advantage over option D is modest; the deciding factors are code-sharing and project goals.
+
+### D. Client-side parsing in TypeScript
+
+* Good, because it solves privacy exactly as well as C — the file still never leaves the browser.
+* Good, because it needs no WASM toolchain, debugs natively in the browser, and adds no payload beyond ordinary JS.
+* Good, because LZ4 and JSON parsing are well-served by existing TypeScript libraries.
+* Bad, because the save-parsing and normalization logic would exist twice — once in Go for the ingestion CLI, once in TypeScript — with two places to fix when the format drifts.
+* Bad, because it does not serve the Go learning goal.
+* Neutral, because this is a legitimate fallback if WASM proves painful, not a rejected-on-merit option.
+
+### E. Wrap an existing save tool
+
+Shell out to or embed NomNom, goatfungus' editor, or NMSSaveExplorer.
+
+* Good, because these are mature and handle platform quirks and format drift already.
+* Bad, because they are desktop applications, not libraries, and cannot run in a browser — which defeats the client-side requirement entirely.
+* Bad, because licensing is hostile to reuse: NomNom and the NMSCD tools are GPL-3.0; goatfungus' editor and NMSSaveExplorer publish no license at all, which is more restrictive than GPL, not less.
+* Bad, because they are full *editors*, carrying save-writing capability this project deliberately refuses.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    subgraph browser["Browser — save never leaves this boundary"]
+        A["User drops save.hg"] --> B["Go/WASM parser"]
+        B --> C["LZ4 block decode<br/>magic 0xFEEDA1E5"]
+        C --> D["JSON with obfuscated keys"]
+        D --> E["Deobfuscate via mapping.json"]
+        E --> F["PersistentPlayerBases[]"]
+        F --> G["Stage 1: Name, GalacticAddress, BaseType"]
+        F --> H["Stage 2: Objects[].ObjectID"]
+        H --> I["join"]
+        I --> K["Base records<br/>identity + already-built"]
+        G --> K
+        K --> L["Base planner cards"]
+    end
+    J["Tier 1 parts catalog<br/>(ADR-0001)"] --> I
+    M["Tier 2 constants<br/>(ADR-0001)"] --> N["Existing power gen / draw"]
+    K --> N
+    O["Manual entry"] --> L
+```
+
+## More Information
+
+**Verified against the live mapping table.** Every field this decision depends on was resolved in `mapping.json` (1,424 entries, `libMBIN_version 6.45.0.1`): `PersistentPlayerBases` → `F?0`, `Name` → `NKm`, `GalacticAddress` → `oZw`, `BaseType` → `peI`, `Objects` → `@ZJ`, `ObjectID` → `r<7`, `Position` → `wMC`, plus `Owner`, `RegionSeed`, `LastUpdateTimestamp`, `BaseVersion`.
+
+**Unverified, to settle during the spike:**
+
+1. The macOS save file location. PC is `%APPDATA%/HelloGames/NMS/st_<steamid>/`; the Mac path is presumably under `~/Library/Application Support/HelloGames/` but has not been confirmed.
+2. Whether container inventories are reachable, which determines if stage 3 is feasible at all.
+3. Whether `ObjectID` values join cleanly to `GcBaseBuildingEntry.ID` without normalization — the join is the premise of stage 2 and should be proven early.
+
+**Multiple save slots.** `save.hg`, `save2.hg` and so on correspond to different playthroughs. The import flow needs a slot picker; silently taking the first file found would be wrong.
+
+**Why format knowledge is safe to use.** The `.hg` structure is a fact about a file format, not copyrightable expression, and this project implements it independently. The same reasoning as ADR-0001: no code is taken from the GPL-3.0 and unlicensed tools surveyed above, and `mapping.json` is fetched at ingestion time rather than redistributed.
+
+**Relationship to open decisions.** This ADR strengthens the case for a Go/WASM component in the frontend stack decision, which remains open. It does not settle that decision — a TypeScript frontend with a TypeScript parser (option D) remains coherent, and the fallback is cheap. The stack ADR should weigh this alongside the tree-canvas rendering requirement.
+
+**References.**
+
+* ADR-0001 — supplies `mapping.json` and the base-parts catalog this decision joins against
+* `docs/design/base-planner/handoff.md` — the base card fields import populates (env strip, portal address, BUILD TODO, POWER)
+* [MBINCompiler](https://github.com/monkeyman192/MBINCompiler) — source of `mapping.json`, LGPL-3.0
+* [pierrec/lz4](https://github.com/pierrec/lz4) — BSD-3-Clause, LZ4 block support for Go
+* Surveyed and rejected for reuse: [NomNom](https://github.com/zencq/NomNom) (GPL-3.0), [NMSCD/NMS-Save-Decoder](https://github.com/NMSCD/NMS-Save-Decoder) (GPL-3.0), [goatfungus/NMSSaveEditor](https://github.com/goatfungus/NMSSaveEditor) (unlicensed), [NMSSaveExplorer](https://github.com/CheckForUpdates/NMSSaveExplorer) (unlicensed)

--- a/docs/adrs/ADR-0003-go-wasm-domain-core.md
+++ b/docs/adrs/ADR-0003-go-wasm-domain-core.md
@@ -1,0 +1,159 @@
+---
+status: proposed
+date: 2026-08-17
+decision-makers: [Jon Stump]
+extends: [ADR-0001, ADR-0002]
+---
+
+# ADR-0003: Go/WASM domain core with a thin view layer
+
+## Context and Problem Statement
+
+The planner's substantive logic — dependency graph construction, method resolution, quantity rollup, power math, save parsing, plan serialization — has to live somewhere. ADR-0001 put game-data ingestion in a Go CLI; ADR-0002 put save parsing in Go compiled to WASM. Neither settled where the rest goes.
+
+The maintainer's stated goal is to learn Go at depth, which raises the obvious follow-up: should the *frontend itself* be Go? Where exactly is the line between Go and JavaScript?
+
+## Decision Drivers
+
+* **Learning goal** — the maintainer explicitly wants to be thrown in the deep end on Go, not to write a thin Go veneer.
+* **Code reuse** — the ingestion CLI (ADR-0001) and the browser both need the same graph model and the same notion of a recipe node. Writing it twice guarantees divergence.
+* **Canvas requirement** — the tree canvas needs a mature flow library with pan/zoom, custom nodes, and bezier edge routing. `docs/design/tree-canvas/handoff.md` names React Flow plus elkjs. No Go equivalent exists, and elkjs itself is a transpiled Java project with no Go port.
+* **Testability** — the rollup math is pure computation with known-correct expected values from the handoffs. It should be testable without a browser.
+* **Replaceability** — the view framework is the part most likely to be revisited; domain logic should survive a change of mind.
+* **Interaction latency** — every recompute (method toggle, class picker, quantity slider) must feel instant.
+
+## Considered Options
+
+* **A. All logic in TypeScript** — Go confined to the ingestion CLI
+* **B. Go frontend framework** — whole UI in Go via go-app or Vugu
+* **C. Go/WASM domain core with a thin JS view layer**
+* **D. Ad hoc split** — some logic in Go, some in TypeScript, decided case by case
+
+## Decision Outcome
+
+Chosen option: **C, a Go/WASM domain core with a thin JS view layer**, because it puts the majority of the app's non-trivial code in Go — satisfying the learning goal far better than a Go veneer would — while leaving the one genuinely hard UI component to a library that already exists.
+
+**The Go core owns:**
+
+* Dependency graph construction, traversal, and cycle detection
+* Method resolution — craft / refine / raw / cook, and which are legal per node
+* Quantity propagation and the producer rollup: plants = qty ÷ yield, domes = plants ÷ 16, extractor counts sized to fill time, harvest and fill durations
+* Power math — generation and draw, EM class multipliers, solar plus battery derivation, deficit sizing
+* Leaf-to-base assignment and per-base aggregation
+* Save file parsing and the `ObjectID` → parts-catalog join (ADR-0002)
+* Plan serialization to and from the URL hash
+
+**The view layer owns:**
+
+* CSS from the design tokens, and all component markup
+* Flow library wiring and elkjs layout invocation
+* Local UI state — selection, section collapse, form inputs, focus management
+* Accessibility — focus trapping in the method popover, `aria-live` announcements, topological tab order
+
+**Package boundary — the load-bearing structural rule.** The domain lives in a package that imports **no** `syscall/js`. A separate, thin adapter package is the only code permitted to touch `js.Value`. This is what makes the domain testable as ordinary Go, reusable verbatim by the ingestion CLI, and portable if WASM is ever abandoned. Without this split, the "shared code" benefit evaporates and the domain becomes untestable outside a browser.
+
+**Data crosses the boundary as serialized values**, not live object graphs. The view never recomputes a domain value it could ask for.
+
+### Consequences
+
+* Good, because roughly two-thirds of the app's non-trivial code is Go, which is what "deep end" actually means here — graph algorithms, table-driven tests, interfaces, error handling — rather than learning one framework's component API.
+* Good, because the ingestion CLI and the browser share one graph implementation, so the Stasis Device tree cannot mean two different things in two places.
+* Good, because the pure-Go domain package is testable at speed with no browser and no WASM toolchain in the loop.
+* Good, because the view framework becomes a smaller, more reversible decision — a stack change costs the views, not the domain.
+* Good, because the tree canvas uses a mature library instead of a hand-rolled canvas competing with one.
+* Bad, because the WASM payload is real — standard Go WASM output runs to multiple megabytes. Mitigable with lazy loading and TinyGo, but it is a cost React or Svelte alone would not carry.
+* Bad, because debugging across the JS/WASM boundary is harder than a single sourcemapped language, and Go WASM stack traces in a browser are poor.
+* Bad, because there is still a substantial JavaScript surface. Accessibility, focus management, and DOM work all stay in JS, so this is not "escaping JavaScript" — it is drawing a line through the middle of the app.
+* Neutral, because marshalling cost at the boundary is unlikely to matter at this app's scale (34 nodes, a handful of bases), but it is a real constraint on how chatty the interface can be.
+
+### Confirmation
+
+* **The domain package imports no `syscall/js`.** Verified by grep in review. This is the structural guarantee the whole decision rests on; if it erodes, the decision has failed even if the app works.
+* **The ingestion CLI and the WASM build import the same domain package.** Two import paths, one implementation.
+* **Table-driven tests reproduce the handoffs' known values**: the 34-node Stasis Device tree, 500 each of Sulphurine/Nitrogen/Radon and 300 Condensed Carbon at ×1, and the base-planner rollup figures at `deviceQty` 1 and 10.
+* **Domain tests run without a browser or WASM toolchain** — plain `go test`.
+
+## Pros and Cons of the Options
+
+### A. All logic in TypeScript
+
+* Good, because it is one language end to end, with the best debugging story and no boundary to marshal across.
+* Good, because it has the smallest payload and the simplest build.
+* Bad, because the graph model would exist twice — once in the Go ingestion CLI, once in TypeScript — with two places to fix every time the model changes.
+* Bad, because it reduces Go to a data-prep script, which does not meet the learning goal at all.
+
+### B. Go frontend framework (go-app, Vugu)
+
+Whole UI in Go compiled to WASM.
+
+* Good, because it is the maximum amount of Go, with a single language for the entire application.
+* Good, because [go-app](https://github.com/maxence-charriere/go-app) is genuinely maintained (8,953 stars, pushed 2026-08-12) and renders ordinary HTML/CSS, so the token-based design would be expressible.
+* Bad, because **there is no Go flow-graph library**. The tree canvas would have to be hand-built — pan/zoom, custom nodes, bezier routing, hit testing — competing with a mature library, before any planner logic gets written.
+* Bad, because the alternative to hand-building is calling elkjs and a JS flow library through `syscall/js`, which means writing stringly-typed glue in Go's `js.Value` API precisely where the interaction density is highest — losing the type safety that motivated Go.
+* Bad, because the accessibility work the handoffs specify (focus trap with return-to-node, `aria-live` on every recompute, topological tab order) is painful through `syscall/js`.
+* Bad, because [Vugu](https://github.com/vugu/vugu) self-describes as experimental and [Vecty](https://github.com/hexops/vecty) has not been pushed since October 2022.
+* Neutral, because it teaches go-app's API more than it teaches Go — narrower and less transferable knowledge than a domain core would give.
+
+### C. Go/WASM domain core with a thin JS view layer (chosen)
+
+* Good, because it concentrates Go on graph algorithms and computation, which is transferable Go knowledge rather than framework-specific knowledge.
+* Good, because it shares one implementation with the ingestion CLI.
+* Good, because it leaves the canvas to React Flow or Svelte Flow and elkjs, exactly as the handoff recommends.
+* Good, because the pure-domain package stays testable without a browser.
+* Bad, because it is two languages and a marshalling boundary, with the debugging cost that implies.
+* Bad, because the WASM payload is larger than a JS-only app.
+
+### D. Ad hoc split
+
+Decide per feature whether logic goes in Go or TypeScript.
+
+* Good, because each piece can go wherever it is most convenient at the time.
+* Bad, because without a stated boundary the split drifts, and "which language owns this rule?" becomes a question asked repeatedly forever.
+* Bad, because duplicated logic appears silently on both sides and diverges without anyone noticing.
+* Bad, because it makes the domain untestable as a unit — the thing that makes option C worth its costs.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    subgraph go["Go — shared domain package (no syscall/js)"]
+        D1["Dependency graph<br/>build · traverse · cycle detect"]
+        D2["Method resolution<br/>craft · refine · raw · cook"]
+        D3["Rollup engine<br/>plants · domes · extractors · times"]
+        D4["Power math<br/>gen · draw · class mult · deficit"]
+        D5["Save parsing<br/>+ ObjectID join (ADR-0002)"]
+        D6["Plan serialization<br/>URL hash"]
+    end
+
+    CLI["Ingestion CLI<br/>(ADR-0001)"] --> go
+    go --> ADP["wasm adapter package<br/>(the only syscall/js code)"]
+    ADP --> VIEW
+
+    subgraph VIEW["View layer — JS/TS"]
+        V1["Tokens + component CSS"]
+        V2["Flow library + elkjs"]
+        V3["Local UI state<br/>selection · collapse · inputs"]
+        V4["A11y: focus trap · aria-live"]
+    end
+
+    VIEW --> UI["Tree canvas · Base planner"]
+    ART["Tier 1 + Tier 2 data<br/>(ADR-0001)"] --> go
+```
+
+## More Information
+
+**What this changes about ADR-0002.** That ADR scoped Go/WASM to save parsing and noted the engineering case against a TypeScript parser was modest — mostly code-sharing plus the learning goal. This decision strengthens that considerably: with the whole domain in Go, a TypeScript save parser would be an isolated island of duplicated model knowledge. The ADR-0002 fallback to TypeScript is correspondingly less attractive, though still available if WASM proves unworkable in the spike.
+
+**On payload.** Standard Go WASM output is multiple megabytes. Three mitigations, in order of preference: lazy-load the WASM module so first paint does not wait on it, evaluate TinyGo (smaller output, but with reflection and stdlib limits worth checking against the JSON parsing in ADR-0002), and keep the boundary coarse so the module does not need to be chatty. Worth measuring in the spike rather than assuming.
+
+**On the honest limits of this decision.** This is not an escape from JavaScript. Accessibility, focus management, styling, and the entire canvas remain JS work, and the handoffs specify real accessibility depth. Expect a meaningful JS surface regardless — the claim is that the *interesting* logic is Go, not that JS is marginal.
+
+**Deferred.** The view framework is a separate decision (see ADR-0004) and deliberately smaller because of this one. Client state management within the view is deferred further still — with domain state in Go, the view holds much less than a typical SPA, and the right answer depends on how the boundary feels in practice.
+
+**References.**
+
+* ADR-0001 — ingestion CLI sharing this domain package; Tier 1/Tier 2 data consumed by it
+* ADR-0002 — save parsing, now a component of this core rather than a standalone WASM module
+* `docs/design/tree-canvas/handoff.md` — the flow-library requirement that rules out a pure-Go frontend
+* `docs/design/base-planner/handoff.md` — the rollup and power math the core implements
+* [go-app](https://github.com/maxence-charriere/go-app) · [Vugu](https://github.com/vugu/vugu) · [Vecty](https://github.com/hexops/vecty) — surveyed and rejected for option B

--- a/docs/adrs/ADR-0004-react-view-layer.md
+++ b/docs/adrs/ADR-0004-react-view-layer.md
@@ -1,0 +1,124 @@
+---
+status: proposed
+date: 2026-08-17
+decision-makers: [Jon Stump]
+extends: [ADR-0003]
+---
+
+# ADR-0004: React with TypeScript and Vite for the view layer
+
+## Context and Problem Statement
+
+ADR-0003 moved the dependency graph, rollup engine, power math, save parsing, and plan serialization into a Go/WASM domain core. That leaves the view layer with a narrower job than a typical SPA: render the design's markup from its tokens, wire a flow library and elkjs for the tree canvas, hold local UI state, and carry the accessibility behavior the handoffs specify.
+
+Which framework does that job?
+
+## Decision Drivers
+
+* **Concentrate the learning budget.** Go is already the new thing (ADR-0001, ADR-0002, ADR-0003). Taking on an unfamiliar view framework at the same time means two simultaneous unknowns.
+* **The flow library is the hard dependency.** `docs/design/tree-canvas/handoff.md` names React Flow (`@xyflow/react`) plus elkjs explicitly.
+* **The design mandates custom CSS.** Every color, spacing step, and control size is measured and final, with strict border rules. Component libraries are largely unusable here, so ecosystem breadth matters less than it usually would.
+* **View state is small.** Domain state lives in Go. The view holds selection, section collapse, form inputs, and focus — not the plan.
+* **Accessibility is specified in detail.** Focus trapping in the method popover with return-to-node, `aria-live="polite"` on every recompute, nodes as buttons in topological tab order.
+
+## Considered Options
+
+* **A. React + TypeScript + Vite**
+* **B. SvelteKit + Svelte 5**
+* **C. Solid + SolidStart**
+
+## Decision Outcome
+
+Chosen option: **A, React with TypeScript and Vite**, because the maintainer already knows it, which is the whole point — it concentrates the learning budget on the Go domain core where the interesting work now lives.
+
+This is a deliberate trade and worth recording honestly: **on isolated merit the recommendation was Svelte 5.** Svelte Flow is first-party, so the hardest component carried no compromise; fine-grained reactivity suits the recompute-heavy interactions; and the static adapter matched the no-backend deployment. Those advantages are real and are being knowingly declined. What outweighs them is that ADR-0003 makes the Go core the substantial and unfamiliar part of this project, and adding a second unfamiliar thing alongside it raises the risk of finishing neither well.
+
+The performance argument for Svelte was investigated and **does not apply at this scale**. Measured package sizes put elkjs (7.8 MB unpacked) and the forthcoming Go WASM module far ahead of any framework delta; React and ReactDOM at roughly 40–45 KB gzipped versus Svelte's smaller runtime is a one-time, cache-friendly difference swamped by both. At 34 canvas nodes and three base cards, React's re-render model is comfortably fast with ordinary memoization. The real load-time levers — lazy-loading elkjs and lazy-loading the WASM module — are framework-independent.
+
+**Styling: plain CSS custom properties with scoped component styles.** The theme handoff specifies recreating tokens as CSS custom properties in a global stylesheet. A utility framework would fight that token discipline and the strict border rules, and buys nothing when no component library is in use.
+
+**No Redux for now.** With domain state in the Go core, the view holds far less than a typical React app, and Redux's actions/reducers/middleware machinery would be boilerplate around a small amount of UI state. Start with `useReducer` plus context, or Zustand if that proves thin. See the open question below — this is deferred, not settled.
+
+### Consequences
+
+* Good, because the maintainer is immediately productive in the view layer and attention goes to the Go core.
+* Good, because React Flow is the reference implementation the tree-canvas handoff was written against, so the guidance maps directly.
+* Good, because React's ecosystem depth is a genuine advantage for the accessibility work — focus trapping and live-region patterns are well-trodden, and the handoffs demand real rigor there.
+* Good, because ADR-0003 makes this decision cheap to revisit: a framework change costs the views, not the domain.
+* Bad, because it teaches the maintainer nothing new on the frontend, which was an original stated interest.
+* Bad, because React's re-render model is the weaker fit for the rollup recompute pattern, requiring memoization discipline on the `deviceQty` path that Svelte would have given structurally. Not a performance problem at this scale, but ongoing authoring attention.
+* Neutral, because bundle size is slightly larger than Svelte's, and immaterial next to elkjs and the WASM module.
+
+### Confirmation
+
+* **Tokens are CSS custom properties in a global stylesheet**, with no hardcoded hex values in component styles. Verified by grep for `#` literals outside the token file.
+* **Border discipline holds**: 3px identity frames only; hover is `filter: brightness(1.12)`, focus is an outboard outline, selection is an inboard ring via an overlay element. No `inset box-shadow` anywhere — it paints under positioned children.
+* **The view recomputes no domain values.** Any arithmetic on quantities, power, or counts in the React tree is a defect; those come from the Go core.
+* **Accessibility is tested, not assumed**: focus returns to the invoking node on popover close, and every recompute produces an `aria-live` announcement.
+
+## Pros and Cons of the Options
+
+### A. React + TypeScript + Vite (chosen)
+
+* Good, because the maintainer knows it, so the learning budget goes entirely to Go.
+* Good, because React Flow is exactly what the handoff specifies, making its guidance directly applicable.
+* Good, because the ecosystem is deepest where this project actually needs help — accessibility primitives, focus management.
+* Good, because Vite's build is fast and its WASM handling is well-supported.
+* Bad, because it teaches nothing new on the frontend.
+* Bad, because correct fine-grained updates require memoization discipline rather than coming for free.
+
+### B. SvelteKit + Svelte 5
+
+* Good, because runes are a genuinely different reactivity model and would be real learning.
+* Good, because Svelte Flow (`@xyflow/svelte`) is first-party from the xyflow team, so the hardest component carries no compromise.
+* Good, because fine-grained reactivity fits the recompute pattern structurally.
+* Good, because the static adapter matches the no-backend deployment model exactly.
+* Bad, because it is a second unfamiliar thing alongside the Go core, and the Go core is where this project's difficulty is now concentrated.
+* Neutral, because the smaller ecosystem costs little here — the design requires custom CSS regardless.
+
+### C. Solid + SolidStart
+
+* Good, because signals give fine-grained updates, and JSX means React knowledge partly transfers.
+* Good, because performance is excellent for fine-grained update patterns.
+* Bad, because there is no first-party flow library — only community Solid ports of varying maturity, on the single hardest component in the app. That is the wrong place to accept ecosystem risk.
+* Bad, because it carries much of Svelte's unfamiliarity cost without Svelte's first-party flow support.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    CORE["Go/WASM domain core<br/>(ADR-0003)"] -->|"serialized values"| BR
+
+    subgraph BR["React + TypeScript + Vite"]
+        ST["View state<br/>useReducer / Zustand<br/>selection · collapse · inputs"]
+        TOK["Global stylesheet<br/>CSS custom properties"]
+        A11Y["Focus trap · aria-live · tab order"]
+
+        subgraph SURF["Surfaces"]
+            TC["Tree canvas<br/>@xyflow/react + elkjs"]
+            BP["Base planner cards"]
+        end
+    end
+
+    ST --> SURF
+    TOK --> SURF
+    A11Y --> SURF
+    SURF -->|"user intent<br/>(method change, assignment, qty)"| CORE
+```
+
+## More Information
+
+**Open question — client state management.** The maintainer's stated preference was "React/Redux". This ADR records React as decided and deliberately leaves the state library open, because ADR-0003 materially changed what the view holds: with the plan, the graph, and all derived quantities living in Go, React is left with selection, section collapse, form inputs, and focus.
+
+The recommendation is to start without Redux — `useReducer` plus context, or Zustand — and adopt Redux Toolkit only if a concrete need appears. There is one genuine argument in Redux's favor worth naming rather than dismissing: **its devtools time-travel is useful precisely when debugging a boundary you cannot step through**, and the JS/WASM boundary is exactly that. If the boundary proves hard to reason about during the spike, that alone may justify the machinery. Settle this after the first working slice, not before.
+
+**Load-time work, deferred but noted.** Lazy-load elkjs (only needed when the tree canvas mounts, and it can run in a web worker) and lazy-load the WASM module (only needed on save import and first plan computation). Both matter far more than framework choice and neither needs deciding now.
+
+**Reversibility.** ADR-0003's package boundary is what makes this decision low-stakes. If React proves a poor fit, the domain package is untouched and only the views are rewritten. That was a deliberate design goal, and it is the reason this ADR could be settled on familiarity rather than on merit-in-isolation without much regret.
+
+**References.**
+
+* ADR-0003 — the domain core that narrows this decision's scope
+* `docs/design/tree-canvas/handoff.md` — React Flow + elkjs recommendation, keyboard and a11y requirements
+* `docs/design/theme/handoff.md` — tokens as CSS custom properties, border discipline, control scale
+* `docs/design/base-planner/handoff.md` — card anatomy and the interactions the view wires up

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,56 @@
+# Handoff: NMS Base & Resource Planner
+
+## Overview
+A planning tool for No Man's Sky players: pick a target item (industrial product like a Stasis Device, or a cooking recipe like a cake), see its full crafting/refining/cooking dependency tree, assign leaf resources to player bases, and get per-base **build checklists** — what to plant, construct, and power at each base, with a harvest-run route across them. It is a build planner, not a shopping list: **there is no "buy" method anywhere** (craft / refine / raw / cook only), and power deficits are presented as actions ("+ 1 × EM generator"), not warnings.
+
+## About the Design Files
+Every file in this bundle is a **design reference created in HTML** — interactive prototypes showing intended look and behavior, not production code to copy directly. The task is to **recreate these designs in the target codebase's environment** using its established patterns and libraries — or, if no codebase exists yet, to pick an appropriate stack (the tree-canvas handoff recommends React with `@xyflow/react` + `elkjs`; the rest is ordinary component UI). The `.dc.html` files open directly in a browser (keep each folder's `support.js` and `image-slot.js` next to them); all interactions in them are real and worth clicking through before implementing.
+
+Each surface has its own detailed `handoff.md` — **those are the specs**; this README is the map:
+- `theme/handoff.md` — design tokens, type, control scale, accessibility math
+- `tree-canvas/handoff.md` — dependency-tree surface (nodes, edges, method popover, a11y)
+- `base-planner/handoff.md` — base cards, build todos, power, route bar, v1 vs v2, 8-bit restyle
+- `bases-map/handoff.md` — Base Atlas overview map (districts, runs, building sprites)
+
+## Changes since the first handoff zip
+- **8-bit restyle** (v2 planner + atlas; spec in `base-planner/handoff.md` §"8-bit restyle"): Silkscreen pixel font for display text (≥8px caps), radius 0 everywhere, pixel-notch card corners via clip-path, chunked segment meters instead of smooth fills, hard 3px offset button shadows. v1 planner and token sheet keep the pre-8-bit look; Silkscreen joins the font set. Planner v2 card frames are now a padding-based colored wrapper + inner clip-path panel (continuous 3px border with notched corners on both edges).
+- **TARGET switcher** in planner v2: STASIS (industrial, 3 bases) ↔ CAKE (cooking: Hexaberry Cake, 2 bases — RANCH fauna rows + KITCHEN Nutrient-Processor steps, `unverified` chip). Method vocabulary is craft / refine / raw / cook.
+- **New surface: Base Atlas** (`bases-map/`).
+- **Cross-navigation**: tree ↔ planner ↔ atlas header links ("view planner →" / "view atlas →" / "view tree →").
+
+## Fidelity
+**High-fidelity.** Colors, typography, spacing, and states are final and measured (contrast ratios and color-blind ΔE are computed live in `theme/Theme Tokens.dc.html`). Recreate pixel-perfectly with the codebase's component library. The **data is sample data**: yields, extractor rates, power draws, stock levels, biomes, and the Hexaberry Cake recipe are illustrative — production reads real game data (the Stasis Device tree structure itself is real, verified against community sources 2026-08; nodes flagged `unverified` carry that badge in the UI).
+
+## Screens / Views
+1. **Tree Canvas** (`tree-canvas/Tree Canvas.dc.html`) — left-to-right flowchart of the full dependency tree (34-node Stasis Device chain prototyped). Node cards 178px on #3c3836; leaf nodes framed 3px in their assigned base's color; method readable from badge AND edge style (refine inputs dashed). Click a node → method popover (segmented craft|refine, assign-to-base select on leaves). Production: React Flow custom nodes + elkjs layered layout.
+2. **Base Atlas** (`bases-map/Bases Map.dc.html`) — city-builder overview: pixel-grid map, each base an 8-bit habitation-pod building in its identity color, dashed district territories (FARMLANDS, STASIS DISTRICT), traceable harvest-run routes (dotted paths, numbered waypoints, method chips) switched by a RUN toggle, side panel with base dossier or run leg list. See `bases-map/handoff.md`.
+3. **Base Planner v2** (`base-planner/Base Planner v2.dc.html`) — the manager view, one card per base: tinted environment strip (biome, hazards, sentinel/economy/star, copyable portal address), collapsible producer sections with stocked-vs-needed bars, POWER block (EM|SOLAR type, C/B/A/S class, deficit-fix button, grid diagram on selected card), checkable BUILD TODO with progress bar, screenshot drop slot, tagged notes. Header TARGET switcher swaps the whole plan (STASIS ↔ CAKE) — the cake plan demonstrates RANCH (fauna products) and KITCHEN (Nutrient Processor steps) producer types. Harvest-run route bar above the cards.
+4. **Base Planner v1** (`base-planner/Base Planner.dc.html`) — the simpler literal-markup reference for the card anatomy; superseded by v2 but kept because its markup is easier to read.
+5. **Token sheet** (`theme/Theme Tokens.dc.html`) — living spec: every token with live-computed WCAG contrast and protan/deutan ΔE validation tables. Recreate tokens as CSS custom properties in the global stylesheet.
+6. **Explorations** (`explorations/Theme Variants.dc.html`) — the decision record: scheme options 3a–3d/4a–4b (gruvbox classic 4a chosen), base-palette derivation 5a, and the 6a deficit→resolved card states. Reference only.
+
+## Interactions & Behavior
+Specified per surface in the three handoff.md files. Cross-cutting rules:
+- **Borders carry identity only**: 3px base-color frames; hover = brightness(1.12), focus = 2px #8ec07c outline outboard, selection = 2px #8ec07c ring **inboard via overlay element** (never inset box-shadow — it paints under positioned children). Nothing else may write to a border.
+- Every recompute (method/class/type change, deficit fix, todo check) announces via `aria-live="polite"`.
+- Color is never the sole carrier: methods have glyph+text, bases have names, warnings have ⚠+text, deficits have stated kPs + red meter segment.
+- Plan state (target, methods, assignments, todo checks) should serialize into a shareable URL hash; no localStorage.
+
+## State Management
+Per-base UI state (v2 prototype's `ui` map is the reference shape): power type + EM class, extractor class, added generators, section open/closed, todo done-map, note tags + text, selection. Plan-level: target, device/batch quantity. All quantities derive from the dependency graph — the prototypes' math (plants = qty÷yield, domes = plants÷16, extractors sized to ~1.5h fill, power gen = units × class-multiplied output) shows the intended rollup shape, not real constants.
+
+## Design Tokens
+Full set with measured contrast in `theme/handoff.md`. Core: bg #282828 / canvas #1d2021 / panel #32302f / raised #3c3836 / border #504945; text #ebdbb2, bright #fbf1c7, muted #a89984; interactive orange #fe8019 (only), ok/selection aqua #8ec07c, danger red #fb4934, warn yellow #d79921. Base identity palette (6): #fabd2f, #e6d9c0, #e8543a, #93b4d1, #a08f78, #b3618a. Type: Chakra Petch (display) / Space Grotesk (body) / JetBrains Mono + tabular-nums (all numerals). Spacing 4/8/12/16/24/32/48; radius 2px controls, 4px panels; controls 40px default, 30px small, 22px micro-segmented.
+
+## Assets
+No image assets — fonts load from Google Fonts (Silkscreen 400/700, Chakra Petch 600/700, Space Grotesk 400–600, JetBrains Mono 400–600). `base-planner/image-slot.js` is a prototype-only drag-and-drop placeholder; in production the screenshot slot is an ordinary image upload. Scanline/grid textures are CSS gradients (values in theme handoff). No game assets or trade dress are used or should be.
+
+## Files
+```
+theme/          handoff.md · Theme Tokens.dc.html · support.js
+tree-canvas/    handoff.md · Tree Canvas.dc.html · support.js
+base-planner/   handoff.md · Base Planner.dc.html · Base Planner v2.dc.html · image-slot.js · support.js
+bases-map/      handoff.md · Bases Map.dc.html · support.js
+explorations/   Theme Variants.dc.html · support.js
+```
+`support.js` files are the prototype runtime — needed to open the `.dc.html` files, irrelevant to production.

--- a/docs/design/base-planner/Base Planner v2.dc.html
+++ b/docs/design/base-planner/Base Planner v2.dc.html
@@ -1,0 +1,411 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@600;700&amp;family=Silkscreen:wght@400;700&amp;family=Space+Grotesk:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;600&amp;display=swap" rel="stylesheet">
+<script src="image-slot.js"></script>
+<style>
+body{margin:0;background:#282828;background-image:repeating-linear-gradient(0deg,rgba(251,241,199,.018) 0 1px,transparent 1px 3px)}
+a{color:#8ec07c;text-decoration:none}a:hover{color:#b8db9c;text-decoration:underline}
+button{font-family:inherit}
+input::placeholder{color:#7c6f64}
+</style>
+</helmet>
+<div style="min-height:100vh;padding:24px;display:flex;flex-direction:column;gap:16px;box-sizing:border-box">
+  <div data-screen-label="Planner header" style="display:flex;align-items:center;gap:16px;flex-wrap:wrap">
+    <div style="display:flex;flex-direction:column;gap:4px">
+      <div style="display:flex;align-items:center;gap:10px">
+        <div style="font:700 14px 'Silkscreen',monospace;letter-spacing:.02em;color:#fbf1c7">{{ targetName }} <span style="color:#a89984;font-size:14px">×{{ targetQty }}</span></div>
+        <sc-if value="{{ unverified }}" hint-placeholder-val="{{ false }}"><span title="community recipe data, not verified in-game" style="padding:2px 7px;border:1px dashed #504945;border-radius:0;font:500 9.5px 'JetBrains Mono',monospace;color:#a89984">unverified</span></sc-if>
+      </div>
+      <div style="font:500 11.5px 'JetBrains Mono',monospace;color:#8ec07c;font-variant-numeric:tabular-nums">{{ basesCount }} BASES · {{ totGen }} kPs GEN · READY ~{{ totReady }}</div>
+    </div>
+    <div style="display:flex;align-items:center;gap:8px;margin-left:8px">
+      <span style="font:500 9.5px 'JetBrains Mono',monospace;letter-spacing:.1em;color:#7c6f64">TARGET</span>
+      <div style="display:flex;flex-shrink:0;border:1px solid #504945;border-radius:0;overflow:hidden">
+        <sc-for list="{{ targetOpts }}" as="o" hint-placeholder-count="2">
+          <button onClick="{{ o.set }}" style="height:26px;padding:0 10px;cursor:pointer;font:600 10.5px 'JetBrains Mono',monospace;letter-spacing:.06em;border:none;border-left:{{ o.bl }};background:{{ o.bg }};color:{{ o.fg }};box-shadow:{{ o.sh }}">{{ o.k }}</button>
+        </sc-for>
+      </div>
+    </div>
+    <span style="flex:1"></span>
+    <div style="display:flex;gap:8px;align-items:center">
+      <button style="height:34px;padding:0 14px;background:#fe8019;border:1px solid #af3a03;border-radius:0;box-shadow:3px 3px 0 rgba(0,0,0,.35);color:#1d2021;font:600 13px 'Space Grotesk',sans-serif;cursor:pointer" style-hover="background:#ffa347">Recompute</button>
+      <button style="height:34px;padding:0 14px;background:#3c3836;border:1px solid #504945;border-radius:0;box-shadow:3px 3px 0 rgba(0,0,0,.35);color:#ebdbb2;font:500 13px 'Space Grotesk',sans-serif;cursor:pointer" style-hover="filter:brightness(1.12)">Share</button>
+      <a href="../tree-canvas/Tree Canvas.dc.html" style="font:500 13px 'Space Grotesk',sans-serif;margin-left:4px">view tree →</a>
+      <a href="../bases-map/Bases Map.dc.html" style="font:500 13px 'Space Grotesk',sans-serif;margin-left:4px">view atlas →</a>
+    </div>
+  </div>
+
+  <div data-screen-label="Harvest run route bar" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;background:#32302f;border:1px solid #3c3836;border-radius:0;padding:10px 14px">
+    <span style="font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64">HARVEST RUN</span>
+    <sc-for list="{{ route }}" as="l" hint-placeholder-count="3">
+      <div style="display:flex;align-items:center;gap:10px">
+        <span style="display:inline-flex;align-items:center;gap:7px;height:26px;padding:0 10px;background:#3c3836;border-left:3px solid {{ l.color }};border-radius:0">
+          <span style="font:600 11px 'JetBrains Mono',monospace;color:#a89984">{{ l.n }}</span>
+          <span style="font:500 12px 'Space Grotesk',sans-serif;color:#fbf1c7">{{ l.name }}</span>
+        </span>
+        <sc-if value="{{ l.hasMethod }}" hint-placeholder-val="{{ true }}">
+          <span style="font:500 10px 'JetBrains Mono',monospace;letter-spacing:.08em;color:#7c6f64">─ {{ l.method }} →</span>
+        </sc-if>
+      </div>
+    </sc-for>
+    <span style="flex:1"></span>
+    <span style="font:italic 12px 'Space Grotesk',sans-serif;color:#a89984">reorder</span>
+  </div>
+
+  <div style="display:flex;gap:20px;flex-wrap:wrap;align-items:flex-start">
+    <sc-for list="{{ bases }}" as="b" hint-placeholder-count="3">
+      <div data-screen-label="Base card" onClick="{{ b.select }}" tabIndex="0" style="width:340px;box-sizing:border-box;background:{{ b.color }};padding:3px;border-radius:0;clip-path:polygon(0 8px,4px 8px,4px 4px,8px 4px,8px 0,calc(100% - 8px) 0,calc(100% - 8px) 4px,calc(100% - 4px) 4px,calc(100% - 4px) 8px,100% 8px,100% calc(100% - 8px),calc(100% - 4px) calc(100% - 8px),calc(100% - 4px) calc(100% - 4px),calc(100% - 8px) calc(100% - 4px),calc(100% - 8px) 100%,8px 100%,8px calc(100% - 4px),4px calc(100% - 4px),4px calc(100% - 8px),0 calc(100% - 8px));position:relative;display:flex;flex-direction:column;cursor:pointer" style-focus="outline:2px solid #8ec07c;outline-offset:2px">
+        <sc-if value="{{ b.selRing }}" hint-placeholder-val="{{ false }}"><div style="position:absolute;inset:3px;border:2px solid #8ec07c;pointer-events:none;z-index:2"></div></sc-if>
+        <div style="background:#32302f;display:flex;flex-direction:column;flex:1;clip-path:polygon(0 6px,3px 6px,3px 3px,6px 3px,6px 0,calc(100% - 6px) 0,calc(100% - 6px) 3px,calc(100% - 3px) 3px,calc(100% - 3px) 6px,100% 6px,100% calc(100% - 6px),calc(100% - 3px) calc(100% - 6px),calc(100% - 3px) calc(100% - 3px),calc(100% - 6px) calc(100% - 3px),calc(100% - 6px) 100%,6px 100%,6px calc(100% - 3px),3px calc(100% - 3px),3px calc(100% - 6px),0 calc(100% - 6px))">
+        <div style="display:flex;align-items:center;gap:10px;padding:13px 16px 11px">
+          <span style="width:10px;height:10px;background:{{ b.color }};border-radius:1px"></span>
+          <span style="font:400 10px 'Silkscreen',monospace;letter-spacing:.02em;color:#fbf1c7">{{ b.name }}</span>
+          <span style="flex:1"></span>
+          <span style="font:600 11px 'JetBrains Mono',monospace;color:#8ec07c;font-variant-numeric:tabular-nums">{{ b.progressLabel }}</span>
+        </div>
+        <div style="height:6px;background:#1d2021"><div style="width:{{ b.progressPct }};height:100%;background:repeating-linear-gradient(90deg,#8ec07c 0 5px,rgba(0,0,0,0) 5px 7px)"></div></div>
+        <div style="display:flex;flex-direction:column;gap:6px;padding:8px 16px;border-bottom:1px solid #3a3634;background:{{ b.tint }}">
+          <div style="display:flex;align-items:center;gap:8px">
+            <span style="display:inline-flex;align-items:center;gap:5px;height:20px;padding:0 7px;background:#45403d;border:1px solid #504945;border-radius:0;font:600 9.5px 'JetBrains Mono',monospace;letter-spacing:.08em;color:#ebdbb2">{{ b.biome }}</span>
+            <span style="font:10.5px 'JetBrains Mono',monospace;color:#a89984">{{ b.hazard }}</span>
+          </div>
+          <div style="display:flex;align-items:center;gap:4px 8px;flex-wrap:wrap">
+            <span style="font:500 10px 'JetBrains Mono',monospace;letter-spacing:.06em;color:#a89984;white-space:nowrap">SENT {{ b.sent }} · {{ b.econ }} · CLASS {{ b.star }}</span>
+            <span style="display:inline-flex;align-items:center;gap:6px;white-space:nowrap;margin-left:auto">
+              <span style="font:500 9.5px 'JetBrains Mono',monospace;letter-spacing:.1em;color:#7c6f64">PORTAL</span>
+              <span style="font:500 11px 'JetBrains Mono',monospace;letter-spacing:.06em;color:#ebdbb2">{{ b.portal }}</span>
+              <button onClick="{{ b.copy }}" style="height:20px;padding:0 7px;background:#3c3836;border:1px solid #504945;border-radius:0;color:#a89984;font:500 10px 'JetBrains Mono',monospace;cursor:pointer" style-hover="filter:brightness(1.12)">copy</button>
+            </span>
+          </div>
+        </div>
+        <div style="padding:12px 16px;display:flex;flex-direction:column;gap:12px">
+
+          <sc-for list="{{ b.sections }}" as="sec" hint-placeholder-count="1">
+            <div style="display:flex;flex-direction:column;gap:6px">
+              <div style="display:flex;align-items:center;gap:6px 8px;min-height:22px;flex-wrap:wrap">
+                <button onClick="{{ sec.toggle }}" style="display:flex;align-items:center;gap:6px;background:none;border:none;padding:0;cursor:pointer;font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64;white-space:nowrap" style-hover="color:#a89984">{{ sec.caret }} {{ sec.label }}</button>
+                <span style="font:10.5px 'JetBrains Mono',monospace;color:#7c6f64;font-variant-numeric:tabular-nums;white-space:nowrap">{{ sec.summaryShow }}</span>
+                <span style="flex:1"></span>
+                <sc-if value="{{ sec.hasPicker }}" hint-placeholder-val="{{ false }}">
+                  <span style="font:500 9.5px 'JetBrains Mono',monospace;letter-spacing:.1em;color:#7c6f64;flex-shrink:0">CLASS</span>
+                  <div style="display:flex;flex-shrink:0;border:1px solid #504945;border-radius:0;overflow:hidden">
+                    <sc-for list="{{ sec.picker }}" as="o" hint-placeholder-count="4">
+                      <button onClick="{{ o.set }}" style="height:22px;padding:0 8px;cursor:pointer;font:600 10.5px 'JetBrains Mono',monospace;border:none;border-left:{{ o.bl }};background:{{ o.bg }};color:{{ o.fg }};box-shadow:{{ o.sh }}">{{ o.k }}</button>
+                    </sc-for>
+                  </div>
+                </sc-if>
+              </div>
+              <sc-if value="{{ sec.open }}" hint-placeholder-val="{{ false }}">
+                <sc-for list="{{ sec.rows }}" as="r" hint-placeholder-count="4">
+                  <div style="background:#3c3836;border-radius:0;padding:9px 11px;display:flex;flex-direction:column;gap:4px">
+                    <div style="display:flex;justify-content:space-between;font:500 13px 'Space Grotesk',sans-serif;color:#fbf1c7"><span>{{ r.name }}</span><span style="font-family:'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">{{ r.qty }}</span></div>
+                    <div style="font:11.5px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums"><span style="color:#ebdbb2">{{ r.main }}</span></div>
+                    <sc-if value="{{ r.hasTime }}" hint-placeholder-val="{{ true }}"><div style="font:11.5px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums">{{ r.time }}</div></sc-if>
+                    <sc-if value="{{ r.showBar }}" hint-placeholder-val="{{ true }}">
+                      <div style="display:flex;align-items:center;gap:8px"><div style="flex:1;height:5px;background:#1d2021"><div style="width:{{ r.stockPct }};height:100%;background:{{ r.stockColor }}"></div></div><span style="font:10px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums">{{ r.stockLabel }}</span></div>
+                    </sc-if>
+                    <sc-if value="{{ r.hasNote }}" hint-placeholder-val="{{ false }}"><div style="font:11.5px 'JetBrains Mono',monospace;color:#8ec07c">{{ r.note }}</div></sc-if>
+                  </div>
+                </sc-for>
+              </sc-if>
+            </div>
+          </sc-for>
+
+          <div style="display:flex;flex-direction:column;gap:6px">
+            <div style="display:flex;align-items:center;gap:8px;min-height:22px;flex-wrap:wrap">
+              <button onClick="{{ b.powToggle }}" style="display:flex;align-items:center;gap:6px;background:none;border:none;padding:0;cursor:pointer;font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64;white-space:nowrap" style-hover="color:#a89984">{{ b.powCaret }} POWER</button>
+              <span style="font:10.5px 'JetBrains Mono',monospace;color:#7c6f64;font-variant-numeric:tabular-nums;white-space:nowrap">{{ b.powSummaryShow }}</span>
+              <span style="flex:1"></span>
+              <div style="display:flex;flex-shrink:0;border:1px solid #504945;border-radius:0;overflow:hidden">
+                <sc-for list="{{ b.powOpts }}" as="o" hint-placeholder-count="2">
+                  <button onClick="{{ o.set }}" style="height:22px;padding:0 8px;cursor:pointer;font:600 10.5px 'JetBrains Mono',monospace;border:none;border-left:{{ o.bl }};background:{{ o.bg }};color:{{ o.fg }};box-shadow:{{ o.sh }}">{{ o.k }}</button>
+                </sc-for>
+              </div>
+              <sc-if value="{{ b.isEm }}" hint-placeholder-val="{{ true }}">
+                <div style="display:flex;flex-shrink:0;border:1px solid #504945;border-radius:0;overflow:hidden">
+                  <sc-for list="{{ b.emOpts }}" as="o" hint-placeholder-count="4">
+                    <button onClick="{{ o.set }}" style="height:22px;padding:0 8px;cursor:pointer;font:600 10.5px 'JetBrains Mono',monospace;border:none;border-left:{{ o.bl }};background:{{ o.bg }};color:{{ o.fg }};box-shadow:{{ o.sh }}">{{ o.k }}</button>
+                  </sc-for>
+                </div>
+              </sc-if>
+            </div>
+            <sc-if value="{{ b.powOpen }}" hint-placeholder-val="{{ true }}">
+              <div style="background:#3c3836;border-radius:0;padding:9px 11px;display:flex;flex-direction:column;gap:7px">
+                <div style="display:grid;grid-template-columns:32px 1fr 64px;gap:8px;align-items:center;font:10.5px 'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">
+                  <span style="color:#a89984">GEN</span><div style="height:7px;background:#1d2021"><div style="width:{{ b.genPct }};height:100%;background:repeating-linear-gradient(90deg,#8ec07c 0 5px,rgba(0,0,0,0) 5px 7px)"></div></div><span style="color:#ebdbb2;text-align:right">{{ b.gen }} kPs</span>
+                  <span style="color:#a89984">DRAW</span><div style="height:7px;background:#1d2021;display:flex"><div style="width:{{ b.safePct }};height:100%;background:repeating-linear-gradient(90deg,#a89984 0 5px,rgba(0,0,0,0) 5px 7px)"></div><div style="width:{{ b.overPct }};height:100%;background:repeating-linear-gradient(90deg,#fb4934 0 5px,rgba(0,0,0,0) 5px 7px)"></div></div><span style="color:{{ b.drawColor }};text-align:right">{{ b.draw }} kPs</span>
+                </div>
+                <sc-if value="{{ b.deficit }}" hint-placeholder-val="{{ false }}">
+                  <div style="display:flex;align-items:center;gap:8px"><span style="font:11.5px 'Space Grotesk',sans-serif;color:#fb4934">⚠ deficit {{ b.def }} kPs</span><span style="flex:1"></span><button onClick="{{ b.fix }}" style="height:26px;padding:0 10px;background:#3c3836;border:1px solid #665c54;border-radius:0;color:#ebdbb2;font:500 11.5px 'Space Grotesk',sans-serif;cursor:pointer" style-hover="filter:brightness(1.12)">{{ b.fixLabel }}</button></div>
+                </sc-if>
+                <sc-if value="{{ b.okState }}" hint-placeholder-val="{{ true }}">
+                  <div style="font:11.5px 'Space Grotesk',sans-serif;color:#8ec07c">✓ headroom +{{ b.head }} kPs · {{ b.genDesc }}</div>
+                </sc-if>
+                <sc-if value="{{ b.showGrid }}" hint-placeholder-val="{{ false }}">
+                  <div style="display:flex;align-items:center;gap:6px;padding-top:2px;flex-wrap:wrap">
+                    <span style="padding:3px 7px;border:1px solid #504945;border-radius:0;font:500 9.5px 'JetBrains Mono',monospace;color:#ebdbb2;white-space:nowrap">{{ b.gridGen }}</span>
+                    <div style="flex:1;min-width:8px;height:1px;background:#504945"></div>
+                    <span style="padding:3px 7px;border:1px solid #504945;border-radius:0;font:600 9.5px 'JetBrains Mono',monospace;color:#a89984">BUS</span>
+                    <div style="flex:1;min-width:8px;height:1px;background:#504945"></div>
+                    <sc-for list="{{ b.loads }}" as="ld" hint-placeholder-count="2">
+                      <span style="padding:3px 7px;border:1px dashed #504945;border-radius:0;font:500 9.5px 'JetBrains Mono',monospace;color:#a89984;white-space:nowrap">{{ ld }}</span>
+                    </sc-for>
+                  </div>
+                </sc-if>
+              </div>
+            </sc-if>
+          </div>
+
+          <div style="display:flex;flex-direction:column;gap:6px">
+            <div style="display:flex;align-items:center;gap:8px;min-height:22px">
+              <button onClick="{{ b.buildToggle }}" style="display:flex;align-items:center;gap:6px;background:none;border:none;padding:0;cursor:pointer;font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64" style-hover="color:#a89984">{{ b.buildCaret }} BUILD TODO</button>
+              <span style="font:10.5px 'JetBrains Mono',monospace;color:#7c6f64;font-variant-numeric:tabular-nums">{{ b.buildSummaryShow }}</span>
+            </div>
+            <sc-if value="{{ b.buildOpen }}" hint-placeholder-val="{{ true }}">
+              <sc-for list="{{ b.items }}" as="it" hint-placeholder-count="3">
+                <button onClick="{{ it.toggle }}" style="display:flex;align-items:center;gap:9px;background:#3c3836;border:none;border-radius:0;padding:8px 11px;cursor:pointer;text-align:left" style-hover="filter:brightness(1.12)">
+                  <span style="font:600 13px 'JetBrains Mono',monospace;color:{{ it.color }}">{{ it.box }}</span>
+                  <span style="font:500 12.5px 'Space Grotesk',sans-serif;color:{{ it.color }};text-decoration:{{ it.deco }}">{{ it.label }}</span>
+                </button>
+              </sc-for>
+              <div style="font:11px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums;padding:2px 1px 0">◷ harvest cycle {{ b.harvestPct }} elapsed</div>
+            </sc-if>
+          </div>
+
+          <div style="display:flex;flex-direction:column;gap:6px">
+            <div style="display:flex;align-items:center;gap:8px;min-height:22px">
+              <button onClick="{{ b.photoToggle }}" style="display:flex;align-items:center;gap:6px;background:none;border:none;padding:0;cursor:pointer;font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64" style-hover="color:#a89984">{{ b.photoCaret }} SCREENSHOT</button>
+            </div>
+            <sc-if value="{{ b.photoOpen }}" hint-placeholder-val="{{ false }}">
+              <div onClick="{{ b.stop }}" style="width:100%;height:140px">
+                <image-slot id="{{ b.photoId }}" shape="rect" placeholder="Drop a screenshot of this base"></image-slot>
+              </div>
+            </sc-if>
+          </div>
+
+          <div style="display:flex;flex-direction:column;gap:6px">
+            <div style="display:flex;align-items:center;gap:8px;min-height:22px">
+              <button onClick="{{ b.notesToggle }}" style="display:flex;align-items:center;gap:6px;background:none;border:none;padding:0;cursor:pointer;font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64" style-hover="color:#a89984">{{ b.notesCaret }} NOTES</button>
+              <span style="font:10.5px 'JetBrains Mono',monospace;color:#7c6f64">{{ b.notesSummaryShow }}</span>
+            </div>
+            <sc-if value="{{ b.notesOpen }}" hint-placeholder-val="{{ false }}">
+              <div style="display:flex;gap:6px">
+                <sc-for list="{{ b.tags }}" as="tg" hint-placeholder-count="3">
+                  <button onClick="{{ tg.toggle }}" style="height:22px;padding:0 8px;background:{{ tg.bg }};border:1px solid {{ tg.bd }};border-radius:0;color:{{ tg.fg }};font:600 9.5px 'JetBrains Mono',monospace;letter-spacing:.08em;cursor:pointer">{{ tg.label }}</button>
+                </sc-for>
+              </div>
+              <input onClick="{{ b.stop }}" onChange="{{ b.onNote }}" defaultValue="{{ b.note }}" placeholder="Add a note…" style="height:30px;padding:0 10px;background:#45403d;border:1px solid #504945;border-radius:0;color:#ebdbb2;font:12.5px 'Space Grotesk',sans-serif;outline:none;width:100%;box-sizing:border-box">
+            </sc-if>
+          </div>
+
+          <div style="border-top:1px solid #3c3836;padding-top:10px;display:flex;justify-content:space-between;align-items:baseline;gap:8px">
+            <span style="font:11.5px 'JetBrains Mono',monospace;color:#a89984">{{ b.doneCount }} of {{ b.itemCount }} built</span>
+            <span style="font:600 12px 'JetBrains Mono',monospace;color:#fbf1c7;font-variant-numeric:tabular-nums">ready ~{{ b.ready }}</span>
+          </div>
+        </div>
+        </div>
+      </div>
+    </sc-for>
+
+    <div data-screen-label="Unassigned bin" style="width:340px;border:3px dashed #504945;border-radius:0;clip-path:polygon(0 8px,4px 8px,4px 4px,8px 4px,8px 0,calc(100% - 8px) 0,calc(100% - 8px) 4px,calc(100% - 4px) 4px,calc(100% - 4px) 8px,100% 8px,100% calc(100% - 8px),calc(100% - 4px) calc(100% - 8px),calc(100% - 4px) calc(100% - 4px),calc(100% - 8px) calc(100% - 4px),calc(100% - 8px) 100%,8px 100%,8px calc(100% - 4px),4px calc(100% - 4px),4px calc(100% - 8px),0 calc(100% - 8px));padding:14px 16px;display:flex;flex-direction:column;gap:8px;box-sizing:border-box">
+      <div style="display:flex;align-items:center;gap:8px">
+        <span style="font:400 10px 'Silkscreen',monospace;letter-spacing:.02em;color:#a89984">UNASSIGNED</span>
+        <span style="font:600 11px 'JetBrains Mono',monospace;color:#7c6f64">(0)</span>
+      </div>
+      <div style="font:13px 'Space Grotesk',sans-serif;color:#a89984;line-height:1.5">Every leaf on the tree is assigned. Resources you clear from a base collect here with a <span style="color:#d79921">⚠</span> until reassigned on the <a href="../tree-canvas/Tree Canvas.dc.html">tree</a>.</div>
+    </div>
+  </div>
+  <div aria-live="polite" style="position:absolute;width:1px;height:1px;overflow:hidden;clip-path:inset(50%)">{{ announce }}</div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1180,&quot;height&quot;:1050},&quot;deviceQty&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:1,&quot;min&quot;:1,&quot;max&quot;:10,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Plan&quot;},&quot;emOutput&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:110,&quot;min&quot;:50,&quot;max&quot;:300,&quot;unit&quot;:&quot;kPs&quot;,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Plan&quot;},&quot;solarOutput&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:50,&quot;min&quot;:20,&quot;max&quot;:150,&quot;unit&quot;:&quot;kPs&quot;,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Plan&quot;}}">
+class Component extends DCLogic {
+  state = {
+    sel: null, announce: '', target: 'STASIS',
+    ui: {
+      f: { add: 0, cls: 'B', em: 'B', pow: 'EM', open: { prod: false, power: true, build: true, photo: false, notes: false }, done: {}, tags: {}, note: '' },
+      r: { add: 0, cls: 'B', em: 'B', pow: 'EM', open: { prod: true, kitchen: true, power: true, build: true, photo: false, notes: false }, done: {}, tags: {}, note: '' },
+      v: { add: 0, cls: 'B', em: 'B', pow: 'EM', open: { prod: false, power: true, build: true, photo: false, notes: false }, done: { domes: true }, tags: {}, note: '' },
+      g: { add: 0, cls: 'B', em: 'B', pow: 'EM', open: { prod: false, power: true, build: true, photo: false, notes: false }, done: {}, tags: { restock: true }, note: 'depot 2 half full — top up before stasis run' },
+      c: { add: 0, cls: 'B', em: 'B', pow: 'SOLAR', open: { prod: false, power: true, build: true, photo: false, notes: false }, done: { ext: true }, tags: {}, note: '' }
+    }
+  };
+  up = (id, patch, msg) => this.setState(st => {
+    const next = { ui: { ...st.ui, [id]: { ...st.ui[id], ...patch } } };
+    if (msg) next.announce = msg;
+    return next;
+  });
+  renderVals() {
+    const p = this.props, s = this.state;
+    const q = Math.max(1, Math.min(10, p.deviceQty ?? 1));
+    const mult = { C: .5, B: 1, A: 1.5, S: 2 };
+    const emBase = Math.max(10, p.emOutput ?? 110), solarBase = Math.max(10, p.solarOutput ?? 50);
+    const fmt = min => { min = Math.round(min); const h = Math.floor(min / 60), m = min % 60; return h ? h + 'h ' + m + 'm' : m + 'm'; };
+    const pc = (v, sc) => Math.round(v / sc * 100) + '%';
+    const frac = { 'Frost Crystal': .35, 'Gamma Root': .8, 'Solanium': .2, 'Star Bulb': 1, 'Cactus Flesh': .5, 'Faecium': 0, 'Sulphurine': .4, 'Nitrogen': .1, 'Radon': 0, 'Paraffinium': 1, 'Ionised Cobalt': .6, 'Phosphorus': .25, 'Dioxite': 0, 'Heptaploid Wheat': .25, 'Hexaberry': .6, 'Sweetroot': 1, 'Wild Milk': .3, 'Proto-Egg': .5, 'Refined Flour': 0, 'Butter': 0, 'Cake Batter': 0, 'Hexaberry Cake': 0 };
+    const row = (name, need, main, time) => {
+      const st = Math.min(need, Math.round(need * (frac[name] ?? 0)));
+      return { name, qty: '×' + need, main, time, hasTime: !!time, showBar: true, hasNote: false, note: '',
+        stockPct: pc(st, need), stockLabel: st + ' / ' + need + ' stocked', stockColor: st >= need ? '#8ec07c' : '#a89984' };
+    };
+    const power = (units, emCls, type, draw) => {
+      const solar = type === 'SOLAR';
+      const out = solar ? solarBase : Math.round(emBase * mult[emCls]);
+      const unitName = solar ? 'Solar Panel' : 'EM generator', gen = units * out;
+      const bat = solar ? Math.ceil(units / 2) : 0;
+      const sc = Math.max(gen, draw) * 1.18, def = Math.max(0, draw - gen), n = Math.ceil(def / out) || 0;
+      return { gen, out, draw, def, n, solar, bat, unitName, genPct: pc(gen, sc), safePct: pc(Math.min(gen, draw), sc), overPct: pc(def, sc),
+        drawColor: def ? '#fb4934' : '#ebdbb2', fixLabel: '+ ' + n + ' × ' + unitName + ' (+' + n * out + ')',
+        desc: units + ' × ' + unitName + (solar ? ' + ' + bat + ' × Battery (night)' : ' ' + emCls) + ' (' + out + ' kPs ea)' };
+    };
+    const seg = (cur, k, i, set) => ({ k, bl: i ? '1px solid #504945' : 'none',
+      bg: k === cur ? 'rgba(142,192,124,.16)' : '#3c3836', fg: k === cur ? '#b8db9c' : '#7c6f64',
+      sh: k === cur ? 'inset 0 -2px 0 #8ec07c' : 'none', set });
+    const clsPicker = (id, what) => ['C', 'B', 'A', 'S'].map((k, i) => seg(s.ui[id].cls, k, i, e => { e.stopPropagation(); this.up(id, { cls: k }, what + ' class set to ' + k + '. Totals updated.'); }));
+    const emPicker = id => ['C', 'B', 'A', 'S'].map((k, i) => seg(s.ui[id].em, k, i, e => { e.stopPropagation(); this.up(id, { em: k }, 'EM generator class set to ' + k + '. Totals updated.'); }));
+    const powPicker = id => ['EM', 'SOLAR'].map((k, i) => seg(s.ui[id].pow, k, i, e => { e.stopPropagation(); this.up(id, { pow: k }, 'Power type set to ' + (k === 'EM' ? 'electromagnetic' : 'solar') + '. Totals updated.'); }));
+    const TAGS = [['restock', '⚠ RESTOCK'], ['rebuild', '↻ REBUILD'], ['visit', '◈ VISIT']];
+    const assemble = (def, u, sections, P, units, itemsDef, readyM, hf) => {
+      const id = def.id;
+      const togOpen = key => e => { e.stopPropagation(); this.up(id, { open: { ...u.open, [key]: !u.open[key] } }); };
+      const items = itemsDef.map(it => ({ label: it.label,
+        box: u.done[it.k] ? '■' : '□', color: u.done[it.k] ? '#7c6f64' : '#ebdbb2', deco: u.done[it.k] ? 'line-through' : 'none',
+        toggle: e => { e.stopPropagation(); this.up(id, { done: { ...u.done, [it.k]: !u.done[it.k] } }, it.label + (u.done[it.k] ? ' unchecked.' : ' marked built.')); } }));
+      if (P.def > 0) items.push({ label: '+ ' + P.n + ' × ' + P.unitName + ' — deficit ' + P.def + ' kPs', box: '□', color: '#fb4934', deco: 'none', toggle: e => e.stopPropagation() });
+      const doneCount = itemsDef.filter(it => u.done[it.k]).length;
+      const progress = Math.round((doneCount + hf) / (itemsDef.length + (P.def > 0 ? 1 : 0) + 1) * 100);
+      const tagCount = TAGS.filter(([k]) => u.tags[k]).length;
+      return {
+        id, name: def.name, color: def.color, tint: def.tint, biome: def.biGlyph + ' ' + def.biLabel, hazard: def.hazard,
+        sent: def.sent, econ: def.econ, star: def.star, portal: def.portal,
+        copy: e => { e.stopPropagation(); try { navigator.clipboard.writeText(def.portal); } catch (err) {} this.setState({ announce: 'Portal address for ' + def.short + ' copied.' }); },
+        select: e => this.setState(st => ({ sel: st.sel === id ? null : id })), selRing: s.sel === id,
+        stop: e => e.stopPropagation(),
+        progressPct: progress + '%', progressLabel: progress + '%',
+        sections: sections.map(sec => { const k = sec.k || 'prod'; return { ...sec, open: !!u.open[k], caret: u.open[k] ? '▾' : '▸', summaryShow: u.open[k] ? '' : sec.summary, toggle: togOpen(k) }; }),
+        powOpen: u.open.power, powCaret: u.open.power ? '▾' : '▸', powToggle: togOpen('power'),
+        powSummaryShow: u.open.power ? '' : P.gen + ' kPs · ' + (P.def > 0 ? 'deficit ' + P.def : 'headroom +' + (P.gen - P.draw)),
+        powOpts: powPicker(id), emOpts: emPicker(id), isEm: !P.solar,
+        gen: P.gen, draw: P.draw, genPct: P.genPct, safePct: P.safePct, overPct: P.overPct, drawColor: P.drawColor,
+        deficit: P.def > 0, okState: P.def === 0, def: P.def, head: P.gen - P.draw, fixLabel: P.fixLabel, genDesc: P.desc,
+        fix: e => { e.stopPropagation(); this.up(id, { add: u.add + P.n }, P.n + ' × ' + P.unitName + ' added to ' + def.short + '. Deficit resolved.'); },
+        showGrid: s.sel === id, gridGen: units + ' × ' + (P.solar ? 'SOLAR' : 'EM ' + u.em), loads: def.loads,
+        buildOpen: u.open.build, buildCaret: u.open.build ? '▾' : '▸', buildToggle: togOpen('build'),
+        buildSummaryShow: u.open.build ? '' : doneCount + '/' + items.length + ' built',
+        items, harvestPct: Math.round(hf * 100) + '%', doneCount, itemCount: items.length, ready: fmt(readyM),
+        photoOpen: u.open.photo, photoCaret: u.open.photo ? '▾' : '▸', photoToggle: togOpen('photo'), photoId: 'base-photo-' + id,
+        notesOpen: u.open.notes, notesCaret: u.open.notes ? '▾' : '▸', notesToggle: togOpen('notes'),
+        notesSummaryShow: u.open.notes ? '' : (tagCount || u.note ? (tagCount ? tagCount + ' tag' + (tagCount > 1 ? 's' : '') : '') + (u.note ? (tagCount ? ' · ' : '') + '1 note' : '') : 'empty'),
+        tags: TAGS.map(([k, label]) => ({ label,
+          bg: u.tags[k] ? 'rgba(142,192,124,.16)' : '#3c3836', bd: u.tags[k] ? '#689d6a' : '#504945', fg: u.tags[k] ? '#b8db9c' : '#a89984',
+          toggle: e => { e.stopPropagation(); this.up(id, { tags: { ...u.tags, [k]: !u.tags[k] } }); } })),
+        note: u.note, onNote: e => this.up(id, { note: e.target.value })
+      };
+    };
+    // --- Verdant Moon (farm)
+    const uv = s.ui.v;
+    const crops = [['Frost Crystal', 300, 4, 120], ['Gamma Root', 400, 4, 60], ['Solanium', 200, 3, 240], ['Star Bulb', 200, 4, 30], ['Cactus Flesh', 100, 3, 60], ['Faecium', 50, 3, 120]];
+    let vDomes = 0, vReadyM = 0;
+    const vRows = crops.map(([n, b, y, h]) => {
+      const need = b * q, plants = Math.ceil(need / y), domes = Math.ceil(plants / 16);
+      vDomes += domes; vReadyM = Math.max(vReadyM, h);
+      return row(n, need, plants + ' plants · ' + domes + ' biodome' + (domes > 1 ? 's' : '') + ' (16/dome)', 'harvest ' + fmt(h));
+    });
+    const vUnits = 4 + uv.add, vP = power(vUnits, uv.em, uv.pow, vDomes * 20 + 40);
+    const vDef = { id: 'v', name: 'BASE D — VERDANT MOON', short: 'Verdant Moon', color: '#93b4d1', tint: 'rgba(142,192,124,.06)', biGlyph: '✿', biLabel: 'LUSH', hazard: 'mild · no storms', sent: 'LOW', econ: 'TRADING ★★', star: 'G2', portal: '20E5F9556C30', loads: [vDomes + ' × dome (' + vDomes * 20 + ')', 'misc (40)'] };
+    const vBase = assemble(vDef, uv, [{ label: 'FARM', hasPicker: false, picker: [], rows: vRows, summary: crops.length + ' crops · ' + vDomes + ' biodomes' }], vP, vUnits,
+      [{ k: 'domes', label: vDomes + ' × Biodome' }, { k: 'gen', label: vUnits + ' × ' + (vP.solar ? 'Solar Panel + ' + vP.bat + ' × Battery' : 'EM generator ' + uv.em) }], vReadyM, .4);
+    // --- Gasworks (gas)
+    const ug = s.ui.g;
+    const gases = [['Sulphurine', 500], ['Nitrogen', 500], ['Radon', 500]];
+    const gRate = 200 * mult[ug.cls];
+    let gExt = 0, gDep = 0, gReadyM = 0;
+    const gRows = gases.map(([n, b]) => {
+      const need = b * q, count = Math.max(1, Math.ceil(need / (gRate * 1.5))), fill = need / (gRate * count) * 60, dep = Math.ceil(need / 720);
+      gExt += count; gDep += dep; gReadyM = Math.max(gReadyM, fill);
+      return row(n, need, count + ' × Gas Extractor', 'fills in ' + fmt(fill) + ' · +' + dep + ' supply depot (720u)');
+    });
+    gRows.push({ name: 'Condensed Carbon', qty: '×' + 300 * q, main: '', time: '', hasTime: false, showBar: false, hasNote: true, note: '✓ byproduct of gas refines — nothing to build', stockPct: '0%', stockLabel: '', stockColor: '#a89984' });
+    const gUnits = 3 + ug.add, gP = power(gUnits, ug.em, ug.pow, gExt * 55 + gDep * 10 + 20);
+    const gDef = { id: 'g', name: 'BASE C — GASWORKS', short: 'Gasworks', color: '#e8543a', tint: 'rgba(215,153,33,.06)', biGlyph: '☣', biLabel: 'TOXIC', hazard: 'acid storms · hazard prot. req.', sent: 'HIGH', econ: 'MINING ★', star: 'K7', portal: '115EF8A10D34', loads: [gExt + ' × extr (' + gExt * 55 + ')', gDep + ' × depot (' + gDep * 10 + ')'] };
+    const gBase = assemble(gDef, ug, [{ label: 'GAS EXTRACTORS', hasPicker: true, picker: clsPicker('g', 'Extractor'), rows: gRows, summary: gExt + ' extractors · ' + gDep + ' depots' }], gP, gUnits,
+      [{ k: 'ext', label: gExt + ' × Gas Extractor ' + ug.cls }, { k: 'dep', label: gDep + ' × Supply Depot' }, { k: 'gen', label: gUnits + ' × ' + (gP.solar ? 'Solar Panel + ' + gP.bat + ' × Battery' : 'EM generator ' + ug.em) }], gReadyM, .65);
+    // --- Cobalt Flats (mineral)
+    const uc = s.ui.c;
+    const minerals = [['Paraffinium', 50], ['Ionised Cobalt', 50], ['Phosphorus', 50], ['Dioxite', 50]];
+    const cRate = 250 * mult[uc.cls];
+    let cExt = 0, cDep = 0, cReadyM = 0;
+    const cRows = minerals.map(([n, b]) => {
+      const need = b * q, count = Math.max(1, Math.ceil(need / (cRate * 1.5))), fill = need / (cRate * count) * 60, dep = need > 360 ? Math.ceil(need / 720) : 0;
+      cExt += count; cDep += dep; cReadyM = Math.max(cReadyM, fill);
+      return row(n, need, count + ' × Mineral Extractor', 'fills in ' + fmt(fill) + (dep ? ' · +' + dep + ' supply depot (720u)' : ''));
+    });
+    const cUnits = 3 + uc.add, cP = power(cUnits, uc.em, uc.pow, cExt * 55 + cDep * 10 + 20);
+    const cItems = [{ k: 'ext', label: cExt + ' × Mineral Extractor ' + uc.cls }];
+    if (cDep) cItems.push({ k: 'dep', label: cDep + ' × Supply Depot' });
+    cItems.push({ k: 'gen', label: cP.solar ? cUnits + ' × Solar Panel + ' + cP.bat + ' × Battery' : cUnits + ' × EM generator ' + uc.em });
+    const cDef = { id: 'c', name: 'BASE F — COBALT FLATS', short: 'Cobalt Flats', color: '#b3618a', tint: 'rgba(147,180,209,.06)', biGlyph: '❄', biLabel: 'FROZEN', hazard: 'blizzards at night · solar dips', sent: 'NONE', econ: 'TECH ★★★', star: 'F0', portal: '40FA92D18B06', loads: [cExt + ' × extr (' + cExt * 55 + ')', 'misc (20)'] };
+    const cBase = assemble(cDef, uc, [{ label: 'MINERAL EXTRACTORS', hasPicker: true, picker: clsPicker('c', 'Extractor'), rows: cRows, summary: cExt + ' extractors' }], cP, cUnits, cItems, cReadyM, 1);
+    // --- Cooking plan: Hexaberry Cake (community recipe, unverified)
+    const genItem = (units, P, cls) => ({ k: 'gen', label: P.solar ? units + ' × Solar Panel + ' + P.bat + ' × Battery' : units + ' × EM generator ' + cls });
+    const uf = s.ui.f;
+    const cakeCrops = [['Heptaploid Wheat', 200, 2, 60], ['Hexaberry', 100, 3, 30], ['Sweetroot', 50, 2, 60]];
+    let fDomes = 0, fReadyM = 0;
+    const fRows = cakeCrops.map(([n, b, y, h]) => {
+      const need = b * q, plants = Math.ceil(need / y), domes = Math.ceil(plants / 16);
+      fDomes += domes; fReadyM = Math.max(fReadyM, h);
+      return row(n, need, plants + ' plants · ' + domes + ' biodome' + (domes > 1 ? 's' : '') + ' (16/dome)', 'harvest ' + fmt(h));
+    });
+    const fUnits = 3 + uf.add, fP = power(fUnits, uf.em, uf.pow, fDomes * 20 + 40);
+    const fDef = { id: 'f', name: 'BASE D — VERDANT MOON', short: 'Verdant Moon', color: '#93b4d1', tint: 'rgba(142,192,124,.06)', biGlyph: '✿', biLabel: 'LUSH', hazard: 'mild · no storms', sent: 'LOW', econ: 'TRADING ★★', star: 'G2', portal: '20E5F9556C30', loads: [fDomes + ' × dome (' + fDomes * 20 + ')', 'misc (40)'] };
+    const fBase = assemble(fDef, uf, [{ label: 'FARM', hasPicker: false, picker: [], rows: fRows, summary: cakeCrops.length + ' crops · ' + fDomes + ' biodomes' }], fP, fUnits,
+      [{ k: 'domes', label: fDomes + ' × Biodome' }, genItem(fUnits, fP, uf.em)], fReadyM, .5);
+    const ur = s.ui.r;
+    const ranchRows = [
+      row('Wild Milk', 25 * q, '5 grazing fauna · 1 × pellet feeder', 'milk cycle 2h'),
+      row('Proto-Egg', 25 * q, '4 nesting fauna', 'collect 1h')
+    ];
+    const kitchenRows = [
+      row('Refined Flour', 50 * q, '◇ 1 × Nutrient Processor · 200 wheat → 50 flour', 'process ~5m'),
+      row('Butter', 25 * q, '◇ 25 milk → 25 butter', 'process ~5m'),
+      row('Cake Batter', 25 * q, '◇ flour + butter + proto-egg', 'process ~5m'),
+      row('Hexaberry Cake', 25 * q, '⚑ final bake · batter + hexaberry', 'process ~10m')
+    ];
+    const rUnits = 2 + ur.add, rP = power(rUnits, ur.em, ur.pow, 100);
+    const rDef = { id: 'r', name: 'BASE B — MEADOW RANCH', short: 'Meadow Ranch', color: '#e6d9c0', tint: 'rgba(230,217,192,.05)', biGlyph: '☼', biLabel: 'TEMPERATE', hazard: 'calm · fauna docile', sent: 'LOW', econ: 'TRADING ★', star: 'M2', portal: '30C1A4E2F715', loads: ['2 × processor (60)', 'feeder (20)', 'misc (20)'] };
+    const rBase = assemble(rDef, ur, [
+      { k: 'prod', label: 'RANCH', hasPicker: false, picker: [], rows: ranchRows, summary: '2 fauna products' },
+      { k: 'kitchen', label: 'KITCHEN', hasPicker: false, picker: [], rows: kitchenRows, summary: '4 processor steps' }
+    ], rP, rUnits, [{ k: 'proc', label: '2 × Nutrient Processor' }, { k: 'feed', label: '1 × Pellet Feeder' }, genItem(rUnits, rP, ur.em)], 120, .25);
+    const isCake = s.target === 'CAKE';
+    const targetOpts = ['STASIS', 'CAKE'].map((k, i) => seg(s.target, k, i, e => this.setState({ target: k, sel: null, announce: 'Plan target set to ' + (k === 'STASIS' ? 'Stasis Device' : 'Hexaberry Cake') + '.' })));
+    return {
+      qty: q, announce: s.announce, targetOpts, unverified: isCake,
+      targetName: isCake ? 'HEXABERRY CAKE' : 'STASIS DEVICE', targetQty: isCake ? 25 * q : q,
+      basesCount: isCake ? 2 : 3,
+      totGen: (isCake ? fP.gen + rP.gen : vP.gen + gP.gen + cP.gen).toLocaleString(),
+      totReady: fmt(isCake ? Math.max(fReadyM, 120) : Math.max(vReadyM, gReadyM, cReadyM)),
+      route: isCake ? [
+        { n: '1', name: 'Verdant Moon', color: '#93b4d1', hasMethod: true, method: '⌁ TELEPORTER' },
+        { n: '2', name: 'Meadow Ranch', color: '#e6d9c0', hasMethod: false, method: '' }
+      ] : [
+        { n: '1', name: 'Verdant Moon', color: '#93b4d1', hasMethod: true, method: '⌁ TELEPORTER' },
+        { n: '2', name: 'Gasworks', color: '#e8543a', hasMethod: true, method: '◇ PORTAL' },
+        { n: '3', name: 'Cobalt Flats', color: '#b3618a', hasMethod: false, method: '' }
+      ],
+      bases: isCake ? [fBase, rBase] : [vBase, gBase, cBase]
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/base-planner/Base Planner.dc.html
+++ b/docs/design/base-planner/Base Planner.dc.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@600;700&amp;family=Space+Grotesk:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;600&amp;display=swap" rel="stylesheet">
+<style>
+body{margin:0;background:#282828;background-image:repeating-linear-gradient(0deg,rgba(251,241,199,.018) 0 1px,transparent 1px 3px)}
+a{color:#8ec07c;text-decoration:none}a:hover{color:#b8db9c;text-decoration:underline}
+button{font-family:inherit}
+</style>
+</helmet>
+<div style="min-height:100vh;padding:24px;display:flex;flex-direction:column;gap:18px;box-sizing:border-box">
+  <div data-screen-label="Base planner header" style="display:flex;align-items:center;gap:16px;flex-wrap:wrap">
+    <div style="display:flex;flex-direction:column;gap:4px">
+      <div style="font:700 20px 'Chakra Petch',sans-serif;letter-spacing:.05em;color:#fbf1c7">STASIS DEVICE <span style="color:#a89984;font-size:14px">×{{ qty }}</span></div>
+      <div style="font:500 11.5px 'JetBrains Mono',monospace;color:#8ec07c;font-variant-numeric:tabular-nums">3 BASES · {{ totGen }} kPs GEN · READY ~{{ totReady }}</div>
+    </div>
+    <span style="flex:1"></span>
+    <div style="display:flex;gap:8px;align-items:center">
+      <button style="height:34px;padding:0 14px;background:#fe8019;border:1px solid #af3a03;border-radius:2px;color:#1d2021;font:600 13px 'Space Grotesk',sans-serif;cursor:pointer" style-hover="background:#ffa347">Recompute</button>
+      <button style="height:34px;padding:0 14px;background:#3c3836;border:1px solid #504945;border-radius:2px;color:#ebdbb2;font:500 13px 'Space Grotesk',sans-serif;cursor:pointer" style-hover="filter:brightness(1.12)">Share</button>
+      <a href="../tree-canvas/Tree Canvas.dc.html" style="font:500 13px 'Space Grotesk',sans-serif;margin-left:4px">view tree →</a>
+    </div>
+  </div>
+
+  <div style="display:flex;gap:20px;flex-wrap:wrap;align-items:flex-start">
+
+    <div data-screen-label="Verdant Moon card" onClick="{{ selV }}" tabIndex="0" style="width:340px;background:#32302f;border:3px solid #93b4d1;border-radius:4px;position:relative;display:flex;flex-direction:column;cursor:pointer" style-focus="outline:2px solid #8ec07c;outline-offset:2px">
+      <sc-if value="{{ vSel }}" hint-placeholder-val="{{ false }}"><div style="position:absolute;inset:3px;border:2px solid #8ec07c;pointer-events:none;z-index:2"></div></sc-if>
+      <div style="display:flex;align-items:center;gap:10px;padding:14px 16px;border-bottom:1px solid #3c3836">
+        <span style="width:10px;height:10px;background:#93b4d1;border-radius:1px"></span>
+        <span style="font:600 15px 'Chakra Petch',sans-serif;letter-spacing:.04em;color:#fbf1c7">BASE D — VERDANT MOON</span>
+        <span style="flex:1"></span>
+        <span style="font:italic 12px 'Space Grotesk',sans-serif;color:#a89984">rename</span>
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;padding:8px 16px;border-bottom:1px solid #3a3634">
+        <span style="display:inline-flex;align-items:center;gap:5px;height:20px;padding:0 7px;background:#45403d;border:1px solid #504945;border-radius:2px;font:600 9.5px 'JetBrains Mono',monospace;letter-spacing:.08em;color:#ebdbb2">✿ LUSH</span>
+        <span style="font:10.5px 'JetBrains Mono',monospace;color:#a89984">mild · no storms</span>
+        <span style="flex:1"></span>
+        <span style="font:500 9.5px 'JetBrains Mono',monospace;letter-spacing:.1em;color:#7c6f64">PORTAL</span>
+        <span style="font:500 11px 'JetBrains Mono',monospace;letter-spacing:.06em;color:#ebdbb2">20E5F9556C30</span>
+        <button onClick="{{ copyV }}" style="height:20px;padding:0 7px;background:#3c3836;border:1px solid #504945;border-radius:2px;color:#a89984;font:500 10px 'JetBrains Mono',monospace;cursor:pointer" style-hover="filter:brightness(1.12)">copy</button>
+      </div>
+      <div style="padding:12px 16px;display:flex;flex-direction:column;gap:12px">
+        <div style="display:flex;flex-direction:column;gap:6px">
+          <div style="font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64">FARM</div>
+          <sc-for list="{{ vRows }}" as="r" hint-placeholder-count="6">
+            <div style="background:#3c3836;border-radius:2px;padding:9px 11px;display:flex;flex-direction:column;gap:3px">
+              <div style="display:flex;justify-content:space-between;font:500 13px 'Space Grotesk',sans-serif;color:#fbf1c7"><span>{{ r.name }}</span><span style="font-family:'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">{{ r.qty }}</span></div>
+              <div style="font:11.5px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums"><span style="color:#ebdbb2">{{ r.main }}</span></div>
+              <sc-if value="{{ showTimes }}" hint-placeholder-val="{{ true }}"><div style="font:11.5px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums">{{ r.time }}</div></sc-if>
+            </div>
+          </sc-for>
+        </div>
+        <div style="display:flex;flex-direction:column;gap:6px">
+          <div style="display:flex;align-items:center;gap:8px">
+            <span style="font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64">POWER</span><span style="flex:1"></span>
+            <div style="display:flex;border:1px solid #504945;border-radius:2px;overflow:hidden">
+              <sc-for list="{{ vPowOpts }}" as="o" hint-placeholder-count="2">
+                <button onClick="{{ o.set }}" style="height:22px;padding:0 8px;cursor:pointer;font:600 10.5px 'JetBrains Mono',monospace;border:none;border-left:{{ o.bl }};background:{{ o.bg }};color:{{ o.fg }};box-shadow:{{ o.sh }}">{{ o.k }}</button>
+              </sc-for>
+            </div>
+            <sc-if value="{{ vIsEm }}" hint-placeholder-val="{{ true }}">
+              <span style="font:500 9.5px 'JetBrains Mono',monospace;letter-spacing:.1em;color:#7c6f64">CLASS</span>
+              <div style="display:flex;border:1px solid #504945;border-radius:2px;overflow:hidden">
+                <sc-for list="{{ vEmOpts }}" as="o" hint-placeholder-count="4">
+                  <button onClick="{{ o.set }}" style="height:22px;padding:0 8px;cursor:pointer;font:600 10.5px 'JetBrains Mono',monospace;border:none;border-left:{{ o.bl }};background:{{ o.bg }};color:{{ o.fg }};box-shadow:{{ o.sh }}">{{ o.k }}</button>
+                </sc-for>
+              </div>
+            </sc-if>
+          </div>
+          <div style="background:#3c3836;border-radius:2px;padding:9px 11px;display:flex;flex-direction:column;gap:7px">
+            <div style="display:grid;grid-template-columns:32px 1fr 64px;gap:8px;align-items:center;font:10.5px 'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">
+              <span style="color:#a89984">GEN</span><div style="height:7px;background:#1d2021"><div style="width:{{ vGenPct }};height:100%;background:#8ec07c"></div></div><span style="color:#ebdbb2;text-align:right">{{ vGen }} kPs</span>
+              <span style="color:#a89984">DRAW</span><div style="height:7px;background:#1d2021;display:flex"><div style="width:{{ vSafePct }};height:100%;background:#a89984"></div><div style="width:{{ vOverPct }};height:100%;background:#fb4934"></div></div><span style="color:{{ vDrawColor }};text-align:right">{{ vDraw }} kPs</span>
+            </div>
+            <sc-if value="{{ vDeficit }}" hint-placeholder-val="{{ false }}">
+              <div style="display:flex;align-items:center;gap:8px"><span style="font:11.5px 'Space Grotesk',sans-serif;color:#fb4934">⚠ deficit {{ vDef }} kPs</span><span style="flex:1"></span><button onClick="{{ fixV }}" style="height:26px;padding:0 10px;background:#3c3836;border:1px solid #665c54;border-radius:2px;color:#ebdbb2;font:500 11.5px 'Space Grotesk',sans-serif;cursor:pointer" style-hover="filter:brightness(1.12)">{{ vFixLabel }}</button></div>
+            </sc-if>
+            <sc-if value="{{ vOk }}" hint-placeholder-val="{{ false }}">
+              <div style="font:11.5px 'Space Grotesk',sans-serif;color:#8ec07c">✓ headroom +{{ vHead }} kPs · {{ vGenDesc }}</div>
+            </sc-if>
+          </div>
+        </div>
+        <div style="border-top:1px solid #3c3836;padding-top:10px;display:flex;justify-content:space-between;align-items:baseline;gap:8px">
+          <span style="font:11.5px 'JetBrains Mono',monospace;color:#a89984">BUILD: {{ vBuild }}<sc-if value="{{ vDeficit }}" hint-placeholder-val="{{ false }}"><span style="color:#fb4934"> · +{{ vFixN }} {{ vFixUnit }}</span></sc-if></span>
+          <span style="font:600 12px 'JetBrains Mono',monospace;color:#fbf1c7;font-variant-numeric:tabular-nums">ready ~{{ vReady }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div data-screen-label="Gasworks card" onClick="{{ selG }}" tabIndex="0" style="width:340px;background:#32302f;border:3px solid #e8543a;border-radius:4px;position:relative;display:flex;flex-direction:column;cursor:pointer" style-focus="outline:2px solid #8ec07c;outline-offset:2px">
+      <sc-if value="{{ gSel }}" hint-placeholder-val="{{ false }}"><div style="position:absolute;inset:3px;border:2px solid #8ec07c;pointer-events:none;z-index:2"></div></sc-if>
+      <div style="display:flex;align-items:center;gap:10px;padding:14px 16px;border-bottom:1px solid #3c3836">
+        <span style="width:10px;height:10px;background:#e8543a;border-radius:1px"></span>
+        <span style="font:600 15px 'Chakra Petch',sans-serif;letter-spacing:.04em;color:#fbf1c7">BASE C — GASWORKS</span>
+        <span style="flex:1"></span>
+        <span style="font:italic 12px 'Space Grotesk',sans-serif;color:#a89984">rename</span>
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;padding:8px 16px;border-bottom:1px solid #3a3634">
+        <span style="display:inline-flex;align-items:center;gap:5px;height:20px;padding:0 7px;background:#45403d;border:1px solid #504945;border-radius:2px;font:600 9.5px 'JetBrains Mono',monospace;letter-spacing:.08em;color:#ebdbb2">☣ TOXIC</span>
+        <span style="font:10.5px 'JetBrains Mono',monospace;color:#a89984">acid storms · hazard prot. req.</span>
+        <span style="flex:1"></span>
+        <span style="font:500 9.5px 'JetBrains Mono',monospace;letter-spacing:.1em;color:#7c6f64">PORTAL</span>
+        <span style="font:500 11px 'JetBrains Mono',monospace;letter-spacing:.06em;color:#ebdbb2">115EF8A10D34</span>
+        <button onClick="{{ copyG }}" style="height:20px;padding:0 7px;background:#3c3836;border:1px solid #504945;border-radius:2px;color:#a89984;font:500 10px 'JetBrains Mono',monospace;cursor:pointer" style-hover="filter:brightness(1.12)">copy</button>
+      </div>
+      <div style="padding:12px 16px;display:flex;flex-direction:column;gap:12px">
+        <div style="display:flex;flex-direction:column;gap:6px">
+          <div style="display:flex;align-items:center;gap:8px">
+            <span style="font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64">GAS EXTRACTORS</span><span style="flex:1"></span>
+            <span style="font:500 9.5px 'JetBrains Mono',monospace;letter-spacing:.1em;color:#7c6f64">CLASS</span>
+            <div style="display:flex;border:1px solid #504945;border-radius:2px;overflow:hidden">
+              <sc-for list="{{ gClassOpts }}" as="o" hint-placeholder-count="4">
+                <button onClick="{{ o.set }}" style="height:22px;padding:0 8px;cursor:pointer;font:600 10.5px 'JetBrains Mono',monospace;border:none;border-left:{{ o.bl }};background:{{ o.bg }};color:{{ o.fg }};box-shadow:{{ o.sh }}">{{ o.k }}</button>
+              </sc-for>
+            </div>
+          </div>
+          <sc-for list="{{ gRows }}" as="r" hint-placeholder-count="3">
+            <div style="background:#3c3836;border-radius:2px;padding:9px 11px;display:flex;flex-direction:column;gap:3px">
+              <div style="display:flex;justify-content:space-between;font:500 13px 'Space Grotesk',sans-serif;color:#fbf1c7"><span>{{ r.name }}</span><span style="font-family:'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">{{ r.qty }}</span></div>
+              <div style="font:11.5px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums"><span style="color:#ebdbb2">{{ r.main }}</span></div>
+              <sc-if value="{{ showTimes }}" hint-placeholder-val="{{ true }}"><div style="font:11.5px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums">{{ r.time }}</div></sc-if>
+            </div>
+          </sc-for>
+          <div style="background:#3c3836;border-radius:2px;padding:9px 11px;display:flex;flex-direction:column;gap:3px">
+            <div style="display:flex;justify-content:space-between;font:500 13px 'Space Grotesk',sans-serif;color:#fbf1c7"><span>Condensed Carbon</span><span style="font-family:'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">{{ ccQty }}</span></div>
+            <div style="font:11.5px 'JetBrains Mono',monospace;color:#8ec07c">✓ byproduct of gas refines — nothing to build</div>
+          </div>
+        </div>
+        <div style="display:flex;flex-direction:column;gap:6px">
+          <div style="display:flex;align-items:center;gap:8px">
+            <span style="font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64">POWER</span><span style="flex:1"></span>
+            <div style="display:flex;border:1px solid #504945;border-radius:2px;overflow:hidden">
+              <sc-for list="{{ gPowOpts }}" as="o" hint-placeholder-count="2">
+                <button onClick="{{ o.set }}" style="height:22px;padding:0 8px;cursor:pointer;font:600 10.5px 'JetBrains Mono',monospace;border:none;border-left:{{ o.bl }};background:{{ o.bg }};color:{{ o.fg }};box-shadow:{{ o.sh }}">{{ o.k }}</button>
+              </sc-for>
+            </div>
+            <sc-if value="{{ gIsEm }}" hint-placeholder-val="{{ true }}">
+              <span style="font:500 9.5px 'JetBrains Mono',monospace;letter-spacing:.1em;color:#7c6f64">CLASS</span>
+              <div style="display:flex;border:1px solid #504945;border-radius:2px;overflow:hidden">
+                <sc-for list="{{ gEmOpts }}" as="o" hint-placeholder-count="4">
+                  <button onClick="{{ o.set }}" style="height:22px;padding:0 8px;cursor:pointer;font:600 10.5px 'JetBrains Mono',monospace;border:none;border-left:{{ o.bl }};background:{{ o.bg }};color:{{ o.fg }};box-shadow:{{ o.sh }}">{{ o.k }}</button>
+                </sc-for>
+              </div>
+            </sc-if>
+          </div>
+          <div style="background:#3c3836;border-radius:2px;padding:9px 11px;display:flex;flex-direction:column;gap:7px">
+            <div style="display:grid;grid-template-columns:32px 1fr 64px;gap:8px;align-items:center;font:10.5px 'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">
+              <span style="color:#a89984">GEN</span><div style="height:7px;background:#1d2021"><div style="width:{{ gGenPct }};height:100%;background:#8ec07c"></div></div><span style="color:#ebdbb2;text-align:right">{{ gGen }} kPs</span>
+              <span style="color:#a89984">DRAW</span><div style="height:7px;background:#1d2021;display:flex"><div style="width:{{ gSafePct }};height:100%;background:#a89984"></div><div style="width:{{ gOverPct }};height:100%;background:#fb4934"></div></div><span style="color:{{ gDrawColor }};text-align:right">{{ gDraw }} kPs</span>
+            </div>
+            <sc-if value="{{ gDeficit }}" hint-placeholder-val="{{ true }}">
+              <div style="display:flex;align-items:center;gap:8px"><span style="font:11.5px 'Space Grotesk',sans-serif;color:#fb4934">⚠ deficit {{ gDef }} kPs</span><span style="flex:1"></span><button onClick="{{ fixG }}" style="height:26px;padding:0 10px;background:#3c3836;border:1px solid #665c54;border-radius:2px;color:#ebdbb2;font:500 11.5px 'Space Grotesk',sans-serif;cursor:pointer" style-hover="filter:brightness(1.12)">{{ gFixLabel }}</button></div>
+            </sc-if>
+            <sc-if value="{{ gOk }}" hint-placeholder-val="{{ false }}">
+              <div style="font:11.5px 'Space Grotesk',sans-serif;color:#8ec07c">✓ headroom +{{ gHead }} kPs · {{ gGenDesc }}</div>
+            </sc-if>
+          </div>
+        </div>
+        <div style="border-top:1px solid #3c3836;padding-top:10px;display:flex;justify-content:space-between;align-items:baseline;gap:8px">
+          <span style="font:11.5px 'JetBrains Mono',monospace;color:#a89984">BUILD: {{ gBuild }}<sc-if value="{{ gDeficit }}" hint-placeholder-val="{{ true }}"><span style="color:#fb4934"> · +{{ gFixN }} {{ gFixUnit }}</span></sc-if></span>
+          <span style="font:600 12px 'JetBrains Mono',monospace;color:#fbf1c7;font-variant-numeric:tabular-nums">ready ~{{ gReady }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div data-screen-label="Cobalt Flats card" onClick="{{ selC }}" tabIndex="0" style="width:340px;background:#32302f;border:3px solid #b3618a;border-radius:4px;position:relative;display:flex;flex-direction:column;cursor:pointer" style-focus="outline:2px solid #8ec07c;outline-offset:2px">
+      <sc-if value="{{ cSel }}" hint-placeholder-val="{{ false }}"><div style="position:absolute;inset:3px;border:2px solid #8ec07c;pointer-events:none;z-index:2"></div></sc-if>
+      <div style="display:flex;align-items:center;gap:10px;padding:14px 16px;border-bottom:1px solid #3c3836">
+        <span style="width:10px;height:10px;background:#b3618a;border-radius:1px"></span>
+        <span style="font:600 15px 'Chakra Petch',sans-serif;letter-spacing:.04em;color:#fbf1c7">BASE F — COBALT FLATS</span>
+        <span style="flex:1"></span>
+        <span style="font:italic 12px 'Space Grotesk',sans-serif;color:#a89984">rename</span>
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;padding:8px 16px;border-bottom:1px solid #3a3634">
+        <span style="display:inline-flex;align-items:center;gap:5px;height:20px;padding:0 7px;background:#45403d;border:1px solid #504945;border-radius:2px;font:600 9.5px 'JetBrains Mono',monospace;letter-spacing:.08em;color:#ebdbb2">❄ FROZEN</span>
+        <span style="font:10.5px 'JetBrains Mono',monospace;color:#a89984">blizzards at night · solar dips</span>
+        <span style="flex:1"></span>
+        <span style="font:500 9.5px 'JetBrains Mono',monospace;letter-spacing:.1em;color:#7c6f64">PORTAL</span>
+        <span style="font:500 11px 'JetBrains Mono',monospace;letter-spacing:.06em;color:#ebdbb2">40FA92D18B06</span>
+        <button onClick="{{ copyC }}" style="height:20px;padding:0 7px;background:#3c3836;border:1px solid #504945;border-radius:2px;color:#a89984;font:500 10px 'JetBrains Mono',monospace;cursor:pointer" style-hover="filter:brightness(1.12)">copy</button>
+      </div>
+      <div style="padding:12px 16px;display:flex;flex-direction:column;gap:12px">
+        <div style="display:flex;flex-direction:column;gap:6px">
+          <div style="display:flex;align-items:center;gap:8px">
+            <span style="font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64">MINERAL EXTRACTORS</span><span style="flex:1"></span>
+            <span style="font:500 9.5px 'JetBrains Mono',monospace;letter-spacing:.1em;color:#7c6f64">CLASS</span>
+            <div style="display:flex;border:1px solid #504945;border-radius:2px;overflow:hidden">
+              <sc-for list="{{ cClassOpts }}" as="o" hint-placeholder-count="4">
+                <button onClick="{{ o.set }}" style="height:22px;padding:0 8px;cursor:pointer;font:600 10.5px 'JetBrains Mono',monospace;border:none;border-left:{{ o.bl }};background:{{ o.bg }};color:{{ o.fg }};box-shadow:{{ o.sh }}">{{ o.k }}</button>
+              </sc-for>
+            </div>
+          </div>
+          <sc-for list="{{ cRows }}" as="r" hint-placeholder-count="4">
+            <div style="background:#3c3836;border-radius:2px;padding:9px 11px;display:flex;flex-direction:column;gap:3px">
+              <div style="display:flex;justify-content:space-between;font:500 13px 'Space Grotesk',sans-serif;color:#fbf1c7"><span>{{ r.name }}</span><span style="font-family:'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">{{ r.qty }}</span></div>
+              <div style="font:11.5px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums"><span style="color:#ebdbb2">{{ r.main }}</span></div>
+              <sc-if value="{{ showTimes }}" hint-placeholder-val="{{ true }}"><div style="font:11.5px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums">{{ r.time }}</div></sc-if>
+            </div>
+          </sc-for>
+        </div>
+        <div style="display:flex;flex-direction:column;gap:6px">
+          <div style="display:flex;align-items:center;gap:8px">
+            <span style="font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64">POWER</span><span style="flex:1"></span>
+            <div style="display:flex;border:1px solid #504945;border-radius:2px;overflow:hidden">
+              <sc-for list="{{ cPowOpts }}" as="o" hint-placeholder-count="2">
+                <button onClick="{{ o.set }}" style="height:22px;padding:0 8px;cursor:pointer;font:600 10.5px 'JetBrains Mono',monospace;border:none;border-left:{{ o.bl }};background:{{ o.bg }};color:{{ o.fg }};box-shadow:{{ o.sh }}">{{ o.k }}</button>
+              </sc-for>
+            </div>
+            <sc-if value="{{ cIsEm }}" hint-placeholder-val="{{ false }}">
+              <span style="font:500 9.5px 'JetBrains Mono',monospace;letter-spacing:.1em;color:#7c6f64">CLASS</span>
+              <div style="display:flex;border:1px solid #504945;border-radius:2px;overflow:hidden">
+                <sc-for list="{{ cEmOpts }}" as="o" hint-placeholder-count="4">
+                  <button onClick="{{ o.set }}" style="height:22px;padding:0 8px;cursor:pointer;font:600 10.5px 'JetBrains Mono',monospace;border:none;border-left:{{ o.bl }};background:{{ o.bg }};color:{{ o.fg }};box-shadow:{{ o.sh }}">{{ o.k }}</button>
+                </sc-for>
+              </div>
+            </sc-if>
+          </div>
+          <div style="background:#3c3836;border-radius:2px;padding:9px 11px;display:flex;flex-direction:column;gap:7px">
+            <div style="display:grid;grid-template-columns:32px 1fr 64px;gap:8px;align-items:center;font:10.5px 'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">
+              <span style="color:#a89984">GEN</span><div style="height:7px;background:#1d2021"><div style="width:{{ cGenPct }};height:100%;background:#8ec07c"></div></div><span style="color:#ebdbb2;text-align:right">{{ cGen }} kPs</span>
+              <span style="color:#a89984">DRAW</span><div style="height:7px;background:#1d2021;display:flex"><div style="width:{{ cSafePct }};height:100%;background:#a89984"></div><div style="width:{{ cOverPct }};height:100%;background:#fb4934"></div></div><span style="color:{{ cDrawColor }};text-align:right">{{ cDraw }} kPs</span>
+            </div>
+            <sc-if value="{{ cDeficit }}" hint-placeholder-val="{{ false }}">
+              <div style="display:flex;align-items:center;gap:8px"><span style="font:11.5px 'Space Grotesk',sans-serif;color:#fb4934">⚠ deficit {{ cDef }} kPs</span><span style="flex:1"></span><button onClick="{{ fixC }}" style="height:26px;padding:0 10px;background:#3c3836;border:1px solid #665c54;border-radius:2px;color:#ebdbb2;font:500 11.5px 'Space Grotesk',sans-serif;cursor:pointer" style-hover="filter:brightness(1.12)">{{ cFixLabel }}</button></div>
+            </sc-if>
+            <sc-if value="{{ cOk }}" hint-placeholder-val="{{ true }}">
+              <div style="font:11.5px 'Space Grotesk',sans-serif;color:#8ec07c">✓ headroom +{{ cHead }} kPs · {{ cGenDesc }}</div>
+            </sc-if>
+          </div>
+        </div>
+        <div style="border-top:1px solid #3c3836;padding-top:10px;display:flex;justify-content:space-between;align-items:baseline;gap:8px">
+          <span style="font:11.5px 'JetBrains Mono',monospace;color:#a89984">BUILD: {{ cBuild }}<sc-if value="{{ cDeficit }}" hint-placeholder-val="{{ false }}"><span style="color:#fb4934"> · +{{ cFixN }} {{ cFixUnit }}</span></sc-if></span>
+          <span style="font:600 12px 'JetBrains Mono',monospace;color:#fbf1c7;font-variant-numeric:tabular-nums">ready ~{{ cReady }}</span>
+        </div>
+      </div>
+    </div>
+
+    <sc-if value="{{ showBin }}" hint-placeholder-val="{{ true }}">
+      <div data-screen-label="Unassigned bin" style="width:340px;border:3px dashed #504945;border-radius:4px;padding:14px 16px;display:flex;flex-direction:column;gap:8px;box-sizing:border-box">
+        <div style="display:flex;align-items:center;gap:8px">
+          <span style="font:600 15px 'Chakra Petch',sans-serif;letter-spacing:.04em;color:#a89984">UNASSIGNED</span>
+          <span style="font:600 11px 'JetBrains Mono',monospace;color:#7c6f64">(0)</span>
+        </div>
+        <div style="font:13px 'Space Grotesk',sans-serif;color:#a89984;line-height:1.5">Every leaf on the tree is assigned. Resources you clear from a base collect here with a <span style="color:#d79921">⚠</span> until reassigned on the <a href="../tree-canvas/Tree Canvas.dc.html">tree</a>.</div>
+      </div>
+    </sc-if>
+
+  </div>
+  <div aria-live="polite" style="position:absolute;width:1px;height:1px;overflow:hidden;clip-path:inset(50%)">{{ announce }}</div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1160,&quot;height&quot;:980},&quot;deviceQty&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:1,&quot;min&quot;:1,&quot;max&quot;:10,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Plan&quot;},&quot;emOutput&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:110,&quot;min&quot;:50,&quot;max&quot;:300,&quot;unit&quot;:&quot;kPs&quot;,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Plan&quot;},&quot;solarOutput&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:50,&quot;min&quot;:20,&quot;max&quot;:150,&quot;unit&quot;:&quot;kPs&quot;,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Plan&quot;},&quot;showTimes&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Display&quot;},&quot;showUnassignedBin&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Display&quot;}}">
+class Component extends DCLogic {
+  state = { sel: null, addV: 0, addG: 0, addC: 0, gClass: 'B', cClass: 'B', vEm: 'B', gEm: 'B', cEm: 'B', vPow: 'EM', gPow: 'EM', cPow: 'SOLAR', announce: '' };
+  renderVals() {
+    const p = this.props, s = this.state;
+    const q = Math.max(1, Math.min(10, p.deviceQty ?? 1));
+    const mult = { C: .5, B: 1, A: 1.5, S: 2 };
+    const fmt = min => { min = Math.round(min); const h = Math.floor(min / 60), m = min % 60; return h ? h + 'h ' + m + 'm' : m + 'm'; };
+    const pct = (v, sc) => Math.round(v / sc * 100) + '%';
+    const emBase = Math.max(10, p.emOutput ?? 110), solarBase = Math.max(10, p.solarOutput ?? 50);
+    const power = (units, emCls, type, draw) => {
+      const solar = type === 'SOLAR';
+      const out = solar ? solarBase : Math.round(emBase * mult[emCls]);
+      const unitName = solar ? 'Solar Panel' : 'EM generator', gen = units * out;
+      const bat = solar ? Math.ceil(units / 2) : 0;
+      const sc = Math.max(gen, draw) * 1.18, def = Math.max(0, draw - gen), n = Math.ceil(def / out) || 0;
+      return { gen, out, draw, def, n, solar, bat, genPct: pct(gen, sc), safePct: pct(Math.min(gen, draw), sc), overPct: pct(def, sc),
+        drawColor: def ? '#fb4934' : '#ebdbb2', fixLabel: '+ ' + n + ' × ' + unitName + ' (+' + n * out + ')',
+        fixUnit: (solar ? 'solar panel' : 'generator') + (n === 1 ? '' : 's'),
+        desc: units + ' × ' + unitName + (solar ? ' + ' + bat + ' × Battery (night)' : ' ' + emCls) + ' (' + out + ' kPs ea)',
+        build: solar ? units + ' solar panels · ' + bat + ' batteries' : units + ' generators' };
+    };
+    // Verdant Moon — crops [name, qty/device, yield/plant, harvest min]
+    const crops = [['Frost Crystal', 300, 4, 120], ['Gamma Root', 400, 4, 60], ['Solanium', 200, 3, 240], ['Star Bulb', 200, 4, 30], ['Cactus Flesh', 100, 3, 60], ['Faecium', 50, 3, 120]];
+    let vDomes = 0, vReadyM = 0;
+    const vRows = crops.map(([n, b, y, h]) => {
+      const qty = b * q, plants = Math.ceil(qty / y), domes = Math.ceil(plants / 16);
+      vDomes += domes; vReadyM = Math.max(vReadyM, h);
+      return { name: n, qty: '×' + qty, main: plants + ' plants · ' + domes + ' biodome' + (domes > 1 ? 's' : '') + ' (16/dome)', time: 'harvest ' + fmt(h) };
+    });
+    const vGenN = 4 + s.addV, vP = power(vGenN, s.vEm, s.vPow, vDomes * 20 + 40);
+    // Gasworks — gases [name, qty/device]; extractor base rate 200/h at B
+    const gases = [['Sulphurine', 500], ['Nitrogen', 500], ['Radon', 500]];
+    const gRate = 200 * mult[s.gClass];
+    let gExt = 0, gDep = 0, gReadyM = 0;
+    const gRows = gases.map(([n, b]) => {
+      const qty = b * q, count = Math.max(1, Math.ceil(qty / (gRate * 1.5))), fill = qty / (gRate * count) * 60, dep = Math.ceil(qty / 720);
+      gExt += count; gDep += dep; gReadyM = Math.max(gReadyM, fill);
+      return { name: n, qty: '×' + qty, main: count + ' × Gas Extractor', time: 'fills in ' + fmt(fill) + ' · +' + dep + ' supply depot (720u)' };
+    });
+    const gGenN = 3 + s.addG, gP = power(gGenN, s.gEm, s.gPow, gExt * 55 + gDep * 10 + 20);
+    // Cobalt Flats — minerals; extractor base rate 250/h at B
+    const minerals = [['Paraffinium', 50], ['Ionised Cobalt', 50], ['Phosphorus', 50], ['Dioxite', 50]];
+    const cRate = 250 * mult[s.cClass];
+    let cExt = 0, cDep = 0, cReadyM = 0;
+    const cRows = minerals.map(([n, b]) => {
+      const qty = b * q, count = Math.max(1, Math.ceil(qty / (cRate * 1.5))), fill = qty / (cRate * count) * 60, dep = qty > 360 ? Math.ceil(qty / 720) : 0;
+      cExt += count; cDep += dep; cReadyM = Math.max(cReadyM, fill);
+      return { name: n, qty: '×' + qty, main: count + ' × Mineral Extractor', time: 'fills in ' + fmt(fill) + (dep ? ' · +' + dep + ' supply depot (720u)' : '') };
+    });
+    const cGenN = 3 + s.addC, cP = power(cGenN, s.cEm, s.cPow, cExt * 55 + cDep * 10 + 20);
+    const picker = (key, cls, what) => ['C', 'B', 'A', 'S'].map((k, i) => ({
+      k, bl: i ? '1px solid #504945' : 'none',
+      bg: k === cls ? 'rgba(142,192,124,.16)' : '#3c3836', fg: k === cls ? '#b8db9c' : '#7c6f64',
+      sh: k === cls ? 'inset 0 -2px 0 #8ec07c' : 'none',
+      set: e => { e.stopPropagation(); this.setState({ [key]: k, announce: (what || 'Extractor') + ' class set to ' + k + '. Totals updated.' }); }
+    }));
+    const fix = (key, name, n, unit) => e => { e.stopPropagation(); this.setState(st => ({ [key]: st[key] + n, announce: n + ' ' + (unit || 'EM generator') + (n > 1 ? 's' : '') + ' added to ' + name + '. Deficit resolved.' })); };
+    const typePicker = (key) => ['EM', 'SOLAR'].map((k, i) => ({
+      k, bl: i ? '1px solid #504945' : 'none',
+      bg: k === s[key] ? 'rgba(142,192,124,.16)' : '#3c3836', fg: k === s[key] ? '#b8db9c' : '#7c6f64',
+      sh: k === s[key] ? 'inset 0 -2px 0 #8ec07c' : 'none',
+      set: e => { e.stopPropagation(); this.setState({ [key]: k, announce: 'Power type set to ' + (k === 'EM' ? 'electromagnetic' : 'solar') + '. Totals updated.' }); }
+    }));
+    const sel = id => e => this.setState(st => ({ sel: st.sel === id ? null : id }));
+    const copy = (code, name) => e => { e.stopPropagation(); try { navigator.clipboard.writeText(code); } catch (err) {} this.setState({ announce: 'Portal address for ' + name + ' copied.' }); };
+    const readyM = Math.max(vReadyM, gReadyM, cReadyM);
+    return {
+      qty: q, showTimes: p.showTimes ?? true, showBin: p.showUnassignedBin ?? true, announce: s.announce,
+      totGen: (vP.gen + gP.gen + cP.gen).toLocaleString(), totReady: fmt(readyM),
+      copyV: copy('20E5F9556C30', 'Verdant Moon'), copyG: copy('115EF8A10D34', 'Gasworks'), copyC: copy('40FA92D18B06', 'Cobalt Flats'),
+      selV: sel('v'), selG: sel('g'), selC: sel('c'), vSel: s.sel === 'v', gSel: s.sel === 'g', cSel: s.sel === 'c',
+      vRows, vGen: vP.gen, vDraw: vP.draw, vGenPct: vP.genPct, vSafePct: vP.safePct, vOverPct: vP.overPct, vDrawColor: vP.drawColor,
+      vDeficit: vP.def > 0, vOk: vP.def === 0, vDef: vP.def, vHead: vP.gen - vP.draw, vFixN: vP.n, vFixLabel: vP.fixLabel, vFixUnit: vP.fixUnit,
+      fixV: fix('addV', 'Verdant Moon', vP.n, vP.solar ? 'solar panel' : 'EM generator'), vGenDesc: vP.desc, vReady: fmt(vReadyM),
+      vEmOpts: picker('vEm', s.vEm, 'EM generator'), vPowOpts: typePicker('vPow'), vIsEm: !vP.solar,
+      vBuild: vDomes + ' biodomes · ' + vP.build,
+      gRows, gClassOpts: picker('gClass', s.gClass, 'Extractor'), ccQty: '×' + 300 * q,
+      gGen: gP.gen, gDraw: gP.draw, gGenPct: gP.genPct, gSafePct: gP.safePct, gOverPct: gP.overPct, gDrawColor: gP.drawColor,
+      gDeficit: gP.def > 0, gOk: gP.def === 0, gDef: gP.def, gHead: gP.gen - gP.draw, gFixN: gP.n, gFixLabel: gP.fixLabel, gFixUnit: gP.fixUnit,
+      fixG: fix('addG', 'Gasworks', gP.n, gP.solar ? 'solar panel' : 'EM generator'), gGenDesc: gP.desc, gReady: fmt(gReadyM),
+      gEmOpts: picker('gEm', s.gEm, 'EM generator'), gPowOpts: typePicker('gPow'), gIsEm: !gP.solar,
+      gBuild: gExt + ' extractors · ' + gDep + ' depots · ' + gP.build,
+      cRows, cClassOpts: picker('cClass', s.cClass, 'Extractor'),
+      cGen: cP.gen, cDraw: cP.draw, cGenPct: cP.genPct, cSafePct: cP.safePct, cOverPct: cP.overPct, cDrawColor: cP.drawColor,
+      cDeficit: cP.def > 0, cOk: cP.def === 0, cDef: cP.def, cHead: cP.gen - cP.draw, cFixN: cP.n, cFixLabel: cP.fixLabel, cFixUnit: cP.fixUnit,
+      fixC: fix('addC', 'Cobalt Flats', cP.n, cP.solar ? 'solar panel' : 'EM generator'), cGenDesc: cP.desc, cReady: fmt(cReadyM),
+      cEmOpts: picker('cEm', s.cEm, 'EM generator'), cPowOpts: typePicker('cPow'), cIsEm: !cP.solar,
+      cBuild: cExt + ' extractors' + (cDep ? ' · ' + cDep + ' depots' : '') + ' · ' + cP.build
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/base-planner/handoff.md
+++ b/docs/design/base-planner/handoff.md
@@ -1,0 +1,81 @@
+# Handoff: Base Planner Panel (NMS Base & Resource Planner)
+
+> Convention note: where this document and a later spec disagree, **the spec wins**.
+
+## Overview
+The build-checklist surface: one card per base, rolling the tree's leaf assignments up into concrete construction instructions — what to plant, build, and power, per base. Promotes the `Theme Variants.dc.html` 6a exploration to a full 3-base panel. **No "buy" language**: every line is something the player constructs.
+
+## About the Design Files
+`Base Planner.dc.html` is a **design reference created in HTML**, not production code. All quantities derive live from a small data model (crops/gases/minerals per 1 Stasis Device, sample yields/rates) so the interactions are real: device quantity scales every row, extractor class recomputes counts and fill times, the deficit button appends generators. Production computes the same rollup from the dependency graph shared with the tree canvas.
+
+## Layout
+- Header strip: target + quantity (Chakra Petch), mono aqua summary (`3 BASES · Σ kPs GEN · READY ~t`), Recompute (orange primary) / Share / "view tree →" link.
+- Cards 340px wide, wrap row. Base identity = 3px `--base-*` frame + color chip + name (name is primary identity, SC 1.4.1).
+- Sample bases match the tree's assignments: Verdant Moon (blue, crops), Gasworks (copper, gases + carbon), Cobalt Flats (purple, minerals).
+- Unassigned bin: dashed `--border` panel; cleared leaves collect here with ⚠ (empty state shown; togglable via tweak).
+
+## Card anatomy
+1. **Header** — chip, name, rename affordance.
+2. **Environment strip** — planet-type badge (glyph + caps label, monochrome on `--input-bg` per the method-badge rule: ❀ LUSH / ☣ TOXIC / ❄ FROZEN…), a short hazard note that feeds planning ("acid storms · hazard prot. req.", "blizzards at night · solar dips"), and the 12-glyph **portal address** (mono hex stand-in; production renders the glyph font) with a copy button (announced via aria-live).
+2. **Sections** by producer type, `--panel-raised` rows:
+   - FARM rows: `qty → plants (qty ÷ yield) → biodomes (plants ÷ 16)` + harvest time.
+   - EXTRACTOR rows: count sized to fill within ~1.5h at current class + fill time + supply depots (720u) when qty > 360.
+   - Section-level **class picker** (C/B/A/S, small 22px segmented, aqua selection) — one class per site, not per row: extractors at one hotspot share quality.
+   - Byproduct rows (Condensed Carbon from gas refines) render as `--ok` "nothing to build" — demand met without construction.
+3. **POWER** — GEN/DRAW meters on `--bg-canvas` tracks; overdraw segment `--danger`. Section header carries a **power type picker** (EM | SOLAR) and, for EM, a **CLASS picker** (C/B/A/S): EM output = base kPs × class multiplier (.5/1/1.5/2); solar is classless (fixed kPs/panel) and adds **1 battery per 2 panels** for night coverage. Switching type or downgrading class can reopen a deficit. Deficit is an action: `+ n × [EM generator|Solar Panel] (+n·out)` button appends to the build list and flips the block to `✓ headroom` (6a behavior); the headroom line states count, type/class, per-unit output, and batteries.
+4. **BUILD footer** — the card's rollup: everything constructed; pending generators in `--danger` until the fix is clicked; `ready ~t` = longest producer in the card.
+
+## Interactions (all live in the prototype)
+- Card click/Enter = select (aqua ring **inboard** via overlay element, identity frame untouched; outfitter PR #180 rule).
+- Extractor class picker → counts + fill times + power draw recompute.
+- EM class picker → generator output, deficit/headroom, and fix-button sizing recompute.
+- Power type picker (EM | SOLAR) → swaps generation math (solar: classless, + batteries), re-sizes the fix button, rewrites the BUILD rollup. One type per base in the mock; mixed grids deferred (see open questions). Cobalt Flats defaults to solar as the worked example.
+- Deficit button → generators added, footer + header totals update.
+- All recomputes announce via `aria-live="polite"`.
+
+## Tweaks
+- `deviceQty` 1–10: scales every quantity, plant count, extractor count, fill time.
+- `emOutput` (kPs, default 110): base EM generator output at class B — swap in real game data without touching code.
+- `solarOutput` (kPs, default 50): output per solar panel.
+- `showTimes`: hides the time detail line (compact scanning mode).
+- `showUnassignedBin`: toggles the bin.
+
+## Sample-data notes
+Yields (crops/plant), extractor rates (gas 200/h, mineral 250/h at B), EM output (110 kPs at B), solar output (50 kPs/panel, 1 battery per 2 panels), class multipliers (×.5/1/1.5/2 for extractors and EM generators alike), dome capacity 16, draws (dome 20, extractor 55, depot 10, base overhead) are **illustrative** — production reads game data. Resource lists per base are the real Stasis Device leaves from `docs/design/tree-canvas/handoff.md`.
+
+## Open questions
+1. Theme handoff Q1 (warn-yellow vs base-yellow) — the unassigned bin here uses ⚠ + text on gray, no yellow frame nearby; resolved for this surface, re-check when a yellow-framed base card carries a warning row.
+2. Per-row class override (mixed-class sites)? Deferred — section-level picker holds until a user asks.
+3. Mixed power grids (EM + solar at one base) — the mock is single-type per base; production likely needs a generator list instead of a type toggle.
+3. "ready ~t" ignores refine time at the collector base; app-shell surface should decide where refining time is charged.
+
+## Self-critique / WCAG 2.1 AA findings
+- Deficit text `--danger` 3.82:1 on `--panel-raised` — always paired with ⚠ + stated kPs quantity + red meter segment; per theme handoff rule.
+- Cards are clickable divs with `tabIndex` + focus outline; production should use a proper button/listbox semantic for selection.
+- Time detail lines are 11.5px `--text-muted` mono on `--panel-raised` (4.17:1) — decorative reinforcement of the main line's counts; flagged per theme rule, revisit if times become sole info.
+
+## Files
+- `docs/design/base-planner/Base Planner.dc.html` — interactive prototype (v1: checklists, power, env strip, portal codes)
+- `docs/design/base-planner/Base Planner v2.dc.html` — v2 manager view (see "v2 additions" below)
+- Depends on: `docs/design/theme/handoff.md` tokens · leaf data from `docs/design/tree-canvas/handoff.md`
+- Prior exploration: `Theme Variants.dc.html` 6a
+
+## v2 additions (user-directed, form rounds 1–4)
+- **Checkable BUILD TODO** per card: tick off built items (strike-through); the pending deficit item stays red and uncheckable until fixed via the POWER button. Header **progress bar** counts construction items + harvest-cycle elapsed (user choice: include harvest readiness). Footer: "n of m built · ready ~t".
+- **Harvest-run route bar** above the cards: numbered base chips (identity color as 3px left edge) + travel method between legs (⌁ teleporter / ◇ portal), no timing (user choice).
+- **Storage tracker**: stocked-vs-needed bar per resource row (user choice: per-row); full = `--ok`, partial = `--text-muted`.
+- **Env strip v2**: biome badge + subtle biome tint (decorative, ≤.06 alpha), hazard note, SENT level · economy · star class as mono text (user choice: env strip, not own row), portal + copy.
+- **Collapsible sections** with one-line summaries when closed; BUILD + POWER open by default (user choice). Production section (farm/extractors) collapsed.
+- **Mini power-grid diagram** (gen → BUS → loads) renders in POWER of the **selected card only** (user choice).
+- **Screenshot slot**: collapsible SCREENSHOT section with a drag-and-drop `<image-slot>` (placement decided by us after user skip — collapsed section keeps cards compact).
+- **Notes**: quick tags (⚠ RESTOCK / ↻ REBUILD / ◈ VISIT) + free text (user choice: tags + text).
+- v2 is data-driven (one card template over a bases array) — v1 stays as the simpler literal-markup reference.
+- **Plan targets beyond industry** (user request): a TARGET switcher in the header swaps the whole plan — STASIS (industrial, 3 bases) or CAKE (cooking: Hexaberry Cake ×25/batch, 2 bases). The cooking plan adds two producer types: **RANCH** rows (fauna products — Wild Milk, Proto-Egg · grazing counts + pellet feeder) and a **KITCHEN** section (Nutrient Processor steps: ◇ process wheat→flour, milk→butter, batter, ⚑ final bake), with processors and the feeder as BUILD TODO items. The cake plan carries the `unverified` dashed chip (community recipe convention from the tree canvas). Method vocabulary grows to craft / refine / raw / **cook** — still no buy. Sections now collapse independently (RANCH vs KITCHEN).
+
+## 8-bit restyle (v2 only, user request 2026-08-17)
+- Silkscreen (pixel font) replaces Chakra Petch for the plan title, base names, and UNASSIGNED header (14px title / 10px card names — pixel fonts read small).
+- All corner radii squared to 0; base cards + unassigned bin get a 2-step pixel-notch corner via clip-path (8px/4px stair).
+- Meters and the header progress bar render as chunked pixel segments (repeating-linear-gradient, 5px on / 2px off) instead of smooth fills.
+- Primary/secondary header buttons get a hard 3px offset shadow (no blur).
+- Body/data type stays Space Grotesk / JetBrains Mono for legibility; v1 keeps the pre-8-bit look as reference.
+- New sibling surface: `docs/design/bases-map/` — the Base Atlas (city-builder overview); linked from the header ("view atlas →").

--- a/docs/design/base-planner/image-slot.js
+++ b/docs/design/base-planner/image-slot.js
@@ -1,0 +1,1225 @@
+// @ds-adherence-ignore -- omelette starter scaffold (raw elements/hex/px by design)
+// Copied omelette starter. Re-running copy_starter_component with this kind overwrites this file with the latest version (page content is unaffected).
+/* BEGIN USAGE */
+/**
+ * <image-slot> — user-fillable image placeholder.
+ *
+ * Drop this into a deck, mockup, or page wherever a design needs an image.
+ * You control the slot's shape; it sizes to its container by default. When the search_stock_photos tool
+ * is available, prefill the slot by default — write the photo's URL into
+ * src (with credit/credit-href); the user can still fill or replace it
+ * by dragging an image file onto it (or clicking to browse). The dropped
+ * image persists across reloads via a .image-slots.state.json sidecar —
+ * same read-via-fetch / write-via-window.omelette pattern as
+ * design_canvas.jsx, so the filled slot shows on share links, downloaded
+ * zips, and PPTX export. Outside the omelette runtime the slot is read-only.
+ *
+ * The sidecar is a SIBLING of the HTML file that uses this component: the
+ * read is a document-relative fetch, and the host resolves the bridge's
+ * sidecar writes into the previewed file's directory to match (same
+ * contract as design_canvas.jsx). Pages in the same directory share one
+ * sidecar; keep slot ids distinct across them.
+ *
+ * Attributes:
+ *   id           Persistence key. REQUIRED for the drop to survive reload —
+ *                every slot on the page needs a distinct id.
+ *   shape        'rect' | 'rounded' | 'circle' | 'pill'   (default 'rounded')
+ *                'circle' applies 50% border-radius; on a non-square slot
+ *                that's an ellipse — set equal width and height for a true
+ *                circle.
+ *   radius       Corner radius in px for 'rounded'.       (default 12)
+ *   mask         Any CSS clip-path value. Overrides `shape` — use this for
+ *                hexagons, blobs, arbitrary polygons.
+ *   fit          Initial framing baseline: cover | contain.   (default 'cover')
+ *                cover starts the image filling the frame (overflow cropped);
+ *                contain starts it fully visible (letterboxed). Either way the
+ *                user can always pan/scale from there — double-click, or the
+ *                Edit control, enters reframe mode (drag to move, scroll or
+ *                corner-handles to scale; Escape / click-out commits). The
+ *                crop persists alongside the image in the sidecar.
+ *   placeholder  Empty-state caption.                      (default 'Drop an image')
+ *   src          Optional initial/fallback image URL. Prefill it with a real
+ *                photo via search_stock_photos when that tool is available
+ *                (set credit/credit-href from the result). A user drop
+ *                overrides it; clearing the drop reveals src again.
+ *   credit       Attribution text shown as a small overlay at the
+ *                bottom-left of the filled slot. REQUIRED whenever src
+ *                points at any Unsplash host (images.unsplash.com,
+ *                plus.unsplash.com, …): an Unsplash src with no credit
+ *                renders an error tile INSTEAD of the photo (Unsplash
+ *                terms forbid showing their photos unattributed). Use the
+ *                exact form 'Photo by {photographer name} on Unsplash' —
+ *                the overlay then links the name to credit-href and
+ *                'Unsplash' to the Unsplash homepage, and links back to
+ *                unsplash.com automatically get the required utm referral
+ *                params appended at render time. The credit belongs to
+ *                the src image, so it only shows while src is what's
+ *                displayed — a user-dropped image hides it.
+ *   credit-href  Link for the photographer's name in the credit overlay
+ *                (their Unsplash profile URL from the stock-photo search
+ *                results). http(s) URLs only — anything else renders the
+ *                name as plain text.
+ *
+ * Sizing: the slot fills its container by default (width/height 100%).
+ * Put it in a sized wrapper — absolutely positioned, a grid cell, a fixed
+ * frame — and it takes exactly that box. When the parent's height is
+ * indefinite (ordinary flow), it falls back to full width at a 3:2 aspect
+ * ratio instead of collapsing. In a shrink-to-fit parent (a float,
+ * width:max-content, an unsized absolute wrapper), percentages have
+ * nothing to resolve against — size the slot or its wrapper explicitly
+ * there. For a fixed-size slot, set
+ * width/height on the element itself (inline style), which overrides the
+ * default. When
+ * layering content above a slot (full-bleed layouts), make the overlay
+ * click-through — pointer-events: none on scrims/text plates, re-enabled
+ * on interactive children — so the slot's hover controls stay reachable.
+ * Keep the slot's bottom-left corner visually clear as well: the credit
+ * overlay renders there, and a dark fade or text plate covering it hides
+ * the attribution Unsplash's terms require — end the fade above that
+ * corner, or keep it nearly transparent where the credit sits.
+ *
+ * Usage:
+ *   <div style="position:relative;width:100%;height:100%">      <!-- full-bleed: -->
+ *     <image-slot id="bg" shape="rect"></image-slot>            <!-- fills the wrapper -->
+ *   </div>
+ *   <image-slot id="hero"   style="width:800px;height:450px" shape="rounded" radius="20"
+ *               placeholder="Drop a hero image"></image-slot>
+ *   <image-slot id="avatar" style="width:120px;height:120px" shape="circle"></image-slot>
+ *   <image-slot id="kite"   style="width:300px;height:300px"
+ *               mask="polygon(50% 0, 100% 50%, 50% 100%, 0 50%)"></image-slot>
+ */
+/* END USAGE */
+
+(() => {
+  const STATE_FILE = '.image-slots.state.json';
+
+  // Unsplash terms require visible attribution wherever their photos
+  // display, and every link back to unsplash.com must carry utm referral
+  // params. Two render-time rules enforce that here:
+  //  - an Unsplash-src slot with NO credit attribute renders an error
+  //    tile INSTEAD of the photo (an uncredited Unsplash photo on screen
+  //    is itself the terms violation, so it never renders bare);
+  //  - rendered credit links pointing at unsplash.com get the referral
+  //    params appended when absent (credit-href values live in page
+  //    content that can't be edited after the fact).
+  // Keep the utm_source value in sync with UTM_SOURCE in
+  // platform/web-agent/unsplash.ts — this file is a project-local
+  // artifact and cannot import it (equality is pinned by tests).
+  const UNSPLASH_HOMEPAGE_HREF =
+    'https://unsplash.com/?utm_source=claude_design&utm_medium=referral';
+  // Host rule mirrors the hotlink validator that admits Unsplash srcs into
+  // pages in the first place (cdn$ in unsplash.ts: apex or any subdomain)
+  // — Unsplash+ results serve from plus.unsplash.com, not just images.*,
+  // and an admitted-but-uncredited photo must error whatever unsplash
+  // host it rides on.
+  // Trailing-dot FQDNs (images.unsplash.com.) are the same host to the
+  // browser but would miss the regex — strip one dot so the check fails
+  // CLOSED (unrecognized-but-real Unsplash srcs must error, not render).
+  const isUnsplashHost = (u) => {
+    try {
+      return /(^|\.)unsplash\.com$/.test(
+        new URL(u, document.baseURI).hostname.replace(/\.$/, '')
+      );
+    } catch {
+      return false;
+    }
+  };
+  // Render-time referral normalization for links back to Unsplash:
+  // appends utm_source/utm_medium when absent, preserves every existing
+  // query param, never overwrites an existing utm_source, and passes
+  // non-Unsplash URLs through untouched. Input is an ABSOLUTE validated
+  // http(s) URL (the credit render funnel resolves + validates first).
+  const withReferral = (href) => {
+    try {
+      const u = new URL(href);
+      if (!/(^|\.)unsplash\.com$/.test(u.hostname.replace(/\.$/, ''))) {
+        return href;
+      }
+      if (!u.searchParams.has('utm_source')) {
+        u.searchParams.set('utm_source', 'claude_design');
+      }
+      if (!u.searchParams.has('utm_medium')) {
+        u.searchParams.set('utm_medium', 'referral');
+      }
+      return u.toString();
+    } catch (e) {
+      return href;
+    }
+  };
+  // 2× a ~600px slot in a 1920-wide deck — retina-sharp without making the
+  // sidecar enormous. A 1200px WebP at q=0.85 is ~150-300KB.
+  const MAX_DIM = 1200;
+  // Raster formats only. SVG is excluded (can carry script; createImageBitmap
+  // on SVG blobs is inconsistent). GIF is excluded because the canvas
+  // re-encode keeps only the first frame, so an animated GIF would silently
+  // go still — better to reject than surprise.
+  const ACCEPT = ['image/png', 'image/jpeg', 'image/webp', 'image/avif'];
+
+  // ── Shared sidecar store ────────────────────────────────────────────────
+  // One fetch + immediate write-on-change for every <image-slot> on the
+  // page. Reads via fetch() so viewing works anywhere the HTML and sidecar
+  // are served together; writes go through window.omelette.writeFile, which
+  // the host allowlists to *.state.json basenames only.
+  const subs = new Set();
+  let slots = {};
+  // ids explicitly cleared before the sidecar fetch resolved — otherwise
+  // the merge below can't tell "never set" from "just deleted" and would
+  // resurrect the sidecar's stale value.
+  const tombstones = new Set();
+  let loaded = false;
+  let loadP = null;
+
+  function load() {
+    if (loadP) return loadP;
+    loadP = fetch(STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        // Merge: sidecar loses to any in-memory change that raced ahead of
+        // the fetch (drop or clear) so neither is clobbered by hydration.
+        if (j && typeof j === 'object') {
+          const merged = Object.assign({}, j, slots);
+          // A framing-only write that raced ahead of hydration must not
+          // drop a user image that's only on disk — inherit u from the
+          // sidecar for any in-memory entry that lacks one.
+          for (const k in slots) {
+            if (merged[k] && !merged[k].u && j[k]) {
+              merged[k].u = typeof j[k] === 'string' ? j[k] : j[k].u;
+            }
+          }
+          for (const id of tombstones) delete merged[id];
+          slots = merged;
+        }
+        tombstones.clear();
+      })
+      .catch(() => {})
+      .then(() => { loaded = true; subs.forEach((fn) => fn()); });
+    return loadP;
+  }
+
+  // Serialize writes so two near-simultaneous drops on different slots
+  // can't reorder at the backend and leave the sidecar with only the
+  // first. A save requested mid-flight just marks dirty and re-fires on
+  // completion with the then-current slots.
+  let saving = false;
+  let saveDirty = false;
+  // Unload-time flush: save()'s serialization defers a mid-RTT re-fire to a
+  // .then that never runs in an unloading document, silently dropping a
+  // pagehide commit. Post the current slots immediately instead — content
+  // is a superset snapshot of any in-flight save's, the write is a
+  // whole-file last-writer-wins replace, and postMessage FIFO delivers it
+  // to the host after the in-flight one, so a backend-side reorder at
+  // worst reproduces the dropped-commit outcome this flush improves on.
+  // Guarded on the initial sidecar read: pre-hydration slots can miss
+  // other slots' persisted entries, and flushing it would clobber them —
+  // that narrow case stays best-effort (the in-memory merge in load()
+  // cannot happen in an unloading document anyway).
+  function flushNow() {
+    if (!loaded) return;
+    const w = window.omelette && window.omelette.writeFile;
+    if (!w) return;
+    try { Promise.resolve(w(STATE_FILE, JSON.stringify(slots))).catch(() => {}); } catch (e) {}
+  }
+  function save() {
+    if (saving) { saveDirty = true; return; }
+    const w = window.omelette && window.omelette.writeFile;
+    if (!w) return;
+    saving = true;
+    Promise.resolve(w(STATE_FILE, JSON.stringify(slots)))
+      .catch(() => {})
+      .then(() => { saving = false; if (saveDirty) { saveDirty = false; save(); } });
+  }
+
+  const S_MAX = 5;
+  const clampS = (s) => Math.max(1, Math.min(S_MAX, s));
+
+  // Normalize a stored slot value. Pre-reframe sidecars stored a bare
+  // data-URL string; newer ones store {u, s, x, y}. Either shape is valid.
+  function getSlot(id) {
+    const v = slots[id];
+    if (!v) return null;
+    return typeof v === 'string' ? { u: v, s: 1, x: 0, y: 0 } : v;
+  }
+
+  function setSlot(id, val) {
+    if (!id) return;
+    if (val) { slots[id] = val; tombstones.delete(id); }
+    else { delete slots[id]; if (!loaded) tombstones.add(id); }
+    subs.forEach((fn) => fn());
+    // A drop is rare + high-value — write immediately so nav-away can't lose
+    // it. Gate on the initial read so we don't overwrite a sidecar we haven't
+    // merged yet; the merge in load() keeps this change once the read lands.
+    if (loaded) save(); else load().then(save);
+  }
+
+  // ── Image downscale ─────────────────────────────────────────────────────
+  // Encode through a canvas so the sidecar carries resized bytes, not the
+  // raw upload. Longest side is capped at 2× the slot's rendered width
+  // (retina) and at MAX_DIM. WebP keeps alpha and is ~10× smaller than PNG
+  // for photos, so there's no need for per-image format picking.
+  async function toDataUrl(file, targetW) {
+    const bitmap = await createImageBitmap(file);
+    try {
+      const cap = Math.min(MAX_DIM, Math.max(1, Math.round(targetW * 2)) || MAX_DIM);
+      const scale = Math.min(1, cap / Math.max(bitmap.width, bitmap.height));
+      const w = Math.max(1, Math.round(bitmap.width * scale));
+      const h = Math.max(1, Math.round(bitmap.height * scale));
+      const canvas = document.createElement('canvas');
+      canvas.width = w; canvas.height = h;
+      canvas.getContext('2d').drawImage(bitmap, 0, 0, w, h);
+      return canvas.toDataURL('image/webp', 0.85);
+    } finally {
+      bitmap.close && bitmap.close();
+    }
+  }
+
+  // ── Custom element ──────────────────────────────────────────────────────
+  const stylesheet =
+    // Fill the container by default: slots are usually placed inside a
+    // sized wrapper (a hero frame, a grid cell, an inset:0 layer) and are
+    // expected to take that box — a fixed intrinsic size would render as
+    // a small tile in the corner of a full-bleed wrapper instead.
+    // aspect-ratio is the companion fallback that keeps a bare slot
+    // visible when the parent's height is indefinite: height:100%
+    // resolves to auto there, and the ratio then derives height from
+    // width instead of letting the slot collapse to zero height.
+    // Explicit width/height on the element override all of this.
+    // color:inherit (not a fixed near-black): the placeholder chrome —
+    // empty-state icon/caption (currentColor) and the dashed ring — must
+    // read on dark decks too, and the slide's own text color is the one
+    // color guaranteed to contrast with the slide background. The soft
+    // look comes from opacity on those parts, not from a baked-in alpha.
+    ':host{display:block;position:relative;' +
+    '  font:13px/1.3 system-ui,-apple-system,sans-serif;' +
+    '  width:100%;height:100%;aspect-ratio:3/2}' +
+    '.empty .cap,.empty .sub{opacity:.75}' +
+    '.frame{position:absolute;inset:0;overflow:hidden;background:rgba(127,127,127,.08)}' +
+    // .frame img (clipped) and .spill (unclipped ghost + handles) share the
+    // same left/top/width/height in frame-%, computed by _applyView(), so the
+    // inside-mask crop and the outside-mask spill stay pixel-aligned.
+    '.frame img{position:absolute;max-width:none;transform:translate(-50%,-50%);' +
+    '  -webkit-user-drag:none;user-select:none;touch-action:none}' +
+    // Reframe mode (double-click): the full image spills past the mask. The
+    // spill layer is sized to the IMAGE bounds so its corners are where the
+    // resize handles belong. The ghost <img> inside is translucent; the real
+    // clipped <img> underneath shows the opaque in-mask crop.
+    // popover=manual promotes the spill to the top layer on reframe, so it is
+    // not clipped by any overflow:hidden / clip-path / scroll-container
+    // ancestor (a plain z-index can't escape overflow clipping). UA popover
+    // defaults (inset:0;margin:auto) are reset; _applyView sets viewport px.
+    '.spill{position:fixed;margin:0;inset:auto;border:0;padding:0;background:transparent;' +
+    '  overflow:visible;transform:translate(-50%,-50%);z-index:1;cursor:grab;touch-action:none}' +
+    ':host([data-panning]) .spill{cursor:grabbing}' +
+    '.spill .ghost{position:absolute;inset:0;width:100%;height:100%;opacity:.35;' +
+    '  pointer-events:none;-webkit-user-drag:none;user-select:none;' +
+    '  box-shadow:0 0 0 1px rgba(0,0,0,.2),0 12px 32px rgba(0,0,0,.2)}' +
+    '.spill .handle{position:absolute;width:12px;height:12px;border-radius:50%;' +
+    '  background:#fff;box-shadow:0 0 0 1.5px #c96442,0 1px 3px rgba(0,0,0,.3);' +
+    '  transform:translate(-50%,-50%)}' +
+    '.spill .handle[data-c=nw]{left:0;top:0;cursor:nwse-resize}' +
+    '.spill .handle[data-c=ne]{left:100%;top:0;cursor:nesw-resize}' +
+    '.spill .handle[data-c=sw]{left:0;top:100%;cursor:nesw-resize}' +
+    '.spill .handle[data-c=se]{left:100%;top:100%;cursor:nwse-resize}' +
+    ':host([data-reframe]){z-index:10}' +
+    ':host([data-reframe]) .frame{box-shadow:0 0 0 2px #c96442}' +
+    '.empty{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;' +
+    '  justify-content:center;gap:6px;text-align:center;padding:12px;box-sizing:border-box;' +
+    '  cursor:pointer;user-select:none}' +
+    '.empty svg{opacity:.45}' +
+    '.empty .cap{max-width:90%;font-weight:500;letter-spacing:.01em}' +
+    '.empty .sub{font-size:11px}' +
+    '.empty .sub u{text-underline-offset:2px}' +
+    '.empty:hover .sub{opacity:1}' +
+    ':host([data-over]) .frame{outline:2px solid #c96442;outline-offset:-2px;' +
+    '  background:rgba(201,100,66,.10)}' +
+    '.ring{position:absolute;inset:0;pointer-events:none;border:1.5px dashed currentColor;' +
+    '  opacity:.35;transition:border-color .12s,opacity .12s}' +
+    ':host([data-over]) .ring{border-color:#c96442;opacity:1}' +
+    ':host([data-filled]) .ring{display:none}' +
+    // Controls overlay INSIDE the frame, pinned to the top-right corner, so
+    // a full-bleed slot in an overflow:hidden container still shows them
+    // (the old below-mask placement got clipped). Credit sits bottom-left,
+    // so top-right avoids collision. The blurred pill background keeps them
+    // legible over the image.
+    // The UA [popover] base rule styles the element in EVERY state (only
+    // display:none is gated on :not(:popover-open), and the display:flex
+    // below overrides that) — so the UA resets live HERE, like .spill's,
+    // or the ordinary hover-state strip renders as a bordered Canvas box
+    // centered by margin:auto. inset:auto precedes top/right (shorthand).
+    '.ctl{position:absolute;inset:auto;top:8px;right:8px;margin:0;border:0;padding:0;' +
+    '  background:transparent;overflow:visible;' +
+    '  display:flex;gap:6px;opacity:0;pointer-events:none;transition:opacity .12s;z-index:2;' +
+    '  white-space:nowrap}' +
+    // While reframing, the spill owns the top layer and would swallow every
+    // click on the in-frame controls. Promoting .ctl into the top layer
+    // ABOVE the spill (shown after it — later popovers stack higher) keeps
+    // Edit-as-toggle and Replace clickable mid-reframe. _applyView pins it
+    // to the frame's top-right in viewport px (translateX(-100%)
+    // right-aligns against the computed left edge); inset:auto clears the
+    // base rule's top/right so the inline left/top position it alone.
+    '.ctl:popover-open{position:fixed;inset:auto;transform:translateX(-100%)}' +
+    ':host([data-filled][data-editable]:hover) .ctl,:host([data-reframe]) .ctl' +
+    '  {opacity:1;pointer-events:auto}' +
+    '.ctl button{appearance:none;border:0;border-radius:6px;padding:5px 10px;cursor:pointer;' +
+    '  background:rgba(0,0,0,.65);color:#fff;font:11px/1 system-ui,-apple-system,sans-serif;' +
+    '  backdrop-filter:blur(6px)}' +
+    '.ctl button:hover{background:rgba(0,0,0,.8)}' +
+    '.err{position:absolute;left:8px;bottom:8px;right:8px;color:#b3261e;font-size:11px;' +
+    '  background:rgba(255,255,255,.85);padding:4px 6px;border-radius:5px;pointer-events:none}' +
+    // Replacement in flight: after a src swap the browser keeps painting
+    // the PREVIOUS image until the new one decodes, so a Replace would
+    // flash the old photo and then pop. Hide the stale frame (visibility,
+    // not display — _applyView geometry still applies) and spin until the
+    // new image reports in (load/error clears data-swapping).
+    ':host([data-swapping]) .frame img{visibility:hidden}' +
+    '.loading{position:absolute;inset:0;display:none;align-items:center;' +
+    '  justify-content:center;pointer-events:none}' +
+    ':host([data-swapping]) .loading{display:flex}' +
+    '.loading::after{content:"";width:22px;height:22px;border-radius:50%;' +
+    '  border:2px solid rgba(127,127,127,.25);border-top-color:currentColor;' +
+    '  animation:om-slot-spin .7s linear infinite}' +
+    '@keyframes om-slot-spin{to{transform:rotate(360deg)}}' +
+    // Reduced motion: the static two-tone ring still reads as "working".
+    '@media (prefers-reduced-motion:reduce){.loading::after{animation:none}}' +
+    '.credit{position:absolute;left:6px;bottom:6px;max-width:calc(100% - 12px);display:none;' +
+    '  padding:3px 7px;border-radius:5px;background:rgba(0,0,0,.55);color:#fff;' +
+    '  font:10px/1.2 system-ui,-apple-system,sans-serif;text-decoration:none;' +
+    '  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;backdrop-filter:blur(6px)}' +
+    // The credit is a SPAN holding one or two <a>s (Unsplash's prescribed
+    // form links the photographer AND Unsplash) — anchors style inline so
+    // the overlay reads as one line of text.
+    '.credit a{color:inherit;text-decoration:none}' +
+    '.credit a:hover,.credit a:focus-visible{text-decoration:underline}' +
+    ':host([data-filled][data-credit]) .credit{display:block}' +
+    // Exports must ship JUST the image — no hover controls, no credit chip
+    // (the host marks <html data-om-exporting> for the capture window; the
+    // page-level hide script can't reach shadow DOM, this rule can).
+    ':host-context([data-om-exporting]) .ctl,' +
+    ':host-context([data-om-exporting]) .credit{display:none !important}' +
+    // Print must ship just the image too: the hover-gated controls can be
+    // mid-hover when print() fires, and the credit chip is screen chrome —
+    // the same rule the capture window gets, keyed on print media instead
+    // of the host's data-om-exporting mark (the print path sets no mark).
+    '@media print{.ctl,.credit{display:none !important}}' +
+    // No export-window mask rules here on purpose: the export capture
+    // releases the replacement mask by REMOVING data-swapping (the
+    // shadow-root pass in pages/export/shared.ts HIDE_EXPORT_CHROME_SCRIPT)
+    // — attribute removal works in every engine (:host-context is
+    // Chromium-only), is scoped by construction to slots actually
+    // mid-swap, and hides the spinner through the same gate. A masked img
+    // would otherwise be silently dropped from PPTX decks (the capture
+    // walk skips visibility:hidden imgs).
+    // Attribution error tile: REPLACES the photo when an Unsplash src has
+    // no credit attribute — rendering the photo uncredited is the terms
+    // violation, so the photo must not appear at all.
+    // Calm and neutral on purpose (review feedback): the tile informs the
+    // user; the fix instructions are machine-facing (usage docblock, tool
+    // description, and the turn-end scan's bounce copy name the attributes
+    // for the agent).
+    '.attr-error{position:absolute;inset:0;display:none;flex-direction:column;align-items:center;' +
+    '  justify-content:center;gap:6px;text-align:center;padding:12px;box-sizing:border-box;' +
+    '  background:#f2f1ef;color:#6e6c66;user-select:none;' +
+    '  font:13px/1.45 system-ui,-apple-system,sans-serif}' +
+    '.attr-error svg{opacity:.55}' +
+    '.attr-error .cap{max-width:92%;font-weight:500;letter-spacing:.01em}' +
+    ':host([data-attribution-error]) .attr-error{display:flex}' +
+    ':host([data-attribution-error]) .ring{display:none}';
+
+  const icon =
+    '<svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+    'stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">' +
+    '<rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/>' +
+    '<path d="m21 15-5-5L5 21"/></svg>';
+
+  const warnIcon =
+    '<svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+    'stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">' +
+    '<path d="m21.73 18-8-14a2 2 0 0 0-3.46 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/>' +
+    '<path d="M12 9v4"/><path d="M12 17h.01"/></svg>';
+
+  class ImageSlot extends HTMLElement {
+    static get observedAttributes() {
+      return ['shape', 'radius', 'mask', 'fit', 'placeholder', 'src', 'id', 'credit', 'credit-href'];
+    }
+
+    /** Duplicate-slide hook (called by deck-stage, see its
+     *  _remintDuplicateIds): copy this id's stored image, if any, under a
+     *  freshly minted key and return that key — so a duplicated slide's
+     *  slot keeps its dropped photo instead of reverting to the
+     *  placeholder. 'isFree' is the caller's uniqueness check (document
+     *  ids); candidates must ALSO be unused in the sidecar, which can
+     *  hold keys from other pages sharing the project root. (An EMPTY
+     *  slot on another page leaves no sidecar entry, so its id is not
+     *  detectable here — a minted key can collide with it and that slot
+     *  would show this photo. Same blast radius as two pages reusing an
+     *  id by hand, which the shared sidecar already permits.) Returns null
+     *  when no id could be minted (caller strips the id, today's
+     *  behavior). */
+    static cloneSlot(fromId, isFree) {
+      if (typeof fromId !== 'string' || !fromId) return null;
+      // Pre-hydration the store can't veto candidates or source the copy
+      // — degrade to the strip (today's behavior) rather than mint
+      // against keys we can't see yet. Any rendered (= droppable) slot
+      // means load() has already settled.
+      if (!loaded) return null;
+      const stem = fromId.replace(/-\d+$/, '') || fromId;
+      for (let n = 2; n < 100; n++) {
+        const toId = stem + '-' + n;
+        if (toId === fromId) continue;
+        if (slots[toId] !== undefined) {
+          // Reuse a key holding this exact value (bytes AND crop) if no
+          // live element here owns it — a duplicate op the host refused
+          // after minting leaves such a key behind, and reusing keeps
+          // refused retries from accumulating one orphaned copy per
+          // attempt. Full equality (not just bytes) so a byte-identical
+          // key another PAGE owns with its own crop is stepped past, not
+          // adopted or rewritten. (Entries without .u never match.)
+          const prev = getSlot(toId);
+          const cur = getSlot(fromId);
+          if (!(prev && cur && prev.u && prev.u === cur.u &&
+                prev.s === cur.s && prev.x === cur.x && prev.y === cur.y &&
+                (typeof isFree !== 'function' || isFree(toId)))) continue;
+          return toId;
+        }
+        if (typeof isFree === 'function' && !isFree(toId)) continue;
+        const v = getSlot(fromId);
+        if (v) setSlot(toId, Object.assign({}, v));
+        return toId;
+      }
+      return null;
+    }
+
+    constructor() {
+      super();
+      // clonable: rail thumbnails deep-clone slides and carry this shadow
+      // along; reuse an already-cloned root so upgrade-after-clone works.
+      // (Deliberately NOT serializable — a getHTML consumer would embed
+      // multi-MB sidecar data-URLs into serialized page HTML.)
+      const root = this.shadowRoot ||
+        this.attachShadow({ mode: 'open', clonable: true });
+      // .spill and .ctl sit OUTSIDE .frame so overflow:hidden + border-radius
+      // on the frame (circle, pill, rounded) can't clip them.
+      root.innerHTML =
+        '<style>' + stylesheet + '</style>' +
+        '<div class="frame" part="frame">' +
+        '  <img part="image" alt="" draggable="false" style="display:none">' +
+        '  <div class="empty" part="empty">' + icon +
+        '    <div class="cap"></div>' +
+        '    <div class="sub">or <u>browse files</u></div></div>' +
+        '  <div class="attr-error" part="attribution-error">' + warnIcon +
+        '    <div class="cap">This photo needs attribution</div></div>' +
+        '  <div class="loading" part="loading"></div>' +
+        '  <div class="ring" part="ring"></div>' +
+        '</div>' +
+        // Outside .frame, like .spill/.ctl — the frame's overflow:hidden +
+        // border-radius/clip-path would cut the credit off on circle/pill/mask.
+        // A SPAN, not an <a>: the prescribed Unsplash credit holds two links
+        // (photographer + Unsplash), built per-render in _render().
+        '<span class="credit" part="credit"></span>' +
+        '<div class="spill" popover="manual" data-dc-edit-transparent>' +
+        '  <img class="ghost" alt="" draggable="false">' +
+        '  <div class="handle" data-c="nw"></div><div class="handle" data-c="ne"></div>' +
+        '  <div class="handle" data-c="sw"></div><div class="handle" data-c="se"></div>' +
+        '</div>' +
+        // data-dc-edit-transparent: the DC editor's edit-mode picker lets
+        // clicks through for chrome marked with it (EDIT_TRANSPARENT_SEL)
+        // — without it, Replace/Edit clicks in Edit mode are swallowed by
+        // element selection and the controls look dead.
+        '<div class="ctl" popover="manual" data-dc-edit-transparent><button data-act="replace" title="Replace image">Replace</button>' +
+        '  <button data-act="edit" title="Reframe image">Edit</button></div>' +
+        '<input type="file" accept="' + ACCEPT.join(',') + '" hidden>';
+      this._frame = root.querySelector('.frame');
+      this._ring = root.querySelector('.ring');
+      this._img = root.querySelector('.frame img');
+      this._empty = root.querySelector('.empty');
+      this._cap = root.querySelector('.cap');
+      this._sub = root.querySelector('.sub');
+      this._spill = root.querySelector('.spill');
+      this._ctl = root.querySelector('.ctl');
+      this._credit = root.querySelector('.credit');
+      this._attrError = root.querySelector('.attr-error');
+      // Credit clicks open the link, not browse/reframe.
+      this._credit.addEventListener('click', (e) => e.stopPropagation());
+      this._credit.addEventListener('dblclick', (e) => e.stopPropagation());
+      this._ghost = root.querySelector('.ghost');
+      this._err = null;
+      this._input = root.querySelector('input');
+      this._depth = 0;
+      this._gen = 0;
+      // Encode-in-flight marker (the owning _ingest generation): while set,
+      // the same-src "nothing in flight" clear in _render must not fire —
+      // the stored value still points at the OLD image until the encode
+      // lands, so that clear would unmask the stale image mid-replace.
+      this._swapGen = 0;
+      // Render-owned swap in flight: set when _render assigns a new src,
+      // cleared only by the img's own load/error (or the empty branch).
+      // img.complete CANNOT stand in for this — setting src only QUEUES
+      // the current-request swap (a microtask), so synchronously after an
+      // assignment, complete still reports the OLD settled request. The
+      // pick path does exactly that: the host sets src, credit, and
+      // credit-href back-to-back in one task, and renders #2/#3 would
+      // read the stale complete === true and drop the mask one render
+      // after it was set.
+      this._loadPending = false;
+      // See _render's empty branch: a transient attribution-error wipe of a
+      // showing image must make the follow-up render a replacement (spinner),
+      // not a first fill (blank frame).
+      this._hidShowing = false;
+      this._view = { s: 1, x: 0, y: 0 };
+      this._subFn = () => this._render();
+      // Shadow-DOM listeners live with the shadow DOM — bound once here so
+      // disconnect/reconnect (e.g. React remount) doesn't stack handlers.
+      this._empty.addEventListener('click', () => this._input.click());
+      root.addEventListener('click', (e) => {
+        const act = e.target && e.target.getAttribute && e.target.getAttribute('data-act');
+        if (!act) return;
+        // The hidden controls are opacity-0 but still tabbable — without
+        // this gate a keyboard user could drive them on a read-only share
+        // link (mirrors the dblclick handler's editable gate).
+        if (!this.hasAttribute('data-editable')) return;
+        if (act === 'replace') {
+          this._exitReframe(true);
+          // Host-owned picker (Unsplash modal; it also offers local import).
+          this.dispatchEvent(new CustomEvent('image-slot:pick', {
+            bubbles: true, composed: true, detail: { id: this.id || null }
+          }));
+        }
+        if (act === 'edit') {
+          if (!this._reframes()) return;
+          if (this.hasAttribute('data-reframe')) this._exitReframe(true);
+          else this._enterReframe();
+        }
+      });
+      this._input.addEventListener('change', () => {
+        const f = this._input.files && this._input.files[0];
+        if (f) this._ingest(f);
+        this._input.value = '';
+      });
+      // naturalWidth/Height aren't known until load — re-apply so the cover
+      // baseline is computed from real dimensions, not the 100%×100% fallback.
+      // load/error also release the replacement-in-flight mask (via the
+      // single discipline in _releaseMask): the swap is only revealed once
+      // the new image can actually paint (on error the frame shows its
+      // background, same as a fresh slot with a broken src).
+      this._img.addEventListener('load', () => {
+        this._loadPending = false;
+        this._releaseMask(true);
+        this._applyView();
+      });
+      this._img.addEventListener('error', () => {
+        this._loadPending = false;
+        this._releaseMask(true);
+      });
+      // Gated only on editable — any filled slot can be repositioned/scaled,
+      // regardless of fit. Share links (no writeFile) stay static.
+      this.addEventListener('dblclick', (e) => {
+        if (!this.hasAttribute('data-editable') || !this._reframes()) return;
+        e.preventDefault();
+        if (this.hasAttribute('data-reframe')) this._exitReframe(true);
+        else this._enterReframe();
+      });
+      // Pan + resize both originate on the spill layer. A handle pointerdown
+      // drives an aspect-locked resize anchored at the opposite corner; any
+      // other pointerdown on the spill pans. Offsets are frame-% so a
+      // reframed slot survives responsive resize / PPTX export.
+      this._spill.addEventListener('pointerdown', (e) => {
+        if (e.button !== 0 || !this.hasAttribute('data-reframe')) return;
+        e.preventDefault();
+        e.stopPropagation();
+        this._spill.setPointerCapture(e.pointerId);
+        const rect = this.getBoundingClientRect();
+        const fw = rect.width || 1, fh = rect.height || 1;
+        const corner = e.target.getAttribute && e.target.getAttribute('data-c');
+        let move;
+        if (corner) {
+          // Resize about the OPPOSITE corner. Viewport-px throughout (rect
+          // fw/fh, not clientWidth) so the math survives a transform:scale()
+          // ancestor — deck_stage renders slides scaled-to-fit.
+          const iw = this._img.naturalWidth || 1, ih = this._img.naturalHeight || 1;
+          const contain = (this.getAttribute('fit') || 'cover').toLowerCase() === 'contain';
+          const base = contain ? Math.min(fw / iw, fh / ih) : Math.max(fw / iw, fh / ih);
+          const sx = corner.includes('e') ? 1 : -1;
+          const sy = corner.includes('s') ? 1 : -1;
+          const s0 = this._view.s;
+          const w0 = iw * base * s0, h0 = ih * base * s0;
+          const cx0 = (50 + this._view.x) / 100 * fw;
+          const cy0 = (50 + this._view.y) / 100 * fh;
+          const ox = cx0 - sx * w0 / 2, oy = cy0 - sy * h0 / 2;
+          const diag0 = Math.hypot(w0, h0);
+          const ux = sx * w0 / diag0, uy = sy * h0 / diag0;
+          move = (ev) => {
+            const proj = (ev.clientX - rect.left - ox) * ux +
+                         (ev.clientY - rect.top - oy) * uy;
+            const s = clampS(s0 * proj / diag0);
+            const d = diag0 * s / s0;
+            this._view.s = s;
+            this._view.x = (ox + ux * d / 2) / fw * 100 - 50;
+            this._view.y = (oy + uy * d / 2) / fh * 100 - 50;
+            this._clampView();
+            this._applyView();
+          };
+        } else {
+          this.setAttribute('data-panning', '');
+          const start = { px: e.clientX, py: e.clientY, x: this._view.x, y: this._view.y };
+          move = (ev) => {
+            this._view.x = start.x + (ev.clientX - start.px) / fw * 100;
+            this._view.y = start.y + (ev.clientY - start.py) / fh * 100;
+            this._clampView();
+            this._applyView();
+          };
+        }
+        const up = () => {
+          try { this._spill.releasePointerCapture(e.pointerId); } catch {}
+          this._spill.removeEventListener('pointermove', move);
+          this._spill.removeEventListener('pointerup', up);
+          this._spill.removeEventListener('pointercancel', up);
+          this.removeAttribute('data-panning');
+          this._dragUp = null;
+        };
+        // Stashed so _exitReframe (Escape / outside-click mid-drag) can
+        // tear the capture + listeners down synchronously.
+        this._dragUp = up;
+        this._spill.addEventListener('pointermove', move);
+        this._spill.addEventListener('pointerup', up);
+        this._spill.addEventListener('pointercancel', up);
+      });
+      // Wheel zoom stays available inside reframe mode as a trackpad nicety —
+      // zooms toward the cursor (offset' = cursor·(1-k) + offset·k).
+      this.addEventListener('wheel', (e) => {
+        if (!this.hasAttribute('data-reframe')) return;
+        e.preventDefault();
+        const r = this.getBoundingClientRect();
+        const cx = (e.clientX - r.left) / r.width * 100 - 50;
+        const cy = (e.clientY - r.top) / r.height * 100 - 50;
+        const prev = this._view.s;
+        const next = clampS(prev * Math.pow(1.0015, -e.deltaY));
+        if (next === prev) return;
+        const k = next / prev;
+        this._view.s = next;
+        this._view.x = cx * (1 - k) + this._view.x * k;
+        this._view.y = cy * (1 - k) + this._view.y * k;
+        this._clampView();
+        this._applyView();
+      }, { passive: false });
+    }
+
+    connectedCallback() {
+      // Warn once per page — an id-less slot works for the session but
+      // cannot persist, and two id-less slots would share nothing.
+      if (!this.id && !ImageSlot._warned) {
+        ImageSlot._warned = true;
+        console.warn('<image-slot> without an id will not persist its dropped image.');
+      }
+      this.addEventListener('dragenter', this);
+      this.addEventListener('dragover', this);
+      this.addEventListener('dragleave', this);
+      this.addEventListener('drop', this);
+      subs.add(this._subFn);
+      // The host may inject window.omelette.writeFile AFTER the first render;
+      // re-render on hover so the editable-gated controls reliably appear.
+      this.addEventListener('pointerenter', this._subFn);
+      // width%/height% in _applyView encode the frame aspect at call time —
+      // a host resize (responsive grid, pane divider) would stretch the
+      // image until the next _render. Re-render on size change: _render()
+      // re-seeds _view from stored before clamp/apply, so a shrink→grow
+      // cycle round-trips instead of ratcheting x/y toward the narrower
+      // frame's clamp range.
+      this._ro = new ResizeObserver(() => this._render());
+      this._ro.observe(this);
+      load();
+      this._render();
+    }
+
+    disconnectedCallback() {
+      subs.delete(this._subFn);
+      this.removeEventListener('pointerenter', this._subFn);
+      this.removeEventListener('dragenter', this);
+      this.removeEventListener('dragover', this);
+      this.removeEventListener('dragleave', this);
+      this.removeEventListener('drop', this);
+      if (this._ro) { this._ro.disconnect(); this._ro = null; }
+      // commit=false: a disconnect is not a user intent — committing here
+      // would persist whatever half-finished drag a React remount or DOM
+      // splice happened to interrupt. Deliberate exits commit on their own
+      // paths (Escape/click-out/toggle), and unloads commit via pagehide.
+      this._exitReframe(false);
+    }
+
+    _enterReframe() {
+      if (this.hasAttribute('data-reframe')) return;
+      this.setAttribute('data-reframe', '');
+      this._signalReframe(true);
+      // Best-effort commit when the document unloads mid-reframe (a host
+      // navigation racing the enter signal, a manual reload, tab close):
+      // the sidecar write rides the host bridge, which outlives this
+      // document, so the crop survives even though the mode dies with the
+      // DOM. Held on the instance so _exitReframe detaches exactly what
+      // was attached.
+      this._pagehide = () => { this._exitReframe(true); flushNow(); };
+      window.addEventListener('pagehide', this._pagehide);
+      // Promote spill to the top layer, then keep it pinned over the frame:
+      // scroll/resize cover the common cases, and a per-frame rect check
+      // catches layout shifts that fire neither (an image above finishing
+      // load, streamed DOM pushing the slot down, an ancestor transform
+      // change) so the overlay can't detach from the frame.
+      try { this._spill.showPopover(); } catch {}
+      // After the spill, so the controls stack above it in the top layer.
+      try { this._ctl.showPopover(); } catch {}
+      this._reposition = () => { if (this.hasAttribute('data-reframe')) this._applyView(); };
+      window.addEventListener('scroll', this._reposition, true);
+      window.addEventListener('resize', this._reposition);
+      this._lastRect = '';
+      this._watch = () => {
+        if (!this.hasAttribute('data-reframe')) return;
+        const r = this.getBoundingClientRect();
+        const key = r.left + ',' + r.top + ',' + r.width + ',' + r.height;
+        if (key !== this._lastRect) { this._lastRect = key; this._applyView(); }
+        this._watchId = requestAnimationFrame(this._watch);
+      };
+      this._watchId = requestAnimationFrame(this._watch);
+      this._applyView();
+      // Close on click outside (the spill handler stopPropagation()s so
+      // in-image drags don't reach this) and on Escape. Listeners are held
+      // on the instance so _exitReframe / disconnectedCallback can detach
+      // exactly what was attached.
+      this._outside = (e) => {
+        if (e.composedPath && e.composedPath().includes(this)) return;
+        this._exitReframe(true);
+      };
+      this._esc = (e) => { if (e.key === 'Escape') this._exitReframe(true); };
+      document.addEventListener('pointerdown', this._outside, true);
+      document.addEventListener('keydown', this._esc, true);
+    }
+
+    _exitReframe(commit) {
+      if (!this.hasAttribute('data-reframe')) return;
+      if (this._dragUp) this._dragUp();
+      this.removeAttribute('data-reframe');
+      this.removeAttribute('data-panning');
+      if (this._outside) document.removeEventListener('pointerdown', this._outside, true);
+      if (this._esc) document.removeEventListener('keydown', this._esc, true);
+      this._outside = this._esc = null;
+      if (this._reposition) {
+        window.removeEventListener('scroll', this._reposition, true);
+        window.removeEventListener('resize', this._reposition);
+        this._reposition = null;
+      }
+      if (this._watchId) { cancelAnimationFrame(this._watchId); this._watchId = 0; }
+      if (this._pagehide) {
+        window.removeEventListener('pagehide', this._pagehide);
+        this._pagehide = null;
+      }
+      try { this._spill.hidePopover(); } catch {}
+      try { this._ctl.hidePopover(); } catch {}
+      this._ctl.style.left = ''; this._ctl.style.top = '';
+      if (commit) this._commitView();
+      this._signalReframe(false);
+    }
+
+    // Reframe state lives only in this DOM until commit, invisible to the
+    // host's dirty signals — announce enter/exit so the host can hold
+    // auto-reloads for exactly the gesture (the guest bundle forwards
+    // image-slot:reframe to the host as imageSlotReframe). Dispatched on
+    // the element (composed, so it escapes shadow roots) while connected;
+    // a disconnected exit (disconnectedCallback) falls back to document so
+    // the host still hears it.
+    _signalReframe(active) {
+      const target = this.isConnected ? this : document;
+      target.dispatchEvent(new CustomEvent('image-slot:reframe', {
+        bubbles: true, composed: true,
+        detail: { active: active, id: this.id || null }
+      }));
+    }
+
+    // Public: host's "Import from computer" calls this to run local browse.
+    openFilePicker() { this._exitReframe(true); this._input.click(); }
+
+    // A src write is a newer intent for this slot's content — the host
+    // pick path (setImageSlotImage) or an agent edit — so it must win
+    // over any encode still in flight from an earlier drop: left live,
+    // that encode lands later, passes _ingest's gen guard, and its
+    // setSlot silently overwrites the pick (the stored value shadows
+    // src in _render). Bumping _gen kills the encode before its own
+    // _swapGen clear runs, so clear the dead claim here too — otherwise
+    // _releaseMask (gated on !_swapGen) never fires and the pick's
+    // spinner is stranded. src ONLY: the pick sets credit/credit-href
+    // in the same task, and clearing _swapGen on those would let the
+    // same-src branch unmask the old image mid-encode.
+    attributeChangedCallback(name, oldVal, newVal) {
+      if (name === 'src' && oldVal !== newVal) {
+        this._gen++;
+        this._swapGen = 0;
+      }
+      if (this.shadowRoot) this._render();
+    }
+
+    // handleEvent — one listener object for all four drag events keeps the
+    // add/remove symmetric and the depth counter correct.
+    handleEvent(e) {
+      if (e.type === 'dragenter' || e.type === 'dragover') {
+        // Without preventDefault the browser never fires 'drop'.
+        e.preventDefault();
+        e.stopPropagation();
+        if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+        if (e.type === 'dragenter') this._depth++;
+        this.setAttribute('data-over', '');
+      } else if (e.type === 'dragleave') {
+        // dragenter/leave fire for every descendant crossing — count depth
+        // so hovering the icon inside the empty state doesn't flicker.
+        if (--this._depth <= 0) { this._depth = 0; this.removeAttribute('data-over'); }
+      } else if (e.type === 'drop') {
+        e.preventDefault();
+        e.stopPropagation();
+        this._depth = 0;
+        this.removeAttribute('data-over');
+        const f = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
+        if (f) this._ingest(f);
+      }
+    }
+
+    async _ingest(file) {
+      this._setError(null);
+      if (!file || ACCEPT.indexOf(file.type) < 0) {
+        this._setError('Drop a PNG, JPEG, WebP, or AVIF image.');
+        return;
+      }
+      // toDataUrl can take hundreds of ms on a large photo. A Clear or a
+      // newer drop during that window would be clobbered when this await
+      // resumes — bump + capture a generation so stale encodes bail.
+      const gen = ++this._gen;
+      // Replacing a shown image: surface the swap through the encode too,
+      // not just the decode — otherwise the old photo sits there with no
+      // feedback while the canvas re-encode runs. An empty slot keeps its
+      // placeholder (no spinner) until the encode lands, as before.
+      // _swapGen guards the mask against re-renders DURING the encode
+      // (pointerenter, ResizeObserver, another slot's store write): the
+      // stored value still resolves to the old image there, so _render's
+      // same-src clear would otherwise unmask it mid-replace.
+      if (this.hasAttribute('data-filled')) {
+        this.setAttribute('data-swapping', '');
+        this._swapGen = gen;
+      }
+      try {
+        const w = this.clientWidth || this.offsetWidth || MAX_DIM;
+        const url = await toDataUrl(file, w);
+        if (gen !== this._gen) return;
+        // Only exit reframe once the new image is in hand — a rejected type
+        // or decode failure leaves the in-progress crop untouched.
+        this._exitReframe(false);
+        // Clear BEFORE setSlot: its synchronous re-render must see no
+        // pending encode, so a byte-identical re-upload (same data URL, no
+        // load event coming) still clears the mask via the complete branch.
+        this._swapGen = 0;
+        const val = { u: url, s: 1, x: 0, y: 0 };
+        setSlot(this.id || '', val);
+        // Keep a session-local copy for id-less slots so the drop still
+        // shows, even though it cannot persist.
+        if (!this.id) { this._local = val; this._render(); }
+      } catch (err) {
+        if (gen !== this._gen) return;
+        this._swapGen = 0;
+        // Reveal the kept old image — unless another replacement (a
+        // remote pick's src swap) is still in flight, in which case the
+        // mask stays until THAT image settles (its load/error releases).
+        this._releaseMask();
+        this._setError('Could not read that image.');
+        console.warn('<image-slot> ingest failed:', err);
+      }
+    }
+
+    _setError(msg) {
+      if (this._err) { this._err.remove(); this._err = null; }
+      if (!msg) return;
+      const d = document.createElement('div');
+      d.className = 'err'; d.textContent = msg;
+      this.shadowRoot.appendChild(d);
+      this._err = d;
+      setTimeout(() => { if (this._err === d) { d.remove(); this._err = null; } }, 3000);
+    }
+
+    // Reframing (pan/resize) is available on any filled slot — the user can
+    // always reposition/scale. `fit` only sets the initial baseline (see
+    // _geom): contain starts fully-visible, cover starts frame-filling.
+    _reframes() {
+      return this.hasAttribute('data-filled');
+    }
+
+    // The single release discipline for the replacement-in-flight mask
+    // (data-swapping). The mask comes off only when BOTH hold:
+    //  - no encode is pending (_swapGen) — mid-encode the stored value
+    //    still resolves to the old image, so any reveal paints it;
+    //  - the frame img has settled on its current src — an unsettled src
+    //    means some replacement is still in flight (e.g. a remote pick),
+    //    whoever started it, and revealing would paint the previous
+    //    frame. The load/error listeners pass settled=true (the event IS
+    //    the settlement signal, per spec complete is true by then);
+    //    other callers rely on the complete flag (covers loaded AND
+    //    failed).
+    // Every release path funnels through here EXCEPT _render's empty
+    // branch (the img is being cleared — nothing will ever settle).
+    _releaseMask(settled) {
+      if (
+        !this._swapGen &&
+        !this._loadPending &&
+        (settled || this._img.complete)
+      ) {
+        this.removeAttribute('data-swapping');
+      }
+    }
+
+    // Baseline geometry, shared by clamp/apply/resize. `base` is the scale at
+    // view-scale s=1: cover = fill the frame (overflow on the looser axis),
+    // contain = fit fully inside (letterboxed). Zooming a contain image past
+    // s where it overflows naturally becomes a crop. Null until the img has
+    // loaded (naturalWidth is 0 before that) or when the slot has no layout
+    // box — ResizeObserver fires with a 0×0 rect under display:none, and
+    // clamping against a degenerate 1×1 frame would silently pull the stored
+    // pan toward zero.
+    _geom() {
+      const iw = this._img.naturalWidth, ih = this._img.naturalHeight;
+      const fw = this.clientWidth, fh = this.clientHeight;
+      if (!iw || !ih || !fw || !fh) return null;
+      const contain = (this.getAttribute('fit') || 'cover').toLowerCase() === 'contain';
+      const base = contain
+        ? Math.min(fw / iw, fh / ih)
+        : Math.max(fw / iw, fh / ih);
+      return { iw, ih, fw, fh, base };
+    }
+
+    _clampView() {
+      // Pan range on each axis is half the overflow past the frame edge.
+      const g = this._geom();
+      if (!g) return;
+      const mx = Math.max(0, (g.iw * g.base * this._view.s / g.fw - 1) * 50);
+      const my = Math.max(0, (g.ih * g.base * this._view.s / g.fh - 1) * 50);
+      this._view.x = Math.max(-mx, Math.min(mx, this._view.x));
+      this._view.y = Math.max(-my, Math.min(my, this._view.y));
+    }
+
+    _applyView() {
+      const g = this._geom();
+      // Top-layer controls: pin to the frame's top-right in viewport px
+      // (the same 8px inset as the in-frame layout; unscaled — top-layer UI
+      // reads as chrome, not page content). BEFORE the geometry branch:
+      // placement needs only the frame rect, and a not-yet-loaded or broken
+      // src must not leave the promoted strip floating unpositioned. Gated
+      // on the popover actually being open: without the Popover API,
+      // showPopover() threw (swallowed in _enterReframe), .ctl stays in
+      // its in-frame absolute layout, and viewport-px coordinates would
+      // shove it off-frame — and matches(':popover-open') itself throws
+      // there (unknown pseudo-class), hence the try/catch.
+      if (this.hasAttribute('data-reframe')) {
+        let onTop = false;
+        try { onTop = this._ctl.matches(':popover-open'); } catch {}
+        if (onTop) {
+          const r = this.getBoundingClientRect();
+          this._ctl.style.left = (r.right - 8) + 'px';
+          this._ctl.style.top = (r.top + 8) + 'px';
+        }
+      }
+      if (!g) {
+        // Dimensions not known yet (before img load) — centered fit so there
+        // is no flash of an unpositioned image before the geometry lands.
+        const contain = (this.getAttribute('fit') || 'cover').toLowerCase() === 'contain';
+        this._img.style.width = '100%';
+        this._img.style.height = '100%';
+        this._img.style.left = '50%';
+        this._img.style.top = '50%';
+        this._img.style.objectFit = contain ? 'contain' : 'cover';
+        return;
+      }
+      // Baseline (cover-fill or contain-fit) × view scale. Width/height and
+      // left/top are all frame-% — depends only on the frame aspect ratio, so
+      // a responsive resize keeps the same crop. The spill layer mirrors the
+      // same box so its corners = image corners.
+      const k = g.base * this._view.s;
+      const w = (g.iw * k / g.fw * 100) + '%';
+      const h = (g.ih * k / g.fh * 100) + '%';
+      const l = (50 + this._view.x) + '%';
+      const t = (50 + this._view.y) + '%';
+      this._img.style.width = w; this._img.style.height = h;
+      this._img.style.left = l; this._img.style.top = t;
+      this._img.style.objectFit = '';
+      if (this.hasAttribute('data-reframe')) {
+        // Top-layer spill: position in viewport px over the frame. The top
+        // layer escapes ancestor transforms entirely, so EVERY term must be
+        // in viewport units: getBoundingClientRect gives the frame's scaled
+        // origin AND size, and the rect/layout ratio rescales the ghost —
+        // sizing from layout px alone renders it 1/scale too large under a
+        // scaled deck slide. Inner ghost + handles stay box-relative.
+        const r = this.getBoundingClientRect();
+        const sx = g.fw ? r.width / g.fw : 1;
+        const sy = g.fh ? r.height / g.fh : 1;
+        this._spill.style.width = (g.iw * k * sx) + 'px';
+        this._spill.style.height = (g.ih * k * sy) + 'px';
+        this._spill.style.left = (r.left + (50 + this._view.x) / 100 * r.width) + 'px';
+        this._spill.style.top = (r.top + (50 + this._view.y) / 100 * r.height) + 'px';
+      }
+    }
+
+    _commitView() {
+      const v = { s: this._view.s, x: this._view.x, y: this._view.y };
+      if (this._userUrl) v.u = this._userUrl;
+      // Framing-only (no u) persists too so an author-src slot remembers its
+      // crop; clearing the sidecar still falls through to src=.
+      if (this.id) setSlot(this.id, v);
+      else { this._local = v; }
+    }
+
+    _render() {
+      // Shape / mask. Presets use border-radius so the dashed ring can
+      // follow the rounded outline; clip-path is only applied for an
+      // explicit `mask` (the ring is hidden there since a rectangle
+      // dashed border chopped by an arbitrary polygon looks broken).
+      const mask = this.getAttribute('mask');
+      const shape = (this.getAttribute('shape') || 'rounded').toLowerCase();
+      let radius = '';
+      if (shape === 'circle') radius = '50%';
+      else if (shape === 'pill') radius = '9999px';
+      else if (shape === 'rounded') {
+        const n = parseFloat(this.getAttribute('radius'));
+        radius = (Number.isFinite(n) ? n : 12) + 'px';
+      }
+      this._frame.style.borderRadius = mask ? '' : radius;
+      this._frame.style.clipPath = mask || '';
+      this._ring.style.borderRadius = mask ? '' : radius;
+      this._ring.style.display = mask ? 'none' : '';
+
+      // Controls and reframe entry gate on this so share links stay read-only.
+      const editable = !!(window.omelette && window.omelette.writeFile);
+      this.toggleAttribute('data-editable', editable);
+      this._sub.style.display = editable ? '' : 'none';
+
+      // Content. The sidecar is also writable by the agent's write_file
+      // tool, so its value isn't guaranteed canvas-originated — only accept
+      // data:image/ URLs from it. The `src` attribute is author-controlled
+      // (Claude wrote it into the HTML) so it passes through unchanged.
+      let stored = this.id ? getSlot(this.id) : this._local;
+      if (stored && stored.u && !/^data:image\//i.test(stored.u)) stored = null;
+      const srcAttr = this.getAttribute('src') || '';
+      this._userUrl = (stored && stored.u) || null;
+      const url = this._userUrl || srcAttr;
+      // Don't clobber an in-flight reframe with a store-triggered re-render.
+      if (!this.hasAttribute('data-reframe')) {
+        this._view = {
+          s: stored && Number.isFinite(stored.s) ? clampS(stored.s) : 1,
+          x: stored && Number.isFinite(stored.x) ? stored.x : 0,
+          y: stored && Number.isFinite(stored.y) ? stored.y : 0,
+        };
+      }
+      this._cap.textContent = this.getAttribute('placeholder') || 'Drop an image';
+      // Toggle via style.display — the [hidden] attribute alone loses to
+      // the display:flex / display:block rules in the stylesheet above.
+      // An Unsplash src with no credit attribute must NOT render — showing
+      // the photo uncredited is the Unsplash-terms violation itself. The
+      // error tile replaces the photo until the credit is written. A
+      // user-dropped image is the user's own content and always renders.
+      // Trimmed: credit is agent/user-editable content, and a whitespace-
+      // only value must count as missing — otherwise it would suppress the
+      // error tile AND render an empty credit box (no text, no links),
+      // exactly the unattributed state this gate exists to prevent.
+      const credit = (this.getAttribute('credit') || '').trim();
+      const attrError = !!(
+        !credit && !this._userUrl && srcAttr && isUnsplashHost(srcAttr)
+      );
+      this.toggleAttribute('data-attribution-error', attrError);
+      if (url && !attrError) {
+        const prev = this._img.getAttribute('src');
+        if (prev !== url) {
+          // Replacing an already-shown image: mark the swap BEFORE setting
+          // src so the stale frame is never revealed (see the data-swapping
+          // stylesheet rules). First fill (prev empty) keeps the existing
+          // placeholder-until-load behavior — no spinner. _hidShowing
+          // covers the pick path's transient attribution-error wipe: prev
+          // is gone, but an image WAS showing, so this is a replacement.
+          if (prev || this._hidShowing) this.setAttribute('data-swapping', '');
+          // Mark the swap BEFORE assigning src: complete keeps reporting
+          // the old settled request until the browser's
+          // update-the-image-data microtask runs, so same-task re-renders
+          // (the pick path's credit/credit-href setAttributes) need this
+          // flag, not complete, to know a load is in flight.
+          this._loadPending = true;
+          this._img.src = url;
+          this._ghost.src = url;
+        } else {
+          // Same-src re-render — release if settled, so an ingest-set
+          // spinner can't stick after a byte-identical re-upload (same
+          // data URL, no further load event ever fires).
+          this._releaseMask();
+        }
+        this._hidShowing = false;
+        this._img.style.display = 'block';
+        this._empty.style.display = 'none';
+        this.setAttribute('data-filled', '');
+        this._clampView();
+        this._applyView();
+      } else {
+        this.removeAttribute('data-swapping');
+        // The src is being removed — no load/error will ever fire for it.
+        this._loadPending = false;
+        // A transient attribution-error wipe of a showing image happens on
+        // the pick path: the host sets src one setAttribute before credit,
+        // so render N hides the old image (attrError) and render N+1
+        // restores a URL. Remember the wipe so that restore renders as a
+        // replacement (spinner), not a first fill (blank frame).
+        this._hidShowing = attrError && !!this._img.getAttribute('src');
+        this._img.style.display = 'none';
+        this._img.removeAttribute('src');
+        this._ghost.removeAttribute('src');
+        // The error tile owns the blocked-photo state; .empty stays for
+        // the genuinely-empty slot.
+        this._empty.style.display = attrError ? 'none' : 'flex';
+        this.removeAttribute('data-filled');
+      }
+
+      // Credit belongs to the author src, so a user drop hides it.
+      // textContent + the http(s)-only funnel keep external strings inert.
+      const showCredit = !!(url && credit && !this._userUrl && !attrError);
+      this._credit.textContent = '';
+      if (showCredit) {
+        // Validate once (resolved against the document, http(s) only),
+        // then append the terms-required utm referral params to links
+        // that point back at unsplash.com.
+        let href = '';
+        const rawHref = this.getAttribute('credit-href') || '';
+        if (rawHref) {
+          try {
+            const u = new URL(rawHref, document.baseURI);
+            if (u.protocol === 'http:' || u.protocol === 'https:') {
+              href = withReferral(u.href);
+            }
+          } catch {}
+        }
+        const mkLink = (text, linkHref) => {
+          const a = document.createElement('a');
+          a.setAttribute('target', '_blank');
+          a.setAttribute('rel', 'noopener noreferrer');
+          a.setAttribute('href', linkHref);
+          a.textContent = text;
+          return a;
+        };
+        // Unsplash's prescribed credit is TWO links — the photographer's
+        // name to their profile (credit-href) and 'Unsplash' to the
+        // homepage. Render that split whenever the text has the canonical
+        // shape; other text keeps the legacy single-link rendering.
+        const m = /^Photo by (.+) on Unsplash$/.exec(credit);
+        if (m) {
+          this._credit.appendChild(document.createTextNode('Photo by '));
+          this._credit.appendChild(
+            href ? mkLink(m[1], href) : document.createTextNode(m[1])
+          );
+          this._credit.appendChild(document.createTextNode(' on '));
+          this._credit.appendChild(mkLink('Unsplash', UNSPLASH_HOMEPAGE_HREF));
+        } else if (href) {
+          this._credit.appendChild(mkLink(credit, href));
+        } else {
+          this._credit.textContent = credit;
+        }
+      }
+      this.toggleAttribute('data-credit', showCredit);
+    }
+  }
+
+  if (!customElements.get('image-slot')) {
+    customElements.define('image-slot', ImageSlot);
+  }
+})();

--- a/docs/design/base-planner/support.js
+++ b/docs/design/base-planner/support.js
@@ -1,0 +1,1911 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    if (!window.__resources) {
+      fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+        const raw = t ? parseDcText(t) : null;
+        if (raw?.template) runtime.updateHtml(rootName, raw.template);
+      }).catch(() => {
+      });
+    }
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu",
+    onmousemove: "onMouseMove",
+    onmouseover: "onMouseOver",
+    onmouseout: "onMouseOut",
+    onpointerdown: "onPointerDown",
+    onpointerup: "onPointerUp",
+    onpointermove: "onPointerMove",
+    onpointerenter: "onPointerEnter",
+    onpointerleave: "onPointerLeave",
+    onpointercancel: "onPointerCancel",
+    onpointerover: "onPointerOver",
+    onpointerout: "onPointerOut",
+    ongotpointercapture: "onGotPointerCapture",
+    onlostpointercapture: "onLostPointerCapture",
+    ontouchstart: "onTouchStart",
+    ontouchend: "onTouchEnd",
+    ontouchmove: "onTouchMove",
+    ontouchcancel: "onTouchCancel",
+    ondragstart: "onDragStart",
+    ondragend: "onDragEnd",
+    ondragenter: "onDragEnter",
+    ondragleave: "onDragLeave",
+    ondragover: "onDragOver",
+    onanimationstart: "onAnimationStart",
+    onanimationend: "onAnimationEnd",
+    onanimationiteration: "onAnimationIteration",
+    ontransitionend: "onTransitionEnd"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCamelAttrs(html) {
+    return html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+  }
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = encodeCamelAttrs(html);
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  var SLIDE_ID_VALUE_RE = /^[0-9a-f]{8}$/;
+  var DECK_CONTROL_FLOW_RE = /^(sc-if|sc-for|sc-else|dc-import|x-import)$/;
+  var DECK_AUX_RE = /^(template|script|style|sc-helmet|helmet)$/;
+  function isDeckMountTag(el) {
+    if (el.localName === "deck-stage") return true;
+    return el.localName === "x-import" && (el.getAttribute("component-from-global-scope") || "") === "deck-stage";
+  }
+  function walkDeckChildren(el, host) {
+    const pairs = [...el.childNodes].map((c) => ({ c, b: walk(c, host) })).filter((p) => p.b !== null);
+    const kids = pairs.map((p) => p.b);
+    const seen = /* @__PURE__ */ new Set();
+    const wsSeen = /* @__PURE__ */ new Map();
+    const keys = [];
+    const nextSlideId = new Array(pairs.length);
+    {
+      let upcoming = null;
+      for (let j = pairs.length - 1; j >= 0; j--) {
+        const n = pairs[j].c;
+        if (n.nodeType === Node.ELEMENT_NODE) {
+          const t = n.localName;
+          upcoming = !DECK_AUX_RE.test(t) && !DECK_CONTROL_FLOW_RE.test(t) ? n.getAttribute("data-om-slide-id") : null;
+        }
+        nextSlideId[j] = upcoming;
+      }
+    }
+    for (let j = 0; j < pairs.length; j++) {
+      const { c } = pairs[j];
+      if (c.nodeType === Node.TEXT_NODE) {
+        if ((c.nodeValue ?? "").trim() === "") {
+          const base = nextSlideId[j] ? "omid-ws:" + nextSlideId[j] : "omid-ws:aux";
+          const n = wsSeen.get(base) ?? 0;
+          wsSeen.set(base, n + 1);
+          keys.push(n === 0 ? base : base + ":" + n);
+          continue;
+        }
+        return { kids, keys: null };
+      }
+      if (c.nodeType !== Node.ELEMENT_NODE) {
+        keys.push(j);
+        continue;
+      }
+      const child = c;
+      const tag = child.localName;
+      if (DECK_AUX_RE.test(tag)) {
+        keys.push(j);
+        continue;
+      }
+      if (DECK_CONTROL_FLOW_RE.test(tag)) return { kids, keys: null };
+      const v = child.getAttribute("data-om-slide-id");
+      if (!v || !SLIDE_ID_VALUE_RE.test(v) || seen.has(v)) {
+        return { kids, keys: null };
+      }
+      seen.add(v);
+      keys.push("omid:" + v);
+    }
+    return { kids, keys };
+  }
+  function renderDeckKids(kids, kidKeys, vals, ctx) {
+    return kids.map((b, j) => {
+      const k = kidKeys ? kidKeys[j] : j;
+      const out = b(vals, ctx, k);
+      return kidKeys != null && typeof out === "string" ? h(getReact().Fragment, { key: k }, out) : out;
+    });
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || (el.getAttribute("component-from-global-scope") ? "" : el.getAttribute("src") || el.getAttribute("import") || "");
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const deckKeyed = hasContent && isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : hasContent ? walkChildren(el, host) : [];
+    const kidKeys = deckKeyed?.keys ?? null;
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) {
+        props.children = renderDeckKids(kids, kidKeys, vals, ctx);
+      }
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const deckKeyed = isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : walkChildren(el, host);
+    const kidKeys = deckKeyed?.keys ?? null;
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...renderDeckKids(kids, kidKeys, vals, ctx));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/bundled.ts
+  function bundledBlob(url) {
+    const blobs = window.__resourceBlobs;
+    const b = blobs ? blobs[url.split("#")[0]] : void 0;
+    return b instanceof Blob ? b : null;
+  }
+
+  // src/cdn.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  function cdnScriptFor(url, sri) {
+    const res = window.__resources;
+    const v = res ? res[url] : void 0;
+    return typeof v === "string" && v ? { src: v } : { src: url, integrity: sri };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      const babel = cdnScriptFor(BABEL_URL, BABEL_SRI);
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = babel.src;
+        if (babel.integrity) {
+          s.integrity = babel.integrity;
+          s.crossOrigin = "anonymous";
+        }
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => {
+        const pre = bundledBlob(url);
+        if (pre) return pre.text();
+        return fetch(url).then((r) => {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.text();
+        });
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            if (tag === "LINK") {
+              const rel = (child.getAttribute("rel") || "").toLowerCase().split(/\s+/);
+              const href = (child.getAttribute("href") || "").trim();
+              const res = window.__resources;
+              const pre = res && rel.includes("stylesheet") && !rel.includes("alternate") ? res[href] : void 0;
+              const blob = typeof pre === "string" && pre ? bundledBlob(pre) : null;
+              if (blob) {
+                const el = doc.createElement("style");
+                if (child.hasAttribute("disabled")) {
+                  el.setAttribute("media", "not all");
+                } else if (child.getAttribute("media")) {
+                  el.setAttribute("media", child.getAttribute("media"));
+                }
+                if (child.getAttribute("title"))
+                  el.setAttribute("title", child.getAttribute("title"));
+                void blob.text().then((css) => {
+                  el.textContent = css;
+                });
+                doc.head.appendChild(el);
+                continue;
+              }
+            }
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function scanUnquotedUrl(css, i) {
+    if (css[i] !== "u" && css[i] !== "U" || css.slice(i, i + 4).toLowerCase() !== "url(" || /[a-z0-9_-]/i.test(css[i - 1] ?? "")) {
+      return -1;
+    }
+    let j = i + 4;
+    while (j < css.length && /\s/.test(css[j])) j++;
+    if (css[j] === '"' || css[j] === "'") return -1;
+    while (j < css.length && css[j] !== ")") {
+      if (css[j] === "\\") j++;
+      j++;
+    }
+    return j < css.length ? j + 1 : css.length;
+  }
+  function stripComments(css) {
+    let out = "";
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") {
+          out += c + (css[i + 1] ?? "");
+          i++;
+          continue;
+        }
+        if (c === quote) quote = "";
+        out += c;
+      } else if (c === "'" || c === '"') {
+        quote = c;
+        out += c;
+      } else if (c === "/" && css[i + 1] === "*") {
+        const end = css.indexOf("*/", i + 2);
+        i = end === -1 ? css.length : end + 1;
+        out += " ";
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end === -1) out += c;
+        else {
+          out += css.slice(i, end);
+          i = end - 1;
+        }
+      }
+    }
+    return out;
+  }
+  function importantify(css) {
+    css = stripComments(css);
+    const decls = [];
+    let start = 0;
+    let depth = 0;
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") i++;
+        else if (c === quote) quote = "";
+      } else if (c === "'" || c === '"') quote = c;
+      else if (c === "(") depth++;
+      else if (c === ")") depth = Math.max(0, depth - 1);
+      else if (c === ";" && depth === 0) {
+        decls.push(css.slice(start, i));
+        start = i + 1;
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end !== -1) i = end - 1;
+      }
+    }
+    decls.push(css.slice(start));
+    return decls.map((d) => d.trim()).filter(Boolean).map((d) => /!\s*important$/i.test(d) ? d : d + " !important").join(";");
+  }
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const isPseudoElement = pseudo === "before" || pseudo === "after";
+      const sel = isPseudoElement ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(
+        sel + "{" + (isPseudoElement ? css : importantify(css)) + "}",
+        el.sheet.cssRules.length
+      );
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      const res = window.__resources;
+      const pre = res ? res[url] : void 0;
+      const target = typeof pre === "string" && pre ? pre : url;
+      const blob = bundledBlob(target);
+      (blob ? blob.text() : fetch(target).then((res2) => {
+        if (!res2.ok) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '" failed:',
+            url,
+            "returned",
+            res2.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res2.text();
+      })).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '":',
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          '[dc-runtime] sibling fetch for "' + name + '" threw:',
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/stream-state.ts
+  function createStreamTracker(staleMs = 6e4, now = Date.now) {
+    const since = /* @__PURE__ */ new Map();
+    const liveOne = (n) => {
+      const t = since.get(n);
+      if (t === void 0) return false;
+      if (now() - t > staleMs) {
+        since.delete(n);
+        return false;
+      }
+      return true;
+    };
+    return {
+      push(name, streaming, viewportKey) {
+        if (viewportKey === "dc-model") return;
+        if (streaming) since.set(name, now());
+        else since.delete(name);
+      },
+      live(name) {
+        if (name !== void 0) return liveOne(name);
+        for (const n of [...since.keys()]) if (liveOne(n)) return true;
+        return false;
+      }
+    };
+  }
+
+  // src/index.ts
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      if (integrity) {
+        s.integrity = integrity;
+        s.crossOrigin = "anonymous";
+      }
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    const react = cdnScriptFor(REACT_URL, REACT_SRI);
+    const reactDom = cdnScriptFor(REACT_DOM_URL, REACT_DOM_SRI);
+    return Promise.all([
+      loadScript(react.src, react.integrity),
+      loadScript(reactDom.src, reactDom.integrity)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const streams = createStreamTracker();
+    const api = {
+      __dcUpdate: (name, kind, content, streaming, viewportKey) => {
+        streams.push(name, streaming, viewportKey);
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcStreaming: (name) => streams.live(name),
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`sc-camel-*` attrs,
+       *  `<sc-raw-*>`/`<sc-helmet>` tags); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();

--- a/docs/design/bases-map/Bases Map.dc.html
+++ b/docs/design/bases-map/Bases Map.dc.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Silkscreen:wght@400;700&amp;family=Space+Grotesk:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;600&amp;display=swap" rel="stylesheet">
+<style>
+body{margin:0;background:#282828;background-image:repeating-linear-gradient(0deg,rgba(251,241,199,.018) 0 1px,transparent 1px 3px)}
+a{color:#8ec07c;text-decoration:none}a:hover{color:#b8db9c;text-decoration:underline}
+button{font-family:inherit}
+</style>
+</helmet>
+<div style="min-height:100vh;padding:24px;display:flex;flex-direction:column;gap:16px;box-sizing:border-box">
+  <div data-screen-label="Atlas header" style="display:flex;align-items:center;gap:16px;flex-wrap:wrap">
+    <div style="display:flex;flex-direction:column;gap:5px">
+      <div style="font:700 15px 'Silkscreen',monospace;letter-spacing:.02em;color:#fbf1c7">BASE ATLAS</div>
+      <div style="font:500 11.5px 'JetBrains Mono',monospace;color:#8ec07c;font-variant-numeric:tabular-nums">5 BASES · 2 DISTRICTS · 2 HARVEST RUNS</div>
+    </div>
+    <span style="flex:1"></span>
+    <div style="display:flex;align-items:center;gap:8px">
+      <span style="font:500 9.5px 'JetBrains Mono',monospace;letter-spacing:.1em;color:#7c6f64">RUN</span>
+      <div style="display:flex;flex-shrink:0;border:1px solid #504945;overflow:hidden">
+        <sc-for list="{{ runOpts }}" as="o" hint-placeholder-count="2">
+          <button onClick="{{ o.set }}" style="height:26px;padding:0 10px;cursor:pointer;font:600 10.5px 'JetBrains Mono',monospace;letter-spacing:.06em;border:none;border-left:{{ o.bl }};background:{{ o.bg }};color:{{ o.fg }};box-shadow:{{ o.sh }}">{{ o.k }}</button>
+        </sc-for>
+      </div>
+      <a href="../base-planner/Base Planner v2.dc.html" style="font:500 13px 'Space Grotesk',sans-serif;margin-left:8px">view planner →</a>
+      <a href="../tree-canvas/Tree Canvas.dc.html" style="font:500 13px 'Space Grotesk',sans-serif;margin-left:4px">view tree →</a>
+    </div>
+  </div>
+
+  <div style="display:flex;gap:16px;align-items:stretch;flex-wrap:wrap">
+    <div data-screen-label="Atlas map" style="position:relative;width:940px;height:560px;background:#1d2021;border:1px solid #3c3836;overflow:hidden;flex-shrink:0;background-image:linear-gradient(rgba(251,241,199,.035) 1px,transparent 1px),linear-gradient(90deg,rgba(251,241,199,.035) 1px,transparent 1px);background-size:32px 32px">
+      <sc-if value="{{ showDistricts }}" hint-placeholder-val="{{ true }}">
+        <div style="position:absolute;left:40px;top:56px;width:390px;height:330px;border:2px dashed #504945;background:rgba(142,192,124,.045)">
+          <span style="position:absolute;top:-2px;left:-2px;padding:4px 9px;background:#3c3836;font:400 8px 'Silkscreen',monospace;color:#a89984;letter-spacing:.06em">FARMLANDS</span>
+        </div>
+        <div style="position:absolute;left:490px;top:80px;width:400px;height:340px;border:2px dashed #504945;background:rgba(215,153,33,.04)">
+          <span style="position:absolute;top:-2px;left:-2px;padding:4px 9px;background:#3c3836;font:400 8px 'Silkscreen',monospace;color:#a89984;letter-spacing:.06em">STASIS DISTRICT</span>
+        </div>
+      </sc-if>
+      <sc-for list="{{ runSegs }}" as="sg" hint-placeholder-count="3">
+        <div style="position:absolute;left:{{ sg.l }};top:{{ sg.t }};width:{{ sg.w }};height:{{ sg.h }};background:{{ sg.bg }};opacity:.9"></div>
+      </sc-for>
+      <sc-for list="{{ runLabels }}" as="lb" hint-placeholder-count="2">
+        <span style="position:absolute;left:{{ lb.l }};top:{{ lb.t }};padding:3px 7px;background:#3c3836;border:1px solid #504945;font:500 9px 'JetBrains Mono',monospace;letter-spacing:.08em;color:#a89984;white-space:nowrap">{{ lb.text }}</span>
+      </sc-for>
+      <sc-for list="{{ mapBases }}" as="b" hint-placeholder-count="5">
+        <button data-screen-label="Base building" onClick="{{ b.select }}" style="position:absolute;left:{{ b.x }};top:{{ b.y }};width:76px;background:none;border:none;padding:4px;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:5px;outline:{{ b.ring }}" style-focus="outline:2px solid #8ec07c">
+          <span style="display:flex;flex-direction:column;align-items:center">
+            <span style="width:3px;height:7px;background:#fbf1c7;opacity:.65;margin-left:14px"></span>
+            <span style="width:14px;height:4px;background:#d5c4a1"></span>
+            <span style="width:30px;height:5px;background:{{ b.color }};filter:brightness(.9)"></span>
+            <span style="width:44px;height:6px;background:{{ b.color }};filter:brightness(.7);position:relative;display:block">
+              <span style="position:absolute;left:10px;top:1px;width:2px;height:4px;background:#1d2021;opacity:.4"></span>
+              <span style="position:absolute;left:21px;top:1px;width:2px;height:4px;background:#1d2021;opacity:.4"></span>
+              <span style="position:absolute;left:32px;top:1px;width:2px;height:4px;background:#1d2021;opacity:.4"></span>
+            </span>
+            <span style="width:56px;height:4px;background:#d5c4a1"></span>
+            <span style="width:56px;height:16px;background:#bdae93;position:relative;display:block">
+              <span style="position:absolute;inset:2px 3px;background:repeating-linear-gradient(90deg,#45403d 0 6px,rgba(0,0,0,0) 6px 10px)"></span>
+            </span>
+            <span style="width:48px;height:4px;background:#7c6f64"></span>
+          </span>
+          <span style="font:500 9px 'JetBrains Mono',monospace;letter-spacing:.04em;color:#ebdbb2;background:rgba(29,32,33,.92);padding:2px 5px;white-space:nowrap">{{ b.glyph }} {{ b.short }}</span>
+        </button>
+      </sc-for>
+      <sc-for list="{{ runStops }}" as="st" hint-placeholder-count="3">
+        <span style="position:absolute;left:{{ st.l }};top:{{ st.t }};width:16px;height:16px;background:{{ st.bg }};color:#1d2021;font:700 8px 'Silkscreen',monospace;display:flex;align-items:center;justify-content:center">{{ st.n }}</span>
+      </sc-for>
+    </div>
+
+    <div data-screen-label="Atlas side panel" style="flex:1;min-width:260px;max-width:340px;background:#32302f;border:1px solid #3c3836;padding:16px;display:flex;flex-direction:column;gap:12px;box-sizing:border-box">
+      <sc-if value="{{ selIsBase }}" hint-placeholder-val="{{ false }}">
+        <div style="display:flex;align-items:center;gap:9px">
+          <span style="width:10px;height:10px;background:{{ pColor }}"></span>
+          <span style="font:400 10px 'Silkscreen',monospace;color:#fbf1c7">{{ pName }}</span>
+        </div>
+        <div style="display:flex;flex-direction:column;gap:8px;font:12px 'JetBrains Mono',monospace;color:#a89984">
+          <div><span style="color:#7c6f64">BIOME&#160;&#160;&#160;</span><span style="color:#ebdbb2">{{ pBiome }}</span> · {{ pHazard }}</div>
+          <div><span style="color:#7c6f64">POWER&#160;&#160;&#160;</span><span style="color:#ebdbb2">{{ pGen }}</span></div>
+          <div><span style="color:#7c6f64">TODO&#160;&#160;&#160;&#160;</span><span style="color:#ebdbb2">{{ pTodo }}</span></div>
+          <div><span style="color:#7c6f64">DISTRICT </span><span style="color:#ebdbb2">{{ pDistrict }}</span></div>
+          <div><span style="color:#7c6f64">RUNS&#160;&#160;&#160;&#160;</span><span style="color:#ebdbb2">{{ pRuns }}</span></div>
+          <div style="display:flex;align-items:center;gap:7px"><span style="color:#7c6f64">PORTAL&#160;&#160;</span><span style="color:#ebdbb2">{{ pPortal }}</span>
+            <sc-if value="{{ pHasPortal }}" hint-placeholder-val="{{ true }}"><button onClick="{{ pCopy }}" style="height:20px;padding:0 7px;background:#3c3836;border:1px solid #504945;color:#a89984;font:500 10px 'JetBrains Mono',monospace;cursor:pointer" style-hover="filter:brightness(1.12)">copy</button></sc-if>
+          </div>
+        </div>
+        <div style="border-top:1px solid #3c3836;padding-top:10px"><a href="../base-planner/Base Planner v2.dc.html" style="font:500 12.5px 'Space Grotesk',sans-serif">open in planner →</a></div>
+      </sc-if>
+      <sc-if value="{{ selIsRun }}" hint-placeholder-val="{{ true }}">
+        <div style="display:flex;align-items:center;gap:9px">
+          <span style="width:10px;height:10px;background:{{ rColor }}"></span>
+          <span style="font:400 10px 'Silkscreen',monospace;color:#fbf1c7">{{ rName }}</span>
+        </div>
+        <div style="display:flex;flex-direction:column;gap:6px">
+          <sc-for list="{{ rStops }}" as="st" hint-placeholder-count="3">
+            <div style="display:flex;flex-direction:column;gap:4px">
+              <div style="display:flex;align-items:center;gap:8px;background:#3c3836;padding:7px 10px">
+                <span style="font:700 8px 'Silkscreen',monospace;color:#1d2021;background:{{ st.chip }};width:14px;height:14px;display:flex;align-items:center;justify-content:center">{{ st.n }}</span>
+                <span style="font:500 12px 'Space Grotesk',sans-serif;color:#fbf1c7">{{ st.name }}</span>
+                <span style="flex:1"></span>
+                <span style="font:11px 'JetBrains Mono',monospace;color:#a89984">{{ st.what }}</span>
+              </div>
+              <sc-if value="{{ st.hasMethod }}" hint-placeholder-val="{{ true }}"><div style="font:500 9.5px 'JetBrains Mono',monospace;letter-spacing:.08em;color:#7c6f64;padding-left:11px">│ {{ st.method }}</div></sc-if>
+            </div>
+          </sc-for>
+        </div>
+        <div style="font:11.5px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums">Σ {{ rGen }} kPs GEN · READY ~{{ rReady }}</div>
+        <div style="border-top:1px solid #3c3836;padding-top:10px"><a href="../base-planner/Base Planner v2.dc.html" style="font:500 12.5px 'Space Grotesk',sans-serif">open in planner →</a></div>
+      </sc-if>
+      <div style="margin-top:auto;font:11px 'Space Grotesk',sans-serif;color:#7c6f64;line-height:1.5;border-top:1px solid #3c3836;padding-top:10px">Click a base for its dossier · switch RUN to trace a harvest route · districts group nearby bases.</div>
+    </div>
+  </div>
+  <div aria-live="polite" style="position:absolute;width:1px;height:1px;overflow:hidden;clip-path:inset(50%)">{{ announce }}</div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1280,&quot;height&quot;:700},&quot;showDistricts&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Display&quot;}}">
+class Component extends DCLogic {
+  state = { sel: null, run: 'STASIS', announce: '' };
+  renderVals() {
+    const s = this.state, p = this.props;
+    const BASES = [
+      { id: 'vm', name: 'BASE D — VERDANT MOON', short: 'VERDANT MOON', glyph: '✿', color: '#93b4d1', x: 96, y: 140, biome: 'LUSH', hazard: 'mild · no storms', portal: '20E5F9556C30', gen: '440 kPs (EM)', todo: '1 of 2 built', district: 'FARMLANDS', runs: 'STASIS · CAKE' },
+      { id: 'mr', name: 'BASE B — MEADOW RANCH', short: 'MEADOW RANCH', glyph: '☼', color: '#e6d9c0', x: 268, y: 290, biome: 'TEMPERATE', hazard: 'calm · fauna docile', portal: '30C1A4E2F715', gen: '220 kPs (EM)', todo: '0 of 3 built', district: 'FARMLANDS', runs: 'CAKE' },
+      { id: 'gw', name: 'BASE C — GASWORKS', short: 'GASWORKS', glyph: '☣', color: '#e8543a', x: 566, y: 150, biome: 'TOXIC', hazard: 'acid storms · hazard prot. req.', portal: '115EF8A10D34', gen: '330 kPs (EM)', todo: '0 of 3 built', district: 'STASIS DISTRICT', runs: 'STASIS' },
+      { id: 'cf', name: 'BASE F — COBALT FLATS', short: 'COBALT FLATS', glyph: '❄', color: '#b3618a', x: 742, y: 320, biome: 'FROZEN', hazard: 'blizzards at night · solar dips', portal: '40FA92D18B06', gen: '150 kPs (SOLAR)', todo: '1 of 3 built', district: 'STASIS DISTRICT', runs: 'STASIS' },
+      { id: 'sr', name: 'OUTPOST — SIGNAL RIDGE', short: 'SIGNAL RIDGE', glyph: '▲', color: '#a08f78', x: 430, y: 440, biome: 'ROCKY', hazard: 'high winds', portal: '—', gen: '20 kPs (SOLAR)', todo: '—', district: 'ungrouped', runs: '—' }
+    ];
+    const seg = c => 'repeating-linear-gradient(90deg,' + c + ' 0 6px,rgba(0,0,0,0) 6px 10px)';
+    const segV = c => 'repeating-linear-gradient(0deg,' + c + ' 0 6px,rgba(0,0,0,0) 6px 10px)';
+    const RUNS = {
+      STASIS: { name: 'STASIS RUN', color: '#8ec07c', gen: '920', ready: '4h 0m',
+        segs: [{ l: 134, t: 178, w: 470, h: 4, v: 0 }, { l: 602, t: 190, w: 4, h: 168, v: 1 }, { l: 602, t: 356, w: 178, h: 4, v: 0 }],
+        labels: [{ l: 300, t: 158, text: '⌁ TELEPORTER' }, { l: 616, t: 262, text: '◇ PORTAL' }],
+        stops: [{ id: 'vm', n: '1', l: 126, t: 170, what: 'farm', method: '⌁ TELEPORTER' }, { id: 'gw', n: '2', l: 594, t: 182, what: 'gas', method: '◇ PORTAL' }, { id: 'cf', n: '3', l: 772, t: 348, what: 'minerals', method: '' }] },
+      CAKE: { name: 'CAKE RUN', color: '#d79921', gen: '660', ready: '2h 0m',
+        segs: [{ l: 132, t: 180, w: 4, h: 150, v: 1 }, { l: 132, t: 328, w: 174, h: 4, v: 0 }],
+        labels: [{ l: 148, t: 248, text: '⌁ TELEPORTER' }],
+        stops: [{ id: 'vm', n: '1', l: 126, t: 170, what: 'crops', method: '⌁ TELEPORTER' }, { id: 'mr', n: '2', l: 298, t: 312, what: 'ranch · kitchen', method: '' }] }
+    };
+    const run = RUNS[s.run];
+    const segStyle = c => ['C'].map(() => {});
+    const runOpts = ['STASIS', 'CAKE'].map((k, i) => ({ k: k + ' RUN', bl: i ? '1px solid #504945' : 'none',
+      bg: k === s.run ? 'rgba(142,192,124,.16)' : '#3c3836', fg: k === s.run ? '#b8db9c' : '#7c6f64',
+      sh: k === s.run ? 'inset 0 -2px 0 #8ec07c' : 'none',
+      set: () => this.setState({ run: k, sel: null, announce: RUNS[k].name + ' traced on the atlas.' }) }));
+    const b = BASES.find(x => x.id === s.sel);
+    return {
+      announce: s.announce, showDistricts: p.showDistricts ?? true, runOpts,
+      mapBases: BASES.map(x => ({ ...x, x: x.x + 'px', y: x.y + 'px',
+        ring: s.sel === x.id ? '2px solid #8ec07c' : 'none',
+        select: () => this.setState(st => ({ sel: st.sel === x.id ? null : x.id })) })),
+      runSegs: run.segs.map(g => ({ l: g.l + 'px', t: g.t + 'px', w: g.w + 'px', h: g.h + 'px', bg: g.v ? segV(run.color) : seg(run.color) })),
+      runLabels: run.labels.map(g => ({ l: g.l + 'px', t: g.t + 'px', text: g.text })),
+      runStops: run.stops.map(g => ({ n: g.n, l: g.l + 'px', t: g.t + 'px', bg: run.color })),
+      selIsBase: !!b, selIsRun: !b,
+      pName: b ? b.name : '', pColor: b ? b.color : '#504945', pBiome: b ? b.glyph + ' ' + b.biome : '', pHazard: b ? b.hazard : '',
+      pGen: b ? b.gen : '', pTodo: b ? b.todo : '', pDistrict: b ? b.district : '', pRuns: b ? b.runs : '',
+      pPortal: b ? b.portal : '', pHasPortal: !!b && b.portal !== '—',
+      pCopy: () => { try { navigator.clipboard.writeText(b.portal); } catch (e) {} this.setState({ announce: 'Portal address for ' + b.short + ' copied.' }); },
+      rName: run.name, rColor: run.color, rGen: run.gen, rReady: run.ready,
+      rStops: run.stops.map(g => { const bb = BASES.find(x => x.id === g.id); return { n: g.n, name: bb.short, what: g.what, chip: run.color, hasMethod: !!g.method, method: g.method }; })
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/bases-map/handoff.md
+++ b/docs/design/bases-map/handoff.md
@@ -1,0 +1,32 @@
+# Handoff: Base Atlas (NMS Base & Resource Planner)
+
+> Convention note: where this document and a later spec disagree, **the spec wins**.
+
+## Overview
+City-builder-style overview of all bases and base groups: a pixel-grid map with each base as a small 8-bit building, dashed **district** territories grouping nearby bases, and traceable **harvest-run** routes (dotted pixel paths with numbered waypoints and travel-method labels). A side panel shows the selected base's dossier or the active run's leg list. Companion to the per-base planner (`../base-planner/`) — this is the "where", the planner is the "what to build".
+
+## About the Design Files
+`Bases Map.dc.html` is a design reference in HTML, not production code. Coordinates are hand-placed sample data; production lays bases out from stored positions (player-arranged, drag to move — not prototyped).
+
+## Layout
+- Header: BASE ATLAS (Silkscreen pixel font, 15px) + counts line; RUN segmented toggle (STASIS RUN / CAKE RUN); links to planner + tree.
+- Map: 940×560 `--bg-canvas` with 32px pixel grid (1px lines at .035 alpha).
+- Districts: dashed 2px `--border` rectangles, ≤.05 alpha tint, Silkscreen 8px name tab at top-left. Togglable (tweak).
+- Buildings: habitation-pod pixel structures — stepped dome cap in the base's identity color (ribbed: 2px seam pixels, two brightness steps), light rim + body band (`#d5c4a1`/`#bdae93`) with a repeating dark window strip, darker skirt, antenna — with a mono label chip (glyph + name) beneath. Base identity color lives in the dome only. Click/Enter selects (aqua outline).
+- Routes: active run only. Dotted 4px pixel path (repeating-gradient dashes in run color: STASIS aqua, CAKE yellow), method chips mid-leg, 16px numbered waypoint squares at each stop.
+- Side panel: base dossier (biome/hazard, power, todo, district, runs, portal + copy) or run panel (ordered stops with methods, Σ gen, ready) when no base is selected. Both link to the planner.
+
+## 8-bit conventions (shared with planner v2 restyle)
+Silkscreen for display text only (≥8px, short caps strings); JetBrains Mono/Space Grotesk for data and body. Radius 0 everywhere. Chunked/dashed fills instead of smooth. Hard offset shadows, no blur.
+
+## Sample data
+5 bases (the 4 from the planner plans + 1 ungrouped outpost), 2 districts (FARMLANDS, STASIS DISTRICT), 2 runs matching the planner's targets. Power/todo figures echo the planner's sample state.
+
+## Open questions
+1. Base drag-repositioning and district drawing are production features — not prototyped.
+2. Should selecting a run stop here deep-link to that card in the planner? Link currently goes to the planner top.
+3. Verdant Moon is in both runs — waypoint "1" chips overlap identically by design; revisit if runs can share mid-route stops.
+
+## Files
+- `docs/design/bases-map/Bases Map.dc.html` — interactive prototype
+- Depends on: theme tokens (`../theme/handoff.md`), planner sample state (`../base-planner/handoff.md`)

--- a/docs/design/bases-map/support.js
+++ b/docs/design/bases-map/support.js
@@ -1,0 +1,1911 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    if (!window.__resources) {
+      fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+        const raw = t ? parseDcText(t) : null;
+        if (raw?.template) runtime.updateHtml(rootName, raw.template);
+      }).catch(() => {
+      });
+    }
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu",
+    onmousemove: "onMouseMove",
+    onmouseover: "onMouseOver",
+    onmouseout: "onMouseOut",
+    onpointerdown: "onPointerDown",
+    onpointerup: "onPointerUp",
+    onpointermove: "onPointerMove",
+    onpointerenter: "onPointerEnter",
+    onpointerleave: "onPointerLeave",
+    onpointercancel: "onPointerCancel",
+    onpointerover: "onPointerOver",
+    onpointerout: "onPointerOut",
+    ongotpointercapture: "onGotPointerCapture",
+    onlostpointercapture: "onLostPointerCapture",
+    ontouchstart: "onTouchStart",
+    ontouchend: "onTouchEnd",
+    ontouchmove: "onTouchMove",
+    ontouchcancel: "onTouchCancel",
+    ondragstart: "onDragStart",
+    ondragend: "onDragEnd",
+    ondragenter: "onDragEnter",
+    ondragleave: "onDragLeave",
+    ondragover: "onDragOver",
+    onanimationstart: "onAnimationStart",
+    onanimationend: "onAnimationEnd",
+    onanimationiteration: "onAnimationIteration",
+    ontransitionend: "onTransitionEnd"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCamelAttrs(html) {
+    return html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+  }
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = encodeCamelAttrs(html);
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  var SLIDE_ID_VALUE_RE = /^[0-9a-f]{8}$/;
+  var DECK_CONTROL_FLOW_RE = /^(sc-if|sc-for|sc-else|dc-import|x-import)$/;
+  var DECK_AUX_RE = /^(template|script|style|sc-helmet|helmet)$/;
+  function isDeckMountTag(el) {
+    if (el.localName === "deck-stage") return true;
+    return el.localName === "x-import" && (el.getAttribute("component-from-global-scope") || "") === "deck-stage";
+  }
+  function walkDeckChildren(el, host) {
+    const pairs = [...el.childNodes].map((c) => ({ c, b: walk(c, host) })).filter((p) => p.b !== null);
+    const kids = pairs.map((p) => p.b);
+    const seen = /* @__PURE__ */ new Set();
+    const wsSeen = /* @__PURE__ */ new Map();
+    const keys = [];
+    const nextSlideId = new Array(pairs.length);
+    {
+      let upcoming = null;
+      for (let j = pairs.length - 1; j >= 0; j--) {
+        const n = pairs[j].c;
+        if (n.nodeType === Node.ELEMENT_NODE) {
+          const t = n.localName;
+          upcoming = !DECK_AUX_RE.test(t) && !DECK_CONTROL_FLOW_RE.test(t) ? n.getAttribute("data-om-slide-id") : null;
+        }
+        nextSlideId[j] = upcoming;
+      }
+    }
+    for (let j = 0; j < pairs.length; j++) {
+      const { c } = pairs[j];
+      if (c.nodeType === Node.TEXT_NODE) {
+        if ((c.nodeValue ?? "").trim() === "") {
+          const base = nextSlideId[j] ? "omid-ws:" + nextSlideId[j] : "omid-ws:aux";
+          const n = wsSeen.get(base) ?? 0;
+          wsSeen.set(base, n + 1);
+          keys.push(n === 0 ? base : base + ":" + n);
+          continue;
+        }
+        return { kids, keys: null };
+      }
+      if (c.nodeType !== Node.ELEMENT_NODE) {
+        keys.push(j);
+        continue;
+      }
+      const child = c;
+      const tag = child.localName;
+      if (DECK_AUX_RE.test(tag)) {
+        keys.push(j);
+        continue;
+      }
+      if (DECK_CONTROL_FLOW_RE.test(tag)) return { kids, keys: null };
+      const v = child.getAttribute("data-om-slide-id");
+      if (!v || !SLIDE_ID_VALUE_RE.test(v) || seen.has(v)) {
+        return { kids, keys: null };
+      }
+      seen.add(v);
+      keys.push("omid:" + v);
+    }
+    return { kids, keys };
+  }
+  function renderDeckKids(kids, kidKeys, vals, ctx) {
+    return kids.map((b, j) => {
+      const k = kidKeys ? kidKeys[j] : j;
+      const out = b(vals, ctx, k);
+      return kidKeys != null && typeof out === "string" ? h(getReact().Fragment, { key: k }, out) : out;
+    });
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || (el.getAttribute("component-from-global-scope") ? "" : el.getAttribute("src") || el.getAttribute("import") || "");
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const deckKeyed = hasContent && isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : hasContent ? walkChildren(el, host) : [];
+    const kidKeys = deckKeyed?.keys ?? null;
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) {
+        props.children = renderDeckKids(kids, kidKeys, vals, ctx);
+      }
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const deckKeyed = isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : walkChildren(el, host);
+    const kidKeys = deckKeyed?.keys ?? null;
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...renderDeckKids(kids, kidKeys, vals, ctx));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/bundled.ts
+  function bundledBlob(url) {
+    const blobs = window.__resourceBlobs;
+    const b = blobs ? blobs[url.split("#")[0]] : void 0;
+    return b instanceof Blob ? b : null;
+  }
+
+  // src/cdn.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  function cdnScriptFor(url, sri) {
+    const res = window.__resources;
+    const v = res ? res[url] : void 0;
+    return typeof v === "string" && v ? { src: v } : { src: url, integrity: sri };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      const babel = cdnScriptFor(BABEL_URL, BABEL_SRI);
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = babel.src;
+        if (babel.integrity) {
+          s.integrity = babel.integrity;
+          s.crossOrigin = "anonymous";
+        }
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => {
+        const pre = bundledBlob(url);
+        if (pre) return pre.text();
+        return fetch(url).then((r) => {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.text();
+        });
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            if (tag === "LINK") {
+              const rel = (child.getAttribute("rel") || "").toLowerCase().split(/\s+/);
+              const href = (child.getAttribute("href") || "").trim();
+              const res = window.__resources;
+              const pre = res && rel.includes("stylesheet") && !rel.includes("alternate") ? res[href] : void 0;
+              const blob = typeof pre === "string" && pre ? bundledBlob(pre) : null;
+              if (blob) {
+                const el = doc.createElement("style");
+                if (child.hasAttribute("disabled")) {
+                  el.setAttribute("media", "not all");
+                } else if (child.getAttribute("media")) {
+                  el.setAttribute("media", child.getAttribute("media"));
+                }
+                if (child.getAttribute("title"))
+                  el.setAttribute("title", child.getAttribute("title"));
+                void blob.text().then((css) => {
+                  el.textContent = css;
+                });
+                doc.head.appendChild(el);
+                continue;
+              }
+            }
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function scanUnquotedUrl(css, i) {
+    if (css[i] !== "u" && css[i] !== "U" || css.slice(i, i + 4).toLowerCase() !== "url(" || /[a-z0-9_-]/i.test(css[i - 1] ?? "")) {
+      return -1;
+    }
+    let j = i + 4;
+    while (j < css.length && /\s/.test(css[j])) j++;
+    if (css[j] === '"' || css[j] === "'") return -1;
+    while (j < css.length && css[j] !== ")") {
+      if (css[j] === "\\") j++;
+      j++;
+    }
+    return j < css.length ? j + 1 : css.length;
+  }
+  function stripComments(css) {
+    let out = "";
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") {
+          out += c + (css[i + 1] ?? "");
+          i++;
+          continue;
+        }
+        if (c === quote) quote = "";
+        out += c;
+      } else if (c === "'" || c === '"') {
+        quote = c;
+        out += c;
+      } else if (c === "/" && css[i + 1] === "*") {
+        const end = css.indexOf("*/", i + 2);
+        i = end === -1 ? css.length : end + 1;
+        out += " ";
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end === -1) out += c;
+        else {
+          out += css.slice(i, end);
+          i = end - 1;
+        }
+      }
+    }
+    return out;
+  }
+  function importantify(css) {
+    css = stripComments(css);
+    const decls = [];
+    let start = 0;
+    let depth = 0;
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") i++;
+        else if (c === quote) quote = "";
+      } else if (c === "'" || c === '"') quote = c;
+      else if (c === "(") depth++;
+      else if (c === ")") depth = Math.max(0, depth - 1);
+      else if (c === ";" && depth === 0) {
+        decls.push(css.slice(start, i));
+        start = i + 1;
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end !== -1) i = end - 1;
+      }
+    }
+    decls.push(css.slice(start));
+    return decls.map((d) => d.trim()).filter(Boolean).map((d) => /!\s*important$/i.test(d) ? d : d + " !important").join(";");
+  }
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const isPseudoElement = pseudo === "before" || pseudo === "after";
+      const sel = isPseudoElement ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(
+        sel + "{" + (isPseudoElement ? css : importantify(css)) + "}",
+        el.sheet.cssRules.length
+      );
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      const res = window.__resources;
+      const pre = res ? res[url] : void 0;
+      const target = typeof pre === "string" && pre ? pre : url;
+      const blob = bundledBlob(target);
+      (blob ? blob.text() : fetch(target).then((res2) => {
+        if (!res2.ok) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '" failed:',
+            url,
+            "returned",
+            res2.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res2.text();
+      })).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '":',
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          '[dc-runtime] sibling fetch for "' + name + '" threw:',
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/stream-state.ts
+  function createStreamTracker(staleMs = 6e4, now = Date.now) {
+    const since = /* @__PURE__ */ new Map();
+    const liveOne = (n) => {
+      const t = since.get(n);
+      if (t === void 0) return false;
+      if (now() - t > staleMs) {
+        since.delete(n);
+        return false;
+      }
+      return true;
+    };
+    return {
+      push(name, streaming, viewportKey) {
+        if (viewportKey === "dc-model") return;
+        if (streaming) since.set(name, now());
+        else since.delete(name);
+      },
+      live(name) {
+        if (name !== void 0) return liveOne(name);
+        for (const n of [...since.keys()]) if (liveOne(n)) return true;
+        return false;
+      }
+    };
+  }
+
+  // src/index.ts
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      if (integrity) {
+        s.integrity = integrity;
+        s.crossOrigin = "anonymous";
+      }
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    const react = cdnScriptFor(REACT_URL, REACT_SRI);
+    const reactDom = cdnScriptFor(REACT_DOM_URL, REACT_DOM_SRI);
+    return Promise.all([
+      loadScript(react.src, react.integrity),
+      loadScript(reactDom.src, reactDom.integrity)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const streams = createStreamTracker();
+    const api = {
+      __dcUpdate: (name, kind, content, streaming, viewportKey) => {
+        streams.push(name, streaming, viewportKey);
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcStreaming: (name) => streams.live(name),
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`sc-camel-*` attrs,
+       *  `<sc-raw-*>`/`<sc-helmet>` tags); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();

--- a/docs/design/explorations/Theme Variants.dc.html
+++ b/docs/design/explorations/Theme Variants.dc.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet><meta name="design_doc_mode" content="canvas">
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@600;700&amp;family=Space+Grotesk:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;600&amp;display=swap" rel="stylesheet">
+<style>body{margin:0;background:#f0eee9;font-family:system-ui,sans-serif}a{color:#2a78d6}a:hover{color:#1a5cb0}.dv-turn{padding:40px 44px 32px;scroll-margin-top:16px}.dv-thd{display:flex;align-items:baseline;gap:10px;margin:0 0 20px}.dv-tid{font:600 10px ui-monospace,Menlo,monospace;padding:3px 7px;background:#1a1a1a;color:#fff;border-radius:4px;text-decoration:none}.dv-tname{font:600 13px/1.2 system-ui,sans-serif;color:#1a1a1a}.dv-opts{display:flex;flex-wrap:wrap;gap:28px;align-items:flex-start}.dv-opt{flex:none;display:flex;flex-direction:column;gap:9px;scroll-margin-top:16px}.dv-oid{font:600 10.5px ui-monospace,Menlo,monospace;padding:3px 7px;background:rgba(0,0,0,.08);color:#1a1a1a;border-radius:5px;text-decoration:none}.dv-olabel{display:flex;align-items:baseline;gap:8px;font:400 11px/1.3 system-ui,sans-serif;color:rgba(0,0,0,.55)}.dv-card{max-width:100%;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,.12);overflow:hidden}.dv-opt:target .dv-oid{background:#2a78d6;color:#fff}.dv-next{margin:22px 0 0;font:12px/1.5 system-ui,sans-serif;color:rgba(0,0,0,.5)}.dv-note{font:11px/1.5 system-ui,sans-serif;color:rgba(0,0,0,.6);max-width:340px}</style></helmet>
+<section class="dv-turn" id="t6" style="border-bottom:1px solid rgba(0,0,0,.08)">
+<div class="dv-thd"><a class="dv-tid" href="#t6">6</a><span class="dv-tname">Base C, hi-fi — copper frame from <a class="dv-oid" href="#5a">5a</a>, build-checklist card from 2a, gruvbox <a class="dv-oid" href="#4a">4a</a></span></div>
+<div class="dv-opts">
+<div class="dv-opt" id="6a">
+<div class="dv-olabel"><a class="dv-oid" href="#6a">6a</a>Power-deficit state → resolved state</div>
+<div class="dv-card" style="background:#282828;padding:22px;display:flex;gap:20px;flex-wrap:wrap">
+
+  <div style="width:360px;background:#32302f;border:3px solid #e8543a;border-radius:4px;display:flex;flex-direction:column">
+    <div style="display:flex;align-items:center;gap:10px;padding:14px 16px;border-bottom:1px solid #3c3836">
+      <span style="width:10px;height:10px;background:#e8543a;border-radius:1px"></span>
+      <span style="font:600 15px 'Chakra Petch',sans-serif;letter-spacing:.04em;color:#fbf1c7">BASE C — COPPER RIDGE</span>
+      <span style="flex:1"></span>
+      <span style="font:italic 12px 'Space Grotesk',sans-serif;color:#a89984;cursor:pointer">rename</span>
+    </div>
+    <div style="padding:12px 16px;display:flex;flex-direction:column;gap:12px">
+      <div style="display:flex;flex-direction:column;gap:6px">
+        <div style="font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64">FARM</div>
+        <div style="background:#3c3836;border-radius:2px;padding:9px 11px;display:flex;flex-direction:column;gap:3px">
+          <div style="display:flex;justify-content:space-between;font:500 13px 'Space Grotesk',sans-serif;color:#fbf1c7"><span>Faecium</span><span style="font-family:'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">×200</span></div>
+          <div style="font:11.5px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums"><span style="color:#ebdbb2">64 plants · 4 biodomes</span> (16/dome) · harvest 30m × 4 cycles ≈ 2h 0m</div>
+        </div>
+        <div style="background:#3c3836;border-radius:2px;padding:9px 11px;display:flex;flex-direction:column;gap:3px">
+          <div style="display:flex;justify-content:space-between;font:500 13px 'Space Grotesk',sans-serif;color:#fbf1c7"><span>Frost Crystal</span><span style="font-family:'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">×100</span></div>
+          <div style="font:11.5px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums"><span style="color:#ebdbb2">50 plants · 4 biodomes</span> (13/dome) · harvest 2h × 1 cycle</div>
+        </div>
+      </div>
+      <div style="display:flex;flex-direction:column;gap:6px">
+        <div style="font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64">EXTRACTORS</div>
+        <div style="background:#3c3836;border-radius:2px;padding:9px 11px;display:flex;flex-direction:column;gap:5px">
+          <div style="display:flex;justify-content:space-between;font:500 13px 'Space Grotesk',sans-serif;color:#fbf1c7"><span>Activated Copper</span><span style="font-family:'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">×250</span></div>
+          <div style="display:flex;align-items:center;gap:8px;font:11.5px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums"><span style="color:#ebdbb2">2 × Mineral Extractor</span>
+            <span style="display:inline-flex;border:1px solid #504945;border-radius:2px;overflow:hidden"><span style="padding:2px 7px;color:#7c6f64">C</span><span style="padding:2px 7px;background:rgba(142,192,124,.16);box-shadow:inset 0 -2px 0 #8ec07c;color:#b8db9c;font-weight:600">B</span><span style="padding:2px 7px;color:#7c6f64;border-left:1px solid #504945">A</span><span style="padding:2px 7px;color:#7c6f64;border-left:1px solid #504945">S</span></span>
+          </div>
+          <div style="font:11.5px 'JetBrains Mono',monospace;color:#a89984;font-variant-numeric:tabular-nums">fills in 1h 15m · +1 supply depot (720u)</div>
+        </div>
+      </div>
+      <div style="display:flex;flex-direction:column;gap:6px">
+        <div style="font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64">POWER</div>
+        <div style="background:#3c3836;border-radius:2px;padding:9px 11px;display:flex;flex-direction:column;gap:7px">
+          <div style="display:grid;grid-template-columns:32px 1fr 64px;gap:8px;align-items:center;font:10.5px 'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">
+            <span style="color:#a89984">GEN</span><div style="height:7px;background:#1d2021"><div style="width:58%;height:100%;background:#8ec07c"></div></div><span style="color:#ebdbb2;text-align:right">300 kPs</span>
+            <span style="color:#a89984">DRAW</span><div style="height:7px;background:#1d2021;position:relative"><div style="width:58%;height:100%;background:#a89984"></div><div style="position:absolute;left:58%;top:0;width:16%;height:100%;background:#fb4934"></div></div><span style="color:#fb4934;text-align:right">380 kPs</span>
+          </div>
+          <div style="display:flex;align-items:center;gap:8px">
+            <span style="font:11.5px 'Space Grotesk',sans-serif;color:#fb4934">⚠ deficit 80 kPs</span>
+            <span style="flex:1"></span>
+            <button style="height:26px;padding:0 10px;background:#3c3836;border:1px solid #665c54;border-radius:2px;color:#ebdbb2;font:500 11.5px 'Space Grotesk',sans-serif;cursor:pointer">+ 1 × EM generator (+110)</button>
+          </div>
+        </div>
+      </div>
+      <div style="border-top:1px solid #3c3836;padding-top:10px;display:flex;justify-content:space-between;align-items:baseline">
+        <span style="font:11.5px 'JetBrains Mono',monospace;color:#a89984">BUILD: 8 domes · 2 extractors · 1 depot · <span style="color:#fb4934">+1 generator</span></span>
+        <span style="font:600 12px 'JetBrains Mono',monospace;color:#fbf1c7;font-variant-numeric:tabular-nums">ready ~2h 0m</span>
+      </div>
+    </div>
+  </div>
+
+  <div style="width:360px;background:#32302f;border:3px solid #e8543a;border-radius:4px;display:flex;flex-direction:column;position:relative">
+    <div style="position:absolute;inset:3px;border:2px solid #8ec07c;pointer-events:none"></div>
+    <div style="display:flex;align-items:center;gap:10px;padding:14px 16px;border-bottom:1px solid #3c3836">
+      <span style="width:10px;height:10px;background:#e8543a;border-radius:1px"></span>
+      <span style="font:600 15px 'Chakra Petch',sans-serif;letter-spacing:.04em;color:#fbf1c7">BASE C — COPPER RIDGE</span>
+      <span style="flex:1"></span>
+      <span style="font:italic 12px 'Space Grotesk',sans-serif;color:#a89984;cursor:pointer">rename</span>
+    </div>
+    <div style="padding:12px 16px;display:flex;flex-direction:column;gap:12px">
+      <div style="font:11.5px 'Space Grotesk',sans-serif;color:#a89984;font-style:italic">…farm and extractor sections unchanged…</div>
+      <div style="display:flex;flex-direction:column;gap:6px">
+        <div style="font:600 10px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#7c6f64">POWER</div>
+        <div style="background:#3c3836;border-radius:2px;padding:9px 11px;display:flex;flex-direction:column;gap:7px">
+          <div style="display:grid;grid-template-columns:32px 1fr 64px;gap:8px;align-items:center;font:10.5px 'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">
+            <span style="color:#a89984">GEN</span><div style="height:7px;background:#1d2021"><div style="width:79%;height:100%;background:#8ec07c"></div></div><span style="color:#ebdbb2;text-align:right">410 kPs</span>
+            <span style="color:#a89984">DRAW</span><div style="height:7px;background:#1d2021"><div style="width:73%;height:100%;background:#a89984"></div></div><span style="color:#ebdbb2;text-align:right">380 kPs</span>
+          </div>
+          <div style="font:11.5px 'Space Grotesk',sans-serif;color:#8ec07c">✓ headroom +30 kPs · 2 × EM generator, 1 × solar</div>
+        </div>
+      </div>
+      <div style="border-top:1px solid #3c3836;padding-top:10px;display:flex;justify-content:space-between;align-items:baseline">
+        <span style="font:11.5px 'JetBrains Mono',monospace;color:#a89984">BUILD: 8 domes · 2 extractors · 1 depot · 3 generators</span>
+        <span style="font:600 12px 'JetBrains Mono',monospace;color:#fbf1c7;font-variant-numeric:tabular-nums">ready ~2h 0m</span>
+      </div>
+    </div>
+  </div>
+
+</div>
+<div class="dv-note" style="max-width:740px">Left: deficit state — the fix is a button; clicking it adds the generator to the build list (right card, selected state shown with the aqua ring <i>inboard</i> of the copper frame — selection never touches the identity border). Farm rows compute plants ÷ dome capacity; the footer BUILD line is the card's rollup: everything you construct, plus ready time (longest chain). Numbers are sample data.</div>
+</div>
+</div>
+<p class="dv-next">Try next: "this, but the whole 3-base panel" · "commit <a class="dv-oid" href="#4a">4a</a>+<a class="dv-oid" href="#5a">5a</a>, rebuild the token sheet" · "show Base C's leaf nodes on the tree"</p>
+</section>
+<section class="dv-turn" id="t5" style="border-bottom:1px solid rgba(0,0,0,.08)">
+<div class="dv-thd"><a class="dv-tid" href="#t5">5</a><span class="dv-tname">Gruvbox base-identity palette — 6 frames for <a class="dv-oid" href="#4a">4a</a>, validated</span></div>
+<div class="dv-opts">
+<div class="dv-opt" id="5a">
+<div class="dv-olabel"><a class="dv-oid" href="#5a">5a</a>yellow · sand · copper · blue · gray · purple</div>
+<div class="dv-card" style="width:730px;background:#282828;padding:22px;display:flex;flex-direction:column;gap:16px">
+  <div style="display:flex;flex-wrap:wrap;gap:12px">
+    <div style="display:flex;flex-direction:column;gap:6px;width:104px"><div style="height:58px;border-radius:2px;border:3px solid #fabd2f;background:#32302f;display:flex;align-items:center;justify-content:center"><span style="font:600 12px 'Space Grotesk',sans-serif;color:#fbf1c7">Base A</span></div><div style="font:500 10.5px 'JetBrains Mono',monospace;color:#ebdbb2">yellow #fabd2f</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:104px"><div style="height:58px;border-radius:2px;border:3px solid #e6d9c0;background:#32302f;display:flex;align-items:center;justify-content:center"><span style="font:600 12px 'Space Grotesk',sans-serif;color:#fbf1c7">Base B</span></div><div style="font:500 10.5px 'JetBrains Mono',monospace;color:#ebdbb2">sand #e6d9c0</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:104px"><div style="height:58px;border-radius:2px;border:3px solid #e8543a;background:#32302f;display:flex;align-items:center;justify-content:center"><span style="font:600 12px 'Space Grotesk',sans-serif;color:#fbf1c7">Base C</span></div><div style="font:500 10.5px 'JetBrains Mono',monospace;color:#ebdbb2">copper #e8543a</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:104px"><div style="height:58px;border-radius:2px;border:3px solid #93b4d1;background:#32302f;display:flex;align-items:center;justify-content:center"><span style="font:600 12px 'Space Grotesk',sans-serif;color:#fbf1c7">Base D</span></div><div style="font:500 10.5px 'JetBrains Mono',monospace;color:#ebdbb2">blue #93b4d1</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:104px"><div style="height:58px;border-radius:2px;border:3px solid #a08f78;background:#32302f;display:flex;align-items:center;justify-content:center"><span style="font:600 12px 'Space Grotesk',sans-serif;color:#fbf1c7">Base E</span></div><div style="font:500 10.5px 'JetBrains Mono',monospace;color:#ebdbb2">gray #a08f78</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:104px"><div style="height:58px;border-radius:2px;border:3px solid #b3618a;background:#32302f;display:flex;align-items:center;justify-content:center"><span style="font:600 12px 'Space Grotesk',sans-serif;color:#fbf1c7">Base F</span></div><div style="font:500 10.5px 'JetBrains Mono',monospace;color:#ebdbb2">purple #b3618a</div></div>
+  </div>
+  <div style="display:grid;grid-template-columns:88px 92px repeat(3,96px);gap:2px 12px;background:#32302f;border:1px solid #3c3836;border-radius:4px;padding:14px 16px;font:11.5px 'JetBrains Mono',monospace">
+    <span style="color:#7c6f64;font-size:10px;letter-spacing:.1em">TOKEN</span><span style="color:#7c6f64;font-size:10px;letter-spacing:.1em">HEX</span><span style="color:#7c6f64;font-size:10px;letter-spacing:.1em">VS #1D2021</span><span style="color:#7c6f64;font-size:10px;letter-spacing:.1em">VS #282828</span><span style="color:#7c6f64;font-size:10px;letter-spacing:.1em">VS #32302F</span>
+    <span style="color:#ebdbb2">yellow</span><span style="color:#a89984">#fabd2f</span><span style="color:#ebdbb2">9.67</span><span style="color:#ebdbb2">8.69</span><span style="color:#ebdbb2">7.74</span>
+    <span style="color:#ebdbb2">sand</span><span style="color:#a89984">#e6d9c0</span><span style="color:#ebdbb2">11.75</span><span style="color:#ebdbb2">10.57</span><span style="color:#ebdbb2">9.41</span>
+    <span style="color:#ebdbb2">copper</span><span style="color:#a89984">#e8543a</span><span style="color:#ebdbb2">4.50</span><span style="color:#ebdbb2">4.04</span><span style="color:#ebdbb2">3.60</span>
+    <span style="color:#ebdbb2">blue</span><span style="color:#a89984">#93b4d1</span><span style="color:#ebdbb2">7.57</span><span style="color:#ebdbb2">6.80</span><span style="color:#ebdbb2">6.06</span>
+    <span style="color:#ebdbb2">gray</span><span style="color:#a89984">#a08f78</span><span style="color:#ebdbb2">5.23</span><span style="color:#ebdbb2">4.70</span><span style="color:#ebdbb2">4.19</span>
+    <span style="color:#ebdbb2">purple</span><span style="color:#a89984">#b3618a</span><span style="color:#ebdbb2">3.90</span><span style="color:#ebdbb2">3.51</span><span style="color:#ebdbb2">3.12</span>
+  </div>
+  <div style="font:11.5px 'JetBrains Mono',monospace;color:#a89984;line-height:1.7">min ΔE under protan/deutan sim (flag &lt;20): yellow×copper 31 · sand×blue 33 · sand×gray 27 · copper×gray 23 · blue×purple 23 · <span style="color:#fabd2f">gray×purple 21 (floor)</span> · all other pairs ≥31</div>
+</div>
+<div class="dv-note" style="max-width:720px">All six clear 3:1 (SC 1.4.11) on every surface a frame sits on; purple is the floor at 3.12. CB floor is gray×purple at ΔE 21 — above the flag threshold, but the compression is real: gruvbox's lighter backgrounds shrink the usable gamut, so this palette can't reach Deep Space's ΔE-24 floor. Two canon colors are deliberately absent: <b>green</b> #b8bb26 (collapses into yellow under deutan at ΔE 5 — the classic gruvbox CB trap) and bright <b>orange/red</b> (spent on interactive/deficit). Sand and gray replaced them: less rainbow, safer. Base names stay the primary identity as always.</div>
+</div>
+</div>
+<p class="dv-next">Try next: "commit to <a class="dv-oid" href="#4a">4a</a> + <a class="dv-oid" href="#5a">5a</a>, rebuild the token sheet" · "try green instead of sand anyway" · "back to <a class="dv-oid" href="#3a">3a</a>"</p>
+</section>
+<section class="dv-turn" id="t4" style="border-bottom:1px solid rgba(0,0,0,.08)">
+<div class="dv-thd"><a class="dv-tid" href="#t4">4</a><span class="dv-tname">Gruvbox riffs — retro warmth, same component rules</span></div>
+<div class="dv-opts">
+
+<div class="dv-opt" id="4a">
+<div class="dv-olabel"><a class="dv-oid" href="#4a">4a</a>Gruvbox — classic dark · orange · aqua</div>
+<div class="dv-card" style="width:350px;background:#282828;background-image:repeating-linear-gradient(0deg,rgba(251,241,199,.02) 0 1px,transparent 1px 3px);padding:20px;display:flex;flex-direction:column;gap:14px">
+  <div style="font:700 18px 'Chakra Petch',sans-serif;letter-spacing:.05em;color:#fbf1c7">STASIS DEVICE <span style="color:#a89984;font-size:13px">×1</span></div>
+  <div style="font:500 11.5px 'JetBrains Mono',monospace;color:#8ec07c">3 BASES · 4,850 kPs · ~6h 30m/CYCLE</div>
+  <div style="background:#32302f;border:3px solid #83a598;border-radius:4px;padding:12px 14px;display:flex;flex-direction:column;gap:8px">
+    <div style="display:flex;justify-content:space-between;align-items:baseline"><span style="font:600 15px 'Space Grotesk',sans-serif;color:#fbf1c7">Chromatic Metal</span><span style="font:600 13px 'JetBrains Mono',monospace;color:#ebdbb2">×250</span></div>
+    <div style="display:flex;gap:8px;align-items:center"><span style="height:22px;display:inline-flex;align-items:center;padding:0 8px;background:#3c3836;border:1px solid #504945;border-radius:2px;font:600 10.5px 'JetBrains Mono',monospace;color:#ebdbb2">◇ REFINE</span>
+    <div style="display:flex;border:1px solid #504945;border-radius:2px;overflow:hidden"><span style="height:24px;display:inline-flex;align-items:center;padding:0 10px;background:#3c3836;color:#a89984;font:500 11.5px 'Space Grotesk',sans-serif">craft</span><span style="height:24px;display:inline-flex;align-items:center;padding:0 10px;background:rgba(142,192,124,.16);box-shadow:inset 0 -2px 0 #8ec07c;color:#b8db9c;font:600 11.5px 'Space Grotesk',sans-serif">refine</span></div></div>
+  </div>
+  <div style="background:#32302f;border:1px solid #3c3836;border-radius:4px;padding:12px 14px;display:flex;flex-direction:column;gap:7px">
+    <div style="display:grid;grid-template-columns:32px 1fr 66px;gap:8px;align-items:center;font:10.5px 'JetBrains Mono',monospace">
+      <span style="color:#a89984">GEN</span><div style="height:7px;background:#1d2021"><div style="width:58%;height:100%;background:#8ec07c"></div></div><span style="color:#ebdbb2;text-align:right">300 kPs</span>
+      <span style="color:#a89984">DRAW</span><div style="height:7px;background:#1d2021;position:relative"><div style="width:58%;height:100%;background:#a89984"></div><div style="position:absolute;left:58%;top:0;width:16%;height:100%;background:#fb4934"></div></div><span style="color:#fb4934;text-align:right">380 kPs</span>
+    </div>
+    <div style="font:11.5px 'Space Grotesk',sans-serif;color:#fb4934">⚠ build 1 × EM generator (+110 kPs)</div>
+  </div>
+  <div style="display:flex;gap:8px"><button style="height:34px;padding:0 14px;background:#fe8019;border:1px solid #af3a03;border-radius:2px;color:#1d2021;font:600 13px 'Space Grotesk',sans-serif;cursor:pointer">Recompute</button><button style="height:34px;padding:0 14px;background:#3c3836;border:1px solid #504945;border-radius:2px;color:#ebdbb2;font:500 13px 'Space Grotesk',sans-serif;cursor:pointer">Share</button><span style="align-self:center;font:500 13px 'Space Grotesk',sans-serif;color:#8ec07c;margin-left:4px">view tree →</span></div>
+</div>
+<div class="dv-note">Canonical gruvbox dark: bg0 #282828, cream text #ebdbb2, orange #fe8019 interactive, aqua #8ec07c ok/selection. One deviation from the other schemes: gruvbox has a real red (#fb4934), so deficit gets red and orange stays purely interactive — cleaner than one color doing both.</div>
+</div>
+
+<div class="dv-opt" id="4b">
+<div class="dv-olabel"><a class="dv-oid" href="#4b">4b</a>Gruvbox hard — bg0_h · yellow · blue</div>
+<div class="dv-card" style="width:350px;background:#1d2021;background-image:repeating-linear-gradient(0deg,rgba(251,241,199,.018) 0 1px,transparent 1px 3px);padding:20px;display:flex;flex-direction:column;gap:14px">
+  <div style="font:700 18px 'Chakra Petch',sans-serif;letter-spacing:.05em;color:#fbf1c7">STASIS DEVICE <span style="color:#a89984;font-size:13px">×1</span></div>
+  <div style="font:500 11.5px 'JetBrains Mono',monospace;color:#83a598">3 BASES · 4,850 kPs · ~6h 30m/CYCLE</div>
+  <div style="background:#282828;border:3px solid #d3869b;border-radius:4px;padding:12px 14px;display:flex;flex-direction:column;gap:8px">
+    <div style="display:flex;justify-content:space-between;align-items:baseline"><span style="font:600 15px 'Space Grotesk',sans-serif;color:#fbf1c7">Chromatic Metal</span><span style="font:600 13px 'JetBrains Mono',monospace;color:#ebdbb2">×250</span></div>
+    <div style="display:flex;gap:8px;align-items:center"><span style="height:22px;display:inline-flex;align-items:center;padding:0 8px;background:#32302f;border:1px solid #504945;border-radius:2px;font:600 10.5px 'JetBrains Mono',monospace;color:#ebdbb2">◇ REFINE</span>
+    <div style="display:flex;border:1px solid #504945;border-radius:2px;overflow:hidden"><span style="height:24px;display:inline-flex;align-items:center;padding:0 10px;background:#32302f;color:#a89984;font:500 11.5px 'Space Grotesk',sans-serif">craft</span><span style="height:24px;display:inline-flex;align-items:center;padding:0 10px;background:rgba(131,165,152,.18);box-shadow:inset 0 -2px 0 #83a598;color:#aecfc4;font:600 11.5px 'Space Grotesk',sans-serif">refine</span></div></div>
+  </div>
+  <div style="background:#282828;border:1px solid #32302f;border-radius:4px;padding:12px 14px;display:flex;flex-direction:column;gap:7px">
+    <div style="display:grid;grid-template-columns:32px 1fr 66px;gap:8px;align-items:center;font:10.5px 'JetBrains Mono',monospace">
+      <span style="color:#a89984">GEN</span><div style="height:7px;background:#141617"><div style="width:58%;height:100%;background:#83a598"></div></div><span style="color:#ebdbb2;text-align:right">300 kPs</span>
+      <span style="color:#a89984">DRAW</span><div style="height:7px;background:#141617;position:relative"><div style="width:58%;height:100%;background:#a89984"></div><div style="position:absolute;left:58%;top:0;width:16%;height:100%;background:#fb4934"></div></div><span style="color:#fb4934;text-align:right">380 kPs</span>
+    </div>
+    <div style="font:11.5px 'Space Grotesk',sans-serif;color:#fb4934">⚠ build 1 × EM generator (+110 kPs)</div>
+  </div>
+  <div style="display:flex;gap:8px"><button style="height:34px;padding:0 14px;background:#fabd2f;border:1px solid #b57614;border-radius:2px;color:#1d2021;font:600 13px 'Space Grotesk',sans-serif;cursor:pointer">Recompute</button><button style="height:34px;padding:0 14px;background:#32302f;border:1px solid #504945;border-radius:2px;color:#ebdbb2;font:500 13px 'Space Grotesk',sans-serif;cursor:pointer">Share</button><span style="align-self:center;font:500 13px 'Space Grotesk',sans-serif;color:#83a598;margin-left:4px">view tree →</span></div>
+</div>
+<div class="dv-note">Harder contrast (bg0_h #1d2021), yellow #fabd2f as the interactive accent, blue #83a598 as secondary. Reads more "instrument panel"; yellow buttons are very visible but flirt with the warn color — if picked, warnings move to orange.</div>
+</div>
+
+</div>
+<div class="dv-note" style="max-width:760px;margin-top:20px">Gruvbox's own 6 bright colors (red, green, yellow, blue, purple, aqua) are a natural fit for the base-identity palette — minus whichever two get spent on accent/state. E.g. <a class="dv-oid" href="#4a">4a</a> spends orange + aqua + red, leaving green/yellow/blue/purple + neutral gray + a mixed 6th for base frames; the CB/contrast math gets re-run either way.</div>
+<p class="dv-next">Try next: "go with <a class="dv-oid" href="#4a">4a</a>, rebuild the token sheet" · "<a class="dv-oid" href="#4a">4a</a> but keep coral from <a class="dv-oid" href="#3a">3a</a>" · "show the full base palette in gruvbox"</p>
+</section>
+<section class="dv-turn" id="t3">
+<div class="dv-thd"><a class="dv-tid" href="#t3">3</a><span class="dv-tname">Color scheme variants — same components, four palettes. <a class="dv-oid" href="#3a">3a</a> is the current theme for comparison.</span></div>
+<div class="dv-opts">
+
+<div class="dv-opt" id="3a">
+<div class="dv-olabel"><a class="dv-oid" href="#3a">3a</a>Deep Space — navy · coral · teal (current)</div>
+<div class="dv-card" style="width:350px;background:#0b0e15;background-image:repeating-linear-gradient(0deg,rgba(200,220,255,.016) 0 1px,transparent 1px 3px);padding:20px;display:flex;flex-direction:column;gap:14px">
+  <div style="font:700 18px 'Chakra Petch',sans-serif;letter-spacing:.05em;color:#edf2fc">STASIS DEVICE <span style="color:#8391ad;font-size:13px">×1</span></div>
+  <div style="font:500 11.5px 'JetBrains Mono',monospace;color:#43b5a8">3 BASES · 4,850 kPs · ~6h 30m/CYCLE</div>
+  <div style="background:#161d2e;border:3px solid #7cc4e0;border-radius:4px;padding:12px 14px;display:flex;flex-direction:column;gap:8px">
+    <div style="display:flex;justify-content:space-between;align-items:baseline"><span style="font:600 15px 'Space Grotesk',sans-serif;color:#edf2fc">Chromatic Metal</span><span style="font:600 13px 'JetBrains Mono',monospace;color:#c8d2e8">×250</span></div>
+    <div style="display:flex;gap:8px;align-items:center"><span style="height:22px;display:inline-flex;align-items:center;padding:0 8px;background:#1a2236;border:1px solid #273250;border-radius:2px;font:600 10.5px 'JetBrains Mono',monospace;color:#c8d2e8">◇ REFINE</span>
+    <div style="display:flex;border:1px solid #273250;border-radius:2px;overflow:hidden"><span style="height:24px;display:inline-flex;align-items:center;padding:0 10px;background:#1a2236;color:#8391ad;font:500 11.5px 'Space Grotesk',sans-serif">craft</span><span style="height:24px;display:inline-flex;align-items:center;padding:0 10px;background:rgba(67,181,168,.16);box-shadow:inset 0 -2px 0 #43b5a8;color:#78ded0;font:600 11.5px 'Space Grotesk',sans-serif">refine</span></div></div>
+  </div>
+  <div style="background:#161d2e;border:1px solid #1e2740;border-radius:4px;padding:12px 14px;display:flex;flex-direction:column;gap:7px">
+    <div style="display:grid;grid-template-columns:32px 1fr 66px;gap:8px;align-items:center;font:10.5px 'JetBrains Mono',monospace">
+      <span style="color:#8391ad">GEN</span><div style="height:7px;background:#0b0e15"><div style="width:58%;height:100%;background:#43b5a8"></div></div><span style="color:#c8d2e8;text-align:right">300 kPs</span>
+      <span style="color:#8391ad">DRAW</span><div style="height:7px;background:#0b0e15;position:relative"><div style="width:58%;height:100%;background:#8391ad"></div><div style="position:absolute;left:58%;top:0;width:16%;height:100%;background:#e2614b"></div></div><span style="color:#ff8f76;text-align:right">380 kPs</span>
+    </div>
+    <div style="font:11.5px 'Space Grotesk',sans-serif;color:#ff8f76">⚠ build 1 × EM generator (+110 kPs)</div>
+  </div>
+  <div style="display:flex;gap:8px"><button style="height:34px;padding:0 14px;background:#e2614b;border:1px solid #9c4234;border-radius:2px;color:#fff;font:600 13px 'Space Grotesk',sans-serif;cursor:pointer">Recompute</button><button style="height:34px;padding:0 14px;background:#1a2236;border:1px solid #273250;border-radius:2px;color:#c8d2e8;font:500 13px 'Space Grotesk',sans-serif;cursor:pointer">Share</button><span style="align-self:center;font:500 13px 'Space Grotesk',sans-serif;color:#43b5a8;margin-left:4px">view tree →</span></div>
+</div>
+<div class="dv-note">Cool, quiet, blue-leaning. Coral pops hard against navy; teal reads calm. Closest to the brief's stated direction.</div>
+</div>
+
+<div class="dv-opt" id="3b">
+<div class="dv-olabel"><a class="dv-oid" href="#3b">3b</a>Ion Storm — violet charcoal · raspberry · cyan</div>
+<div class="dv-card" style="width:350px;background:#0e0c16;background-image:repeating-linear-gradient(0deg,rgba(215,205,255,.018) 0 1px,transparent 1px 3px);padding:20px;display:flex;flex-direction:column;gap:14px">
+  <div style="font:700 18px 'Chakra Petch',sans-serif;letter-spacing:.05em;color:#efecfc">STASIS DEVICE <span style="color:#8d87b0;font-size:13px">×1</span></div>
+  <div style="font:500 11.5px 'JetBrains Mono',monospace;color:#4aaece">3 BASES · 4,850 kPs · ~6h 30m/CYCLE</div>
+  <div style="background:#1c1833;border:3px solid #6fc0dc;border-radius:4px;padding:12px 14px;display:flex;flex-direction:column;gap:8px">
+    <div style="display:flex;justify-content:space-between;align-items:baseline"><span style="font:600 15px 'Space Grotesk',sans-serif;color:#efecfc">Chromatic Metal</span><span style="font:600 13px 'JetBrains Mono',monospace;color:#cfcbe8">×250</span></div>
+    <div style="display:flex;gap:8px;align-items:center"><span style="height:22px;display:inline-flex;align-items:center;padding:0 8px;background:#221d3d;border:1px solid #322b55;border-radius:2px;font:600 10.5px 'JetBrains Mono',monospace;color:#cfcbe8">◇ REFINE</span>
+    <div style="display:flex;border:1px solid #322b55;border-radius:2px;overflow:hidden"><span style="height:24px;display:inline-flex;align-items:center;padding:0 10px;background:#221d3d;color:#8d87b0;font:500 11.5px 'Space Grotesk',sans-serif">craft</span><span style="height:24px;display:inline-flex;align-items:center;padding:0 10px;background:rgba(74,174,206,.16);box-shadow:inset 0 -2px 0 #4aaece;color:#7fd6f2;font:600 11.5px 'Space Grotesk',sans-serif">refine</span></div></div>
+  </div>
+  <div style="background:#1c1833;border:1px solid #241f42;border-radius:4px;padding:12px 14px;display:flex;flex-direction:column;gap:7px">
+    <div style="display:grid;grid-template-columns:32px 1fr 66px;gap:8px;align-items:center;font:10.5px 'JetBrains Mono',monospace">
+      <span style="color:#8d87b0">GEN</span><div style="height:7px;background:#0e0c16"><div style="width:58%;height:100%;background:#4aaece"></div></div><span style="color:#cfcbe8;text-align:right">300 kPs</span>
+      <span style="color:#8d87b0">DRAW</span><div style="height:7px;background:#0e0c16;position:relative"><div style="width:58%;height:100%;background:#8d87b0"></div><div style="position:absolute;left:58%;top:0;width:16%;height:100%;background:#e0567a"></div></div><span style="color:#ff86a4;text-align:right">380 kPs</span>
+    </div>
+    <div style="font:11.5px 'Space Grotesk',sans-serif;color:#ff86a4">⚠ build 1 × EM generator (+110 kPs)</div>
+  </div>
+  <div style="display:flex;gap:8px"><button style="height:34px;padding:0 14px;background:#e0567a;border:1px solid #9c3a55;border-radius:2px;color:#fff;font:600 13px 'Space Grotesk',sans-serif;cursor:pointer">Recompute</button><button style="height:34px;padding:0 14px;background:#221d3d;border:1px solid #322b55;border-radius:2px;color:#cfcbe8;font:500 13px 'Space Grotesk',sans-serif;cursor:pointer">Share</button><span style="align-self:center;font:500 13px 'Space Grotesk',sans-serif;color:#4aaece;margin-left:4px">view tree →</span></div>
+</div>
+<div class="dv-note">Nebula-purple, more saturated and "space anomaly". Raspberry accent is louder than coral; cyan secondary is icier. Most stylized of the four.</div>
+</div>
+
+<div class="dv-opt" id="3c">
+<div class="dv-olabel"><a class="dv-oid" href="#3c">3c</a>Anomaly Terminal — green-black · amber · phosphor</div>
+<div class="dv-card" style="width:350px;background:#0a100c;background-image:repeating-linear-gradient(0deg,rgba(190,240,205,.02) 0 1px,transparent 1px 3px);padding:20px;display:flex;flex-direction:column;gap:14px">
+  <div style="font:700 18px 'Chakra Petch',sans-serif;letter-spacing:.05em;color:#eaf6ec">STASIS DEVICE <span style="color:#83a18a;font-size:13px">×1</span></div>
+  <div style="font:500 11.5px 'JetBrains Mono',monospace;color:#52c184">3 BASES · 4,850 kPs · ~6h 30m/CYCLE</div>
+  <div style="background:#15231a;border:3px solid #7cc4e0;border-radius:4px;padding:12px 14px;display:flex;flex-direction:column;gap:8px">
+    <div style="display:flex;justify-content:space-between;align-items:baseline"><span style="font:600 15px 'Space Grotesk',sans-serif;color:#eaf6ec">Chromatic Metal</span><span style="font:600 13px 'JetBrains Mono',monospace;color:#c6dcc9">×250</span></div>
+    <div style="display:flex;gap:8px;align-items:center"><span style="height:22px;display:inline-flex;align-items:center;padding:0 8px;background:#1a2b20;border:1px solid #27402f;border-radius:2px;font:600 10.5px 'JetBrains Mono',monospace;color:#c6dcc9">◇ REFINE</span>
+    <div style="display:flex;border:1px solid #27402f;border-radius:2px;overflow:hidden"><span style="height:24px;display:inline-flex;align-items:center;padding:0 10px;background:#1a2b20;color:#83a18a;font:500 11.5px 'Space Grotesk',sans-serif">craft</span><span style="height:24px;display:inline-flex;align-items:center;padding:0 10px;background:rgba(82,193,132,.16);box-shadow:inset 0 -2px 0 #52c184;color:#8ae2ae;font:600 11.5px 'Space Grotesk',sans-serif">refine</span></div></div>
+  </div>
+  <div style="background:#15231a;border:1px solid #1c2f22;border-radius:4px;padding:12px 14px;display:flex;flex-direction:column;gap:7px">
+    <div style="display:grid;grid-template-columns:32px 1fr 66px;gap:8px;align-items:center;font:10.5px 'JetBrains Mono',monospace">
+      <span style="color:#83a18a">GEN</span><div style="height:7px;background:#0a100c"><div style="width:58%;height:100%;background:#52c184"></div></div><span style="color:#c6dcc9;text-align:right">300 kPs</span>
+      <span style="color:#83a18a">DRAW</span><div style="height:7px;background:#0a100c;position:relative"><div style="width:58%;height:100%;background:#83a18a"></div><div style="position:absolute;left:58%;top:0;width:16%;height:100%;background:#dfa03f"></div></div><span style="color:#ffc46e;text-align:right">380 kPs</span>
+    </div>
+    <div style="font:11.5px 'Space Grotesk',sans-serif;color:#ffc46e">⚠ build 1 × EM generator (+110 kPs)</div>
+  </div>
+  <div style="display:flex;gap:8px"><button style="height:34px;padding:0 14px;background:#dfa03f;border:1px solid #9c6d24;border-radius:2px;color:#1a1206;font:600 13px 'Space Grotesk',sans-serif;cursor:pointer">Recompute</button><button style="height:34px;padding:0 14px;background:#1a2b20;border:1px solid #27402f;border-radius:2px;color:#c6dcc9;font:500 13px 'Space Grotesk',sans-serif;cursor:pointer">Share</button><span style="align-self:center;font:500 13px 'Space Grotesk',sans-serif;color:#52c184;margin-left:4px">view tree →</span></div>
+</div>
+<div class="dv-note">CRT-terminal green, amber for danger. Warmest "retro computer" read — closest to old freighter-console vibes.</div>
+</div>
+
+<div class="dv-opt" id="3d">
+<div class="dv-olabel"><a class="dv-oid" href="#3d">3d</a>Redline — warm graphite · ember · ice</div>
+<div class="dv-card" style="width:350px;background:#121012;background-image:repeating-linear-gradient(0deg,rgba(255,225,210,.015) 0 1px,transparent 1px 3px);padding:20px;display:flex;flex-direction:column;gap:14px">
+  <div style="font:700 18px 'Chakra Petch',sans-serif;letter-spacing:.05em;color:#f4ede9">STASIS DEVICE <span style="color:#a09598;font-size:13px">×1</span></div>
+  <div style="font:500 11.5px 'JetBrains Mono',monospace;color:#6fb7c9">3 BASES · 4,850 kPs · ~6h 30m/CYCLE</div>
+  <div style="background:#201c20;border:3px solid #7cc4e0;border-radius:4px;padding:12px 14px;display:flex;flex-direction:column;gap:8px">
+    <div style="display:flex;justify-content:space-between;align-items:baseline"><span style="font:600 15px 'Space Grotesk',sans-serif;color:#f4ede9">Chromatic Metal</span><span style="font:600 13px 'JetBrains Mono',monospace;color:#ddd4d2">×250</span></div>
+    <div style="display:flex;gap:8px;align-items:center"><span style="height:22px;display:inline-flex;align-items:center;padding:0 8px;background:#282328;border:1px solid #362f33;border-radius:2px;font:600 10.5px 'JetBrains Mono',monospace;color:#ddd4d2">◇ REFINE</span>
+    <div style="display:flex;border:1px solid #362f33;border-radius:2px;overflow:hidden"><span style="height:24px;display:inline-flex;align-items:center;padding:0 10px;background:#282328;color:#a09598;font:500 11.5px 'Space Grotesk',sans-serif">craft</span><span style="height:24px;display:inline-flex;align-items:center;padding:0 10px;background:rgba(111,183,201,.16);box-shadow:inset 0 -2px 0 #6fb7c9;color:#a5dcec;font:600 11.5px 'Space Grotesk',sans-serif">refine</span></div></div>
+  </div>
+  <div style="background:#201c20;border:1px solid #2a2529;border-radius:4px;padding:12px 14px;display:flex;flex-direction:column;gap:7px">
+    <div style="display:grid;grid-template-columns:32px 1fr 66px;gap:8px;align-items:center;font:10.5px 'JetBrains Mono',monospace">
+      <span style="color:#a09598">GEN</span><div style="height:7px;background:#121012"><div style="width:58%;height:100%;background:#6fb7c9"></div></div><span style="color:#ddd4d2;text-align:right">300 kPs</span>
+      <span style="color:#a09598">DRAW</span><div style="height:7px;background:#121012;position:relative"><div style="width:58%;height:100%;background:#a09598"></div><div style="position:absolute;left:58%;top:0;width:16%;height:100%;background:#e26a3c"></div></div><span style="color:#ff9a6a;text-align:right">380 kPs</span>
+    </div>
+    <div style="font:11.5px 'Space Grotesk',sans-serif;color:#ff9a6a">⚠ build 1 × EM generator (+110 kPs)</div>
+  </div>
+  <div style="display:flex;gap:8px"><button style="height:34px;padding:0 14px;background:#e26a3c;border:1px solid #a04a26;border-radius:2px;color:#fff;font:600 13px 'Space Grotesk',sans-serif;cursor:pointer">Recompute</button><button style="height:34px;padding:0 14px;background:#282328;border:1px solid #362f33;border-radius:2px;color:#ddd4d2;font:500 13px 'Space Grotesk',sans-serif;cursor:pointer">Share</button><span style="align-self:center;font:500 13px 'Space Grotesk',sans-serif;color:#6fb7c9;margin-left:4px">view tree →</span></div>
+</div>
+<div class="dv-note">Nearly-neutral warm dark with ember orange — closest to NMS's own warm-red UI energy without imitating it. Ice-blue secondary keeps meters cool.</div>
+</div>
+
+</div>
+<div class="dv-note" style="max-width:760px;margin-top:20px">All four keep the same rules: accent = interactive + deficit, secondary = ok/selection, base identity owns borders, monochrome method badges. The 6-color base palette was validated against <a class="dv-oid" href="#3a">3a</a>'s backgrounds; picking <a class="dv-oid" href="#3b">3b</a>–<a class="dv-oid" href="#3d">3d</a> means re-running the contrast/CB math against the new backgrounds (fast — the token sheet computes it live).</div>
+<p class="dv-next">Try next: "keep <a class="dv-oid" href="#3a">3a</a>" · "go with <a class="dv-oid" href="#3c">3c</a>, re-run the palette math" · "mix <a class="dv-oid" href="#3d">3d</a>'s ember accent into <a class="dv-oid" href="#3a">3a</a>"</p>
+</section>
+</x-dc>
+</body>
+</html>

--- a/docs/design/explorations/support.js
+++ b/docs/design/explorations/support.js
@@ -1,0 +1,1911 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    if (!window.__resources) {
+      fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+        const raw = t ? parseDcText(t) : null;
+        if (raw?.template) runtime.updateHtml(rootName, raw.template);
+      }).catch(() => {
+      });
+    }
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu",
+    onmousemove: "onMouseMove",
+    onmouseover: "onMouseOver",
+    onmouseout: "onMouseOut",
+    onpointerdown: "onPointerDown",
+    onpointerup: "onPointerUp",
+    onpointermove: "onPointerMove",
+    onpointerenter: "onPointerEnter",
+    onpointerleave: "onPointerLeave",
+    onpointercancel: "onPointerCancel",
+    onpointerover: "onPointerOver",
+    onpointerout: "onPointerOut",
+    ongotpointercapture: "onGotPointerCapture",
+    onlostpointercapture: "onLostPointerCapture",
+    ontouchstart: "onTouchStart",
+    ontouchend: "onTouchEnd",
+    ontouchmove: "onTouchMove",
+    ontouchcancel: "onTouchCancel",
+    ondragstart: "onDragStart",
+    ondragend: "onDragEnd",
+    ondragenter: "onDragEnter",
+    ondragleave: "onDragLeave",
+    ondragover: "onDragOver",
+    onanimationstart: "onAnimationStart",
+    onanimationend: "onAnimationEnd",
+    onanimationiteration: "onAnimationIteration",
+    ontransitionend: "onTransitionEnd"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCamelAttrs(html) {
+    return html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+  }
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = encodeCamelAttrs(html);
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  var SLIDE_ID_VALUE_RE = /^[0-9a-f]{8}$/;
+  var DECK_CONTROL_FLOW_RE = /^(sc-if|sc-for|sc-else|dc-import|x-import)$/;
+  var DECK_AUX_RE = /^(template|script|style|sc-helmet|helmet)$/;
+  function isDeckMountTag(el) {
+    if (el.localName === "deck-stage") return true;
+    return el.localName === "x-import" && (el.getAttribute("component-from-global-scope") || "") === "deck-stage";
+  }
+  function walkDeckChildren(el, host) {
+    const pairs = [...el.childNodes].map((c) => ({ c, b: walk(c, host) })).filter((p) => p.b !== null);
+    const kids = pairs.map((p) => p.b);
+    const seen = /* @__PURE__ */ new Set();
+    const wsSeen = /* @__PURE__ */ new Map();
+    const keys = [];
+    const nextSlideId = new Array(pairs.length);
+    {
+      let upcoming = null;
+      for (let j = pairs.length - 1; j >= 0; j--) {
+        const n = pairs[j].c;
+        if (n.nodeType === Node.ELEMENT_NODE) {
+          const t = n.localName;
+          upcoming = !DECK_AUX_RE.test(t) && !DECK_CONTROL_FLOW_RE.test(t) ? n.getAttribute("data-om-slide-id") : null;
+        }
+        nextSlideId[j] = upcoming;
+      }
+    }
+    for (let j = 0; j < pairs.length; j++) {
+      const { c } = pairs[j];
+      if (c.nodeType === Node.TEXT_NODE) {
+        if ((c.nodeValue ?? "").trim() === "") {
+          const base = nextSlideId[j] ? "omid-ws:" + nextSlideId[j] : "omid-ws:aux";
+          const n = wsSeen.get(base) ?? 0;
+          wsSeen.set(base, n + 1);
+          keys.push(n === 0 ? base : base + ":" + n);
+          continue;
+        }
+        return { kids, keys: null };
+      }
+      if (c.nodeType !== Node.ELEMENT_NODE) {
+        keys.push(j);
+        continue;
+      }
+      const child = c;
+      const tag = child.localName;
+      if (DECK_AUX_RE.test(tag)) {
+        keys.push(j);
+        continue;
+      }
+      if (DECK_CONTROL_FLOW_RE.test(tag)) return { kids, keys: null };
+      const v = child.getAttribute("data-om-slide-id");
+      if (!v || !SLIDE_ID_VALUE_RE.test(v) || seen.has(v)) {
+        return { kids, keys: null };
+      }
+      seen.add(v);
+      keys.push("omid:" + v);
+    }
+    return { kids, keys };
+  }
+  function renderDeckKids(kids, kidKeys, vals, ctx) {
+    return kids.map((b, j) => {
+      const k = kidKeys ? kidKeys[j] : j;
+      const out = b(vals, ctx, k);
+      return kidKeys != null && typeof out === "string" ? h(getReact().Fragment, { key: k }, out) : out;
+    });
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || (el.getAttribute("component-from-global-scope") ? "" : el.getAttribute("src") || el.getAttribute("import") || "");
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const deckKeyed = hasContent && isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : hasContent ? walkChildren(el, host) : [];
+    const kidKeys = deckKeyed?.keys ?? null;
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) {
+        props.children = renderDeckKids(kids, kidKeys, vals, ctx);
+      }
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const deckKeyed = isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : walkChildren(el, host);
+    const kidKeys = deckKeyed?.keys ?? null;
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...renderDeckKids(kids, kidKeys, vals, ctx));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/bundled.ts
+  function bundledBlob(url) {
+    const blobs = window.__resourceBlobs;
+    const b = blobs ? blobs[url.split("#")[0]] : void 0;
+    return b instanceof Blob ? b : null;
+  }
+
+  // src/cdn.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  function cdnScriptFor(url, sri) {
+    const res = window.__resources;
+    const v = res ? res[url] : void 0;
+    return typeof v === "string" && v ? { src: v } : { src: url, integrity: sri };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      const babel = cdnScriptFor(BABEL_URL, BABEL_SRI);
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = babel.src;
+        if (babel.integrity) {
+          s.integrity = babel.integrity;
+          s.crossOrigin = "anonymous";
+        }
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => {
+        const pre = bundledBlob(url);
+        if (pre) return pre.text();
+        return fetch(url).then((r) => {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.text();
+        });
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            if (tag === "LINK") {
+              const rel = (child.getAttribute("rel") || "").toLowerCase().split(/\s+/);
+              const href = (child.getAttribute("href") || "").trim();
+              const res = window.__resources;
+              const pre = res && rel.includes("stylesheet") && !rel.includes("alternate") ? res[href] : void 0;
+              const blob = typeof pre === "string" && pre ? bundledBlob(pre) : null;
+              if (blob) {
+                const el = doc.createElement("style");
+                if (child.hasAttribute("disabled")) {
+                  el.setAttribute("media", "not all");
+                } else if (child.getAttribute("media")) {
+                  el.setAttribute("media", child.getAttribute("media"));
+                }
+                if (child.getAttribute("title"))
+                  el.setAttribute("title", child.getAttribute("title"));
+                void blob.text().then((css) => {
+                  el.textContent = css;
+                });
+                doc.head.appendChild(el);
+                continue;
+              }
+            }
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function scanUnquotedUrl(css, i) {
+    if (css[i] !== "u" && css[i] !== "U" || css.slice(i, i + 4).toLowerCase() !== "url(" || /[a-z0-9_-]/i.test(css[i - 1] ?? "")) {
+      return -1;
+    }
+    let j = i + 4;
+    while (j < css.length && /\s/.test(css[j])) j++;
+    if (css[j] === '"' || css[j] === "'") return -1;
+    while (j < css.length && css[j] !== ")") {
+      if (css[j] === "\\") j++;
+      j++;
+    }
+    return j < css.length ? j + 1 : css.length;
+  }
+  function stripComments(css) {
+    let out = "";
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") {
+          out += c + (css[i + 1] ?? "");
+          i++;
+          continue;
+        }
+        if (c === quote) quote = "";
+        out += c;
+      } else if (c === "'" || c === '"') {
+        quote = c;
+        out += c;
+      } else if (c === "/" && css[i + 1] === "*") {
+        const end = css.indexOf("*/", i + 2);
+        i = end === -1 ? css.length : end + 1;
+        out += " ";
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end === -1) out += c;
+        else {
+          out += css.slice(i, end);
+          i = end - 1;
+        }
+      }
+    }
+    return out;
+  }
+  function importantify(css) {
+    css = stripComments(css);
+    const decls = [];
+    let start = 0;
+    let depth = 0;
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") i++;
+        else if (c === quote) quote = "";
+      } else if (c === "'" || c === '"') quote = c;
+      else if (c === "(") depth++;
+      else if (c === ")") depth = Math.max(0, depth - 1);
+      else if (c === ";" && depth === 0) {
+        decls.push(css.slice(start, i));
+        start = i + 1;
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end !== -1) i = end - 1;
+      }
+    }
+    decls.push(css.slice(start));
+    return decls.map((d) => d.trim()).filter(Boolean).map((d) => /!\s*important$/i.test(d) ? d : d + " !important").join(";");
+  }
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const isPseudoElement = pseudo === "before" || pseudo === "after";
+      const sel = isPseudoElement ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(
+        sel + "{" + (isPseudoElement ? css : importantify(css)) + "}",
+        el.sheet.cssRules.length
+      );
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      const res = window.__resources;
+      const pre = res ? res[url] : void 0;
+      const target = typeof pre === "string" && pre ? pre : url;
+      const blob = bundledBlob(target);
+      (blob ? blob.text() : fetch(target).then((res2) => {
+        if (!res2.ok) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '" failed:',
+            url,
+            "returned",
+            res2.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res2.text();
+      })).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '":',
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          '[dc-runtime] sibling fetch for "' + name + '" threw:',
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/stream-state.ts
+  function createStreamTracker(staleMs = 6e4, now = Date.now) {
+    const since = /* @__PURE__ */ new Map();
+    const liveOne = (n) => {
+      const t = since.get(n);
+      if (t === void 0) return false;
+      if (now() - t > staleMs) {
+        since.delete(n);
+        return false;
+      }
+      return true;
+    };
+    return {
+      push(name, streaming, viewportKey) {
+        if (viewportKey === "dc-model") return;
+        if (streaming) since.set(name, now());
+        else since.delete(name);
+      },
+      live(name) {
+        if (name !== void 0) return liveOne(name);
+        for (const n of [...since.keys()]) if (liveOne(n)) return true;
+        return false;
+      }
+    };
+  }
+
+  // src/index.ts
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      if (integrity) {
+        s.integrity = integrity;
+        s.crossOrigin = "anonymous";
+      }
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    const react = cdnScriptFor(REACT_URL, REACT_SRI);
+    const reactDom = cdnScriptFor(REACT_DOM_URL, REACT_DOM_SRI);
+    return Promise.all([
+      loadScript(react.src, react.integrity),
+      loadScript(reactDom.src, reactDom.integrity)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const streams = createStreamTracker();
+    const api = {
+      __dcUpdate: (name, kind, content, streaming, viewportKey) => {
+        streams.push(name, streaming, viewportKey);
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcStreaming: (name) => streams.live(name),
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`sc-camel-*` attrs,
+       *  `<sc-raw-*>`/`<sc-helmet>` tags); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();

--- a/docs/design/theme/Theme Tokens.dc.html
+++ b/docs/design/theme/Theme Tokens.dc.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&amp;family=Space+Grotesk:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;600&amp;display=swap" rel="stylesheet">
+<style>body{margin:0;background:#282828;color:#ebdbb2;font-family:'Space Grotesk',sans-serif;background-image:repeating-linear-gradient(0deg,rgba(251,241,199,.018) 0 1px,transparent 1px 3px)}a{color:#8ec07c}a:hover{color:#b8db9c}</style>
+</helmet>
+<div style="max-width:1100px;margin:0 auto;padding:44px 48px 80px;display:flex;flex-direction:column;gap:44px">
+
+<header style="display:flex;flex-direction:column;gap:8px;border-bottom:1px solid #504945;padding-bottom:24px">
+  <div style="font:700 26px 'Chakra Petch',sans-serif;letter-spacing:.06em;color:#fbf1c7">NMS BASE &amp; RESOURCE PLANNER — THEME + TOKENS</div>
+  <div style="font:400 12px 'JetBrains Mono',monospace;color:#a89984">deliverable 1 of 4 · gruvbox (user-selected, deviation logged) · validation tables computed live from token hexes · spec: handoff.md, spec wins</div>
+</header>
+
+<section style="display:flex;flex-direction:column;gap:16px">
+  <div style="display:flex;align-items:center;gap:12px"><span style="font:600 11.5px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#8ec07c">01 · SURFACES &amp; CHROME</span><span style="flex:1;height:1px;background:#3c3836"></span></div>
+  <div style="display:flex;flex-wrap:wrap;gap:14px">
+    <div style="display:flex;flex-direction:column;gap:6px;width:118px"><div style="height:54px;background:#282828;border:1px solid #504945;border-radius:2px"></div><div style="font:500 11px 'JetBrains Mono',monospace;color:#ebdbb2">--bg · #282828</div><div style="font:11px 'Space Grotesk',sans-serif;color:#a89984">app background (bg0)</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:118px"><div style="height:54px;background:#1d2021;border:1px solid #504945;border-radius:2px"></div><div style="font:500 11px 'JetBrains Mono',monospace;color:#ebdbb2">--bg-canvas · #1d2021</div><div style="font:11px 'Space Grotesk',sans-serif;color:#a89984">tree canvas, tracks</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:118px"><div style="height:54px;background:#32302f;border:1px solid #504945;border-radius:2px"></div><div style="font:500 11px 'JetBrains Mono',monospace;color:#ebdbb2">--panel · #32302f</div><div style="font:11px 'Space Grotesk',sans-serif;color:#a89984">panels, base cards</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:118px"><div style="height:54px;background:#3c3836;border:1px solid #504945;border-radius:2px"></div><div style="font:500 11px 'JetBrains Mono',monospace;color:#ebdbb2">--panel-raised · #3c3836</div><div style="font:11px 'Space Grotesk',sans-serif;color:#a89984">rows on panels</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:118px"><div style="height:54px;background:#45403d;border:1px solid #504945;border-radius:2px"></div><div style="font:500 11px 'JetBrains Mono',monospace;color:#ebdbb2">--input-bg · #45403d</div><div style="font:11px 'Space Grotesk',sans-serif;color:#a89984">fields, segmented</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:118px"><div style="height:54px;background:#32302f;border:1px solid #504945;border-radius:2px;display:flex;align-items:center;justify-content:center"><span style="width:70%;height:1px;background:#504945"></span></div><div style="font:500 11px 'JetBrains Mono',monospace;color:#ebdbb2">--border · #504945</div><div style="font:11px 'Space Grotesk',sans-serif;color:#a89984">default border</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:118px"><div style="height:54px;background:#32302f;border:1px solid #504945;border-radius:2px;display:flex;align-items:center;justify-content:center"><span style="width:70%;height:1px;background:#453f3c"></span></div><div style="font:500 11px 'JetBrains Mono',monospace;color:#ebdbb2">--border-soft · #453f3c</div><div style="font:11px 'Space Grotesk',sans-serif;color:#a89984">quiet borders</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:118px"><div style="height:54px;background:#32302f;border:1px solid #504945;border-radius:2px;display:flex;align-items:center;justify-content:center"><span style="width:70%;height:1px;background:#3a3634"></span></div><div style="font:500 11px 'JetBrains Mono',monospace;color:#ebdbb2">--divider · #3a3634</div><div style="font:11px 'Space Grotesk',sans-serif;color:#a89984">hairlines</div></div>
+  </div>
+</section>
+
+<section style="display:flex;flex-direction:column;gap:16px">
+  <div style="display:flex;align-items:center;gap:12px"><span style="font:600 11.5px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#8ec07c">02 · TEXT</span><span style="flex:1;height:1px;background:#3c3836"></span></div>
+  <div style="display:flex;flex-wrap:wrap;gap:14px">
+    <div style="background:#32302f;border:1px solid #453f3c;border-radius:4px;padding:14px 16px;width:220px"><div style="font:500 16px 'Space Grotesk',sans-serif;color:#ebdbb2">Chromatic Metal</div><div style="font:11px 'JetBrains Mono',monospace;color:#a89984;margin-top:6px">--text #ebdbb2 · 9.6:1</div></div>
+    <div style="background:#32302f;border:1px solid #453f3c;border-radius:4px;padding:14px 16px;width:220px"><div style="font:600 16px 'Space Grotesk',sans-serif;color:#fbf1c7">250 required</div><div style="font:11px 'JetBrains Mono',monospace;color:#a89984;margin-top:6px">--text-bright #fbf1c7 · headings, values</div></div>
+    <div style="background:#32302f;border:1px solid #453f3c;border-radius:4px;padding:14px 16px;width:220px"><div style="font:500 16px 'Space Grotesk',sans-serif;color:#a89984">refined from Copper</div><div style="font:11px 'JetBrains Mono',monospace;color:#a89984;margin-top:6px">--text-muted #a89984 · 4.7:1 on --panel; on --panel-raised only ≥17px</div></div>
+    <div style="background:#32302f;border:1px solid #453f3c;border-radius:4px;padding:14px 16px;width:220px"><div style="font:500 18px 'Space Grotesk',sans-serif;color:#7c6f64">watermark / ≥18px only</div><div style="font:11px 'JetBrains Mono',monospace;color:#a89984;margin-top:6px">--text-dim #7c6f64 · 2.7:1 — decorative only, never unique info</div></div>
+  </div>
+</section>
+
+<section style="display:flex;flex-direction:column;gap:16px">
+  <div style="display:flex;align-items:center;gap:12px"><span style="font:600 11.5px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#8ec07c">03 · ACCENT &amp; STATE</span><span style="flex:1;height:1px;background:#3c3836"></span></div>
+  <div style="display:flex;flex-wrap:wrap;gap:14px">
+    <div style="display:flex;flex-direction:column;gap:6px;width:150px"><div style="height:54px;background:#fe8019;border-radius:2px"></div><div style="font:500 11px 'JetBrains Mono',monospace;color:#ebdbb2">--accent · #fe8019</div><div style="font:11px 'Space Grotesk',sans-serif;color:#a89984">interactive ONLY · 5.2:1</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:150px"><div style="height:54px;background:#ffa347;border-radius:2px"></div><div style="font:500 11px 'JetBrains Mono',monospace;color:#ebdbb2">--accent-hover · #ffa347</div><div style="font:11px 'Space Grotesk',sans-serif;color:#a89984">hover</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:150px"><div style="height:54px;background:#fb4934;border-radius:2px"></div><div style="font:500 11px 'JetBrains Mono',monospace;color:#ebdbb2">--danger · #fb4934</div><div style="font:11px 'Space Grotesk',sans-serif;color:#a89984">deficit, destructive · 3.8:1 — always with ⚠ + text</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:150px"><div style="height:54px;background:#8ec07c;border-radius:2px"></div><div style="font:500 11px 'JetBrains Mono',monospace;color:#ebdbb2">--ok · #8ec07c</div><div style="font:11px 'Space Grotesk',sans-serif;color:#a89984">ok, links, selection ring · 6.2:1</div></div>
+    <div style="display:flex;flex-direction:column;gap:6px;width:150px"><div style="height:54px;background:#d79921;border-radius:2px"></div><div style="font:500 11px 'JetBrains Mono',monospace;color:#ebdbb2">--warn · #d79921</div><div style="font:11px 'Space Grotesk',sans-serif;color:#a89984">unassigned warnings · 5.3:1</div></div>
+  </div>
+  <div style="font:12.5px 'Space Grotesk',sans-serif;color:#a89984;max-width:780px">Gruvbox has a real red, so unlike the navy scheme deficit gets <span style="color:#fb4934">--danger</span> and orange stays purely interactive. Aqua is ok/selection; neutral yellow warns. None of these may paint a border — borders belong to base identity (04). States use fill, outline (outboard) and ring (inboard).</div>
+</section>
+
+<section style="display:flex;flex-direction:column;gap:16px">
+  <div style="display:flex;align-items:center;gap:12px"><span style="font:600 11.5px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#8ec07c">04 · BASE ACCENT PALETTE — 6 CATEGORICAL IDENTITIES</span><span style="flex:1;height:1px;background:#3c3836"></span></div>
+  <div style="display:flex;flex-wrap:wrap;gap:14px">
+    <sc-for list="{{ palSwatches }}" as="sw" hint-placeholder-count="6">
+      <div style="display:flex;flex-direction:column;gap:6px;width:140px">
+        <div style="height:64px;border-radius:2px;border:3px solid {{ sw.shown }};background:#32302f;display:flex;align-items:center;justify-content:center"><span style="font:600 13px 'Space Grotesk',sans-serif;color:#fbf1c7">{{ sw.label }}</span></div>
+        <div style="font:500 11px 'JetBrains Mono',monospace;color:#ebdbb2">--base-{{ sw.idx }} {{ sw.name }} · {{ sw.hex }}</div>
+      </div>
+    </sc-for>
+  </div>
+  <div style="font:12px 'JetBrains Mono',monospace;color:#a89984">viewing: {{ simLabel }} — switch simulation in Tweaks to preview protanopia / deuteranopia</div>
+  <div style="display:grid;grid-template-columns:110px 90px repeat(3,110px) 90px;gap:2px 14px;background:#32302f;border:1px solid #453f3c;border-radius:4px;padding:16px 18px;font:12px 'JetBrains Mono',monospace;align-items:baseline">
+    <span style="color:#7c6f64;font-size:10.5px;letter-spacing:.1em">TOKEN</span><span style="color:#7c6f64;font-size:10.5px;letter-spacing:.1em">HEX</span><span style="color:#7c6f64;font-size:10.5px;letter-spacing:.1em">VS CANVAS</span><span style="color:#7c6f64;font-size:10.5px;letter-spacing:.1em">VS --BG</span><span style="color:#7c6f64;font-size:10.5px;letter-spacing:.1em">VS --PANEL</span><span style="color:#7c6f64;font-size:10.5px;letter-spacing:.1em">SC 1.4.11</span>
+    <sc-for list="{{ contrastRows }}" as="r" hint-placeholder-count="6">
+      <span style="color:#ebdbb2">{{ r.name }}</span><span style="color:#a89984">{{ r.hex }}</span><span style="color:#ebdbb2">{{ r.c0 }}</span><span style="color:#ebdbb2">{{ r.c1 }}</span><span style="color:#ebdbb2">{{ r.c2 }}</span><span style="color:{{ r.passColor }}">{{ r.pass }}</span>
+    </sc-for>
+  </div>
+  <div style="display:grid;grid-template-columns:90px repeat(6,72px);gap:2px 10px;background:#32302f;border:1px solid #453f3c;border-radius:4px;padding:16px 18px;font:12px 'JetBrains Mono',monospace;align-items:baseline">
+    <span style="color:#7c6f64;font-size:10.5px;letter-spacing:.1em">MIN ΔE*</span>
+    <sc-for list="{{ matrixHead }}" as="h" hint-placeholder-count="6"><span style="color:#7c6f64;font-size:10.5px;letter-spacing:.1em">{{ h.name }}</span></sc-for>
+    <sc-for list="{{ matrixCells }}" as="c" hint-placeholder-count="42"><span style="color:{{ c.color }}">{{ c.t }}</span></sc-for>
+  </div>
+  <div style="font:12.5px 'Space Grotesk',sans-serif;color:#a89984;max-width:840px">*Pairwise CIELAB ΔE76, minimum across Machado-2009 protanopia and deuteranopia simulations. Worst pair: <span style="color:#ebdbb2;font-family:'JetBrains Mono',monospace">{{ worstPair }}</span>; flag threshold &lt;20. Canon <b style="color:#ebdbb2">green #b8bb26 is excluded</b> — it collapses into yellow under deuteranopia (ΔE 5); orange and red are spent on interactive/danger; sand and gray fill those slots. Gruvbox's lighter backgrounds compress the gamut (every frame color must stay light enough for 3:1), so ΔE 21 is the honest floor. The base <b style="color:#ebdbb2">name</b> is always the primary identity (SC 1.4.1). <b style="color:#ebdbb2">Nothing but base identity may write to a border.</b></div>
+</section>
+
+<section style="display:flex;flex-direction:column;gap:16px">
+  <div style="display:flex;align-items:center;gap:12px"><span style="font:600 11.5px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#8ec07c">05 · TYPE</span><span style="flex:1;height:1px;background:#3c3836"></span></div>
+  <div style="display:flex;flex-wrap:wrap;gap:14px">
+    <div style="background:#32302f;border:1px solid #453f3c;border-radius:4px;padding:18px 20px;flex:1;min-width:280px">
+      <div style="font:700 24px 'Chakra Petch',sans-serif;letter-spacing:.05em;color:#fbf1c7">STASIS DEVICE</div>
+      <div style="font:11px 'JetBrains Mono',monospace;color:#a89984;margin-top:8px">Chakra Petch 600/700 · display, panel titles, rollup figure · floor 13px</div>
+    </div>
+    <div style="background:#32302f;border:1px solid #453f3c;border-radius:4px;padding:18px 20px;flex:1;min-width:280px">
+      <div style="font:400 16px 'Space Grotesk',sans-serif;color:#ebdbb2">Assign each leaf resource to a base; the card computes what to build.</div>
+      <div style="font:11px 'JetBrains Mono',monospace;color:#a89984;margin-top:8px">Space Grotesk 400/500/600 · body &amp; UI</div>
+    </div>
+    <div style="background:#32302f;border:1px solid #453f3c;border-radius:4px;padding:18px 20px;flex:1;min-width:280px">
+      <div style="font:500 16px 'JetBrains Mono',monospace;color:#ebdbb2;font-variant-numeric:tabular-nums">4,850 kPs · 2h 15m<br>1,024 kPs · 0h 40m</div>
+      <div style="font:11px 'JetBrains Mono',monospace;color:#a89984;margin-top:8px">JetBrains Mono + tabular-nums · every quantity, time, kPs · columns stay aligned as values recompute</div>
+    </div>
+  </div>
+  <div style="font:12px 'JetBrains Mono',monospace;color:#a89984">scale · 11.5 label (ls .12em caps) / 13 meta / 15 body / 17 emphasis / 20 h3 / 26 h2 / 34 display</div>
+</section>
+
+<section style="display:flex;flex-direction:column;gap:16px">
+  <div style="display:flex;align-items:center;gap:12px"><span style="font:600 11.5px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#8ec07c">06 · SPACING · RADIUS · CONTROL SCALE</span><span style="flex:1;height:1px;background:#3c3836"></span></div>
+  <div style="display:flex;align-items:flex-end;gap:14px">
+    <div style="display:flex;flex-direction:column;gap:4px;align-items:center"><div style="width:4px;height:4px;background:#8ec07c"></div><span style="font:10.5px 'JetBrains Mono',monospace;color:#a89984">4</span></div>
+    <div style="display:flex;flex-direction:column;gap:4px;align-items:center"><div style="width:8px;height:8px;background:#8ec07c"></div><span style="font:10.5px 'JetBrains Mono',monospace;color:#a89984">8</span></div>
+    <div style="display:flex;flex-direction:column;gap:4px;align-items:center"><div style="width:12px;height:12px;background:#8ec07c"></div><span style="font:10.5px 'JetBrains Mono',monospace;color:#a89984">12</span></div>
+    <div style="display:flex;flex-direction:column;gap:4px;align-items:center"><div style="width:16px;height:16px;background:#8ec07c"></div><span style="font:10.5px 'JetBrains Mono',monospace;color:#a89984">16</span></div>
+    <div style="display:flex;flex-direction:column;gap:4px;align-items:center"><div style="width:24px;height:24px;background:#8ec07c"></div><span style="font:10.5px 'JetBrains Mono',monospace;color:#a89984">24</span></div>
+    <div style="display:flex;flex-direction:column;gap:4px;align-items:center"><div style="width:32px;height:32px;background:#8ec07c"></div><span style="font:10.5px 'JetBrains Mono',monospace;color:#a89984">32</span></div>
+    <div style="display:flex;flex-direction:column;gap:4px;align-items:center"><div style="width:48px;height:48px;background:#8ec07c"></div><span style="font:10.5px 'JetBrains Mono',monospace;color:#a89984">48</span></div>
+    <div style="font:12px 'Space Grotesk',sans-serif;color:#a89984;margin-left:12px">radius: 2px controls · 4px panels</div>
+  </div>
+  <div style="font:12.5px 'Space Grotesk',sans-serif;color:#a89984;max-width:820px">One control scale: default step <span style="font-family:'JetBrains Mono',monospace;color:#ebdbb2">40px</span> = 10+10 pad + 18 line + 2 border, 15px font · small step <span style="font-family:'JetBrains Mono',monospace;color:#ebdbb2">30px</span> = 6+6+16+2, 13px font. A row never mixes steps. Coarse pointers grow square targets to 44px.</div>
+</section>
+
+<section style="display:flex;flex-direction:column;gap:16px">
+  <div style="display:flex;align-items:center;gap:12px"><span style="font:600 11.5px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#8ec07c">07 · CONTROLS</span><span style="flex:1;height:1px;background:#3c3836"></span></div>
+  <div style="display:flex;flex-wrap:wrap;gap:24px;align-items:flex-start">
+    <div style="display:flex;flex-direction:column;gap:10px">
+      <div style="font:10.5px 'JetBrains Mono',monospace;letter-spacing:.1em;color:#7c6f64">DEFAULT STEP · 40PX</div>
+      <div style="display:flex;gap:10px;align-items:center">
+        <button style="height:40px;padding:0 16px;background:#fe8019;border:1px solid #af3a03;border-radius:2px;color:#1d2021;font:600 15px 'Space Grotesk',sans-serif;cursor:pointer" style-hover="background:#ffa347">Recompute plan</button>
+        <button style="height:40px;padding:0 16px;background:#3c3836;border:1px solid #504945;border-radius:2px;color:#ebdbb2;font:500 15px 'Space Grotesk',sans-serif;cursor:pointer" style-hover="border-color:#689d6a;color:#b8db9c">Share</button>
+        <select style="height:40px;padding:0 12px;background:#45403d;border:1px solid #504945;border-radius:2px;color:#ebdbb2;font:500 15px 'Space Grotesk',sans-serif"><option>Stasis Device</option><option>Fusion Ignitor</option></select>
+        <input value="5" style="height:40px;width:64px;padding:0 12px;background:#45403d;border:1px solid #504945;border-radius:2px;color:#fbf1c7;font:500 15px 'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">
+      </div>
+    </div>
+    <div style="display:flex;flex-direction:column;gap:10px">
+      <div style="font:10.5px 'JetBrains Mono',monospace;letter-spacing:.1em;color:#7c6f64">SMALL STEP · 30PX · METHOD SEGMENTED (node popover core control)</div>
+      <div style="display:flex;gap:10px;align-items:center">
+        <div style="display:flex;border:1px solid #504945;border-radius:2px;overflow:hidden">
+          <button style="height:30px;padding:0 14px;background:rgba(142,192,124,.16);border:none;box-shadow:inset 0 -2px 0 #8ec07c;color:#b8db9c;font:600 13px 'Space Grotesk',sans-serif;cursor:pointer">craft</button>
+          <button style="height:30px;padding:0 14px;background:#45403d;border:none;border-left:1px solid #504945;color:#a89984;font:500 13px 'Space Grotesk',sans-serif;cursor:pointer" style-hover="color:#ebdbb2">refine</button>
+          </div>
+        <span style="font:12px 'JetBrains Mono',monospace;color:#a89984">refine: 250 Copper → 125 Chromatic Metal · adds 1 sub-node</span>
+      </div>
+      <div style="display:flex;gap:8px;align-items:center">
+        <span style="height:24px;display:inline-flex;align-items:center;gap:5px;padding:0 9px;background:#45403d;border:1px solid #504945;border-radius:2px;font:600 11px 'JetBrains Mono',monospace;letter-spacing:.08em;color:#ebdbb2">⚒ CRAFT</span>
+        <span style="height:24px;display:inline-flex;align-items:center;gap:5px;padding:0 9px;background:#45403d;border:1px solid #504945;border-radius:2px;font:600 11px 'JetBrains Mono',monospace;letter-spacing:.08em;color:#ebdbb2">◇ REFINE</span>
+        <span style="height:24px;display:inline-flex;align-items:center;gap:5px;padding:0 9px;background:#45403d;border:1px solid #504945;border-radius:2px;font:600 11px 'JetBrains Mono',monospace;letter-spacing:.08em;color:#ebdbb2">▽ RAW</span>
+        <span style="height:24px;display:inline-flex;align-items:center;gap:5px;padding:0 9px;background:transparent;border:1px dashed #504945;border-radius:2px;font:500 11px 'JetBrains Mono',monospace;color:#a89984" title="community data, not verified in-game">unverified</span>
+      </div>
+      <div style="font:12px 'Space Grotesk',sans-serif;color:#a89984;max-width:520px">Method badges stay monochrome — node cards already carry a base-identity frame; a second categorical hue would collide (worse under CB). Refine is reinforced by dashed edges on the canvas.</div>
+    </div>
+  </div>
+</section>
+
+<section style="display:flex;flex-direction:column;gap:16px">
+  <div style="display:flex;align-items:center;gap:12px"><span style="font:600 11.5px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#8ec07c">08 · POWER METER — BAR PAIR (never a gauge)</span><span style="flex:1;height:1px;background:#3c3836"></span></div>
+  <div style="display:flex;flex-wrap:wrap;gap:14px">
+    <div style="background:#3c3836;border:1px solid #453f3c;border-radius:4px;padding:16px 18px;width:320px;display:flex;flex-direction:column;gap:8px">
+      <div style="display:grid;grid-template-columns:34px 1fr 92px;gap:10px;align-items:center;font:11px 'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">
+        <span style="color:#a89984">GEN</span><div style="height:8px;background:#1d2021;border-radius:1px"><div style="width:86%;height:100%;background:#8ec07c;border-radius:1px"></div></div><span style="color:#ebdbb2;text-align:right">520 kPs</span>
+        <span style="color:#a89984">DRAW</span><div style="height:8px;background:#1d2021;border-radius:1px"><div style="width:63%;height:100%;background:#a89984;border-radius:1px"></div></div><span style="color:#ebdbb2;text-align:right">380 kPs</span>
+      </div>
+      <div style="font:12px 'Space Grotesk',sans-serif;color:#8ec07c">✓ headroom +140 kPs</div>
+    </div>
+    <div style="background:#3c3836;border:1px solid #453f3c;border-radius:4px;padding:16px 18px;width:320px;display:flex;flex-direction:column;gap:8px">
+      <div style="display:grid;grid-template-columns:34px 1fr 92px;gap:10px;align-items:center;font:11px 'JetBrains Mono',monospace;font-variant-numeric:tabular-nums">
+        <span style="color:#a89984">GEN</span><div style="height:8px;background:#1d2021;border-radius:1px"><div style="width:58%;height:100%;background:#8ec07c;border-radius:1px"></div></div><span style="color:#ebdbb2;text-align:right">300 kPs</span>
+        <span style="color:#a89984">DRAW</span><div style="height:8px;background:#1d2021;border-radius:1px;position:relative"><div style="width:58%;height:100%;background:#a89984;border-radius:1px"></div><div style="position:absolute;left:58%;top:0;width:16%;height:100%;background:#fb4934"></div></div><span style="color:#fb4934;text-align:right">380 kPs</span>
+      </div>
+      <div style="display:flex;align-items:center;gap:8px"><span style="font:12px 'Space Grotesk',sans-serif;color:#fb4934">⚠ deficit 80 kPs</span><span style="flex:1"></span><button style="height:26px;padding:0 10px;background:#45403d;border:1px solid #665c54;border-radius:2px;color:#ebdbb2;font:500 11.5px 'Space Grotesk',sans-serif;cursor:pointer" style-hover="border-color:#af3a03;color:#ffa347">+ 1 × EM generator (+110)</button></div>
+    </div>
+  </div>
+  <div style="font:12px 'Space Grotesk',sans-serif;color:#a89984">The overdraw segment is the only red in the meter; the fix is a button that appends to the base's build list. Deficit is announced via ⚠ + text, never color alone.</div>
+</section>
+
+<section style="display:flex;flex-direction:column;gap:16px">
+  <div style="display:flex;align-items:center;gap:12px"><span style="font:600 11.5px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#8ec07c">09 · TEXTURE (decorative only)</span><span style="flex:1;height:1px;background:#3c3836"></span></div>
+  <div style="display:flex;flex-wrap:wrap;gap:14px">
+    <div style="width:320px;height:120px;background:#282828;background-image:repeating-linear-gradient(0deg,rgba(251,241,199,.035) 0 1px,transparent 1px 3px);border:1px solid #504945;border-radius:4px;display:flex;align-items:flex-end;padding:10px"><span style="font:10.5px 'JetBrains Mono',monospace;color:#a89984">scanline on --bg surfaces (shown 2× strength)</span></div>
+    <div style="width:320px;height:120px;background:#1d2021;background-image:linear-gradient(rgba(235,219,178,.04) 1px,transparent 1px),linear-gradient(90deg,rgba(235,219,178,.04) 1px,transparent 1px);background-size:24px 24px;border:1px solid #504945;border-radius:4px;display:flex;align-items:flex-end;padding:10px"><span style="font:10.5px 'JetBrains Mono',monospace;color:#a89984">24px grid on --bg-canvas</span></div>
+  </div>
+</section>
+
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;cbSim&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;none&quot;,&quot;protanopia&quot;,&quot;deuteranopia&quot;],&quot;default&quot;:&quot;none&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Validation&quot;}}">
+class Component extends DCLogic {
+  renderVals() {
+    const hex2rgb = h => [1,3,5].map(i => parseInt(h.slice(i,i+2),16)/255);
+    const lin = c => c<=0.04045 ? c/12.92 : Math.pow((c+0.055)/1.055,2.4);
+    const lum = h => { const [r,g,b]=hex2rgb(h).map(lin); return .2126*r+.7152*g+.0722*b; };
+    const cr = (a,b) => { const [x,y]=[lum(a),lum(b)].sort((p,q)=>q-p); return (x+.05)/(y+.05); };
+    const P=[[0.152286,1.052583,-0.204868],[0.114503,0.786281,0.099216],[-0.003882,-0.048116,1.051998]];
+    const D=[[0.367322,0.860646,-0.227968],[0.280085,0.672501,0.047413],[-0.011820,0.042940,0.968881]];
+    const mul=(M,v)=>M.map(r=>r[0]*v[0]+r[1]*v[1]+r[2]*v[2]);
+    const toLab=v=>{const M=[[0.4124,0.3576,0.1805],[0.2126,0.7152,0.0722],[0.0193,0.1192,0.9505]];const [X,Y,Z]=mul(M,v);const W=[0.9505,1,1.089];const f=t=>t>0.008856?Math.cbrt(t):7.787*t+16/116;const [fx,fy,fz]=[X/W[0],Y/W[1],Z/W[2]].map(f);return [116*fy-16,500*(fx-fy),200*(fy-fz)];};
+    const dE=(a,b)=>Math.hypot(a[0]-b[0],a[1]-b[1],a[2]-b[2]);
+    const labOf=(h,M)=>{let v=hex2rgb(h).map(lin);if(M)v=mul(M,v).map(x=>Math.min(1,Math.max(0,x)));return toLab(v);};
+    const simHex=(h,M)=>{if(!M)return h;const g=x=>{x=Math.min(1,Math.max(0,x));const s=x<=0.0031308?12.92*x:1.055*Math.pow(x,1/2.4)-0.055;return Math.round(s*255).toString(16).padStart(2,'0');};const v=mul(M,hex2rgb(h).map(lin));return '#'+v.map(g).join('');};
+    const pal=[['yellow','#fabd2f'],['sand','#e6d9c0'],['copper','#e8543a'],['blue','#93b4d1'],['gray','#a08f78'],['purple','#b3618a']];
+    const bgs=['#1d2021','#282828','#32302f'];
+    const sim = this.props.cbSim ?? 'none';
+    const M = sim==='protanopia'?P:sim==='deuteranopia'?D:null;
+    const palSwatches = pal.map(([name,hex],i)=>({name,hex,shown:simHex(hex,M),idx:i+1,label:'Base '+String.fromCharCode(65+i)}));
+    const contrastRows = pal.map(([name,hex])=>{const cs=bgs.map(b=>cr(hex,b));return {name,hex,c0:cs[0].toFixed(2),c1:cs[1].toFixed(2),c2:cs[2].toFixed(2),pass:cs.every(c=>c>=3)?'pass ≥3:1':'FAIL',passColor:cs.every(c=>c>=3)?'#8ec07c':'#fb4934'};});
+    const matrixHead = pal.map(([name])=>({name}));
+    let worst={v:1e9,t:''};
+    const matrixCells=[];
+    pal.forEach(([ni,hi],i)=>{
+      matrixCells.push({t:ni,color:'#7c6f64'});
+      pal.forEach(([nj,hj],j)=>{
+        if(i===j){matrixCells.push({t:'—',color:'#504945'});return;}
+        const m=Math.min(dE(labOf(hi,P),labOf(hj,P)),dE(labOf(hi,D),labOf(hj,D)));
+        if(m<worst.v)worst={v:m,t:ni+'×'+nj};
+        matrixCells.push({t:m.toFixed(0),color:m<20?'#fb4934':'#ebdbb2'});
+      });
+    });
+    return {palSwatches,contrastRows,matrixHead,matrixCells,
+      worstPair:worst.t+' ΔE '+worst.v.toFixed(1),
+      simLabel:sim==='none'?'normal vision':sim};
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/theme/handoff.md
+++ b/docs/design/theme/handoff.md
@@ -1,0 +1,80 @@
+# Handoff: Theme + Tokens (NMS Base & Resource Planner) — Gruvbox
+
+> Convention note: where this document and a later spec disagree, **the spec wins** — record deviations at the top of this file when integrating.
+> **Deviation from the design brief, by user decision:** the brief's stated direction was deep-space navy + coral + teal. Four schemes were prototyped (`Theme Variants.dc.html`, options 3a–3d) plus two gruvbox riffs (4a, 4b); the user selected **gruvbox classic (4a)**. The retro-sci-fi rules (texture, geometric type, mono numerals, border discipline) carry over unchanged.
+
+## Overview
+Token set for the planner in gruvbox dark. Dark retro-terminal theme: bg0 surfaces, cream text, orange interactive, aqua ok/selection, red deficit. No game assets, fonts, or trade dress.
+
+## About the Design Files
+`Theme Tokens.dc.html` is a **design reference created in HTML** — a living spec sheet, not production code. Its validation tables are **computed live at render time** from the token hexes (WCAG 2.1 contrast; Machado 2009 protanopia/deuteranopia simulation → CIELAB ΔE76), so the page cannot drift from its own math. Recreate as CSS custom properties in the build repo's global stylesheet.
+
+## Tokens
+
+### Backgrounds & chrome (gruvbox canon values)
+- `--bg` #282828 (bg0) · app background
+- `--bg-canvas` #1d2021 (bg0_h) · tree canvas + meter tracks
+- `--panel` #32302f (bg0_s) · panels, base cards
+- `--panel-raised` #3c3836 (bg1) · rows/cards on panels
+- `--input-bg` #45403d · fields, segmented controls
+- `--border` #504945 (bg2) · default 1px border
+- `--border-soft` #453f3c · quiet borders
+- `--divider` #3a3634 · hairlines
+
+### Text (measured vs #282828 / #32302f / #3c3836)
+- `--text` #ebdbb2 (fg1) · 10.75 / 9.57 / 8.45
+- `--text-bright` #fbf1c7 (fg0) · headings, values · 12.99+
+- `--text-muted` #a89984 (gray) · 5.30 / 4.72 / **4.17** — on `--panel-raised` restrict to ≥17px or switch to `--text`
+- `--text-dim` #7c6f64 (bg4) · 3.03 / 2.70 / 2.38 — **decorative ≥18px only**, never unique info
+
+### Accent & state
+- `--accent` #fe8019 (bright orange) · interactive ONLY · 5.20:1 on `--panel`; dark text #1d2021 on orange buttons = 6.49:1
+- `--accent-hover` #ffa347 · `--accent-border` #af3a03
+- `--danger` #fb4934 (bright red) · deficit/destructive · 3.82:1 on `--panel` (non-text ✓; as text always ≥15px w/ glyph)
+- `--ok` #8ec07c (bright aqua) · ok, links, selection ring · 6.24:1
+- `--ok-dim` #689d6a
+- `--warn` #d79921 (neutral yellow) · unassigned warnings · 5.29:1
+- Deviation from the navy scheme's rule: gruvbox has a real red, so deficit gets `--danger` and orange stays purely interactive — cleaner than one color doing both.
+
+### Base accent palette (categorical, 6)
+3px identity frames; **nothing else may write to a border** (the-outfitter #132). Hover = brightness(1.12), focus = 2px `--ok` outline outboard, selection = 2px `--ok` ring inboard.
+- `--base-1` yellow #fabd2f · `--base-2` sand #e6d9c0 · `--base-3` copper #e8543a · `--base-4` blue #93b4d1 · `--base-5` gray #a08f78 · `--base-6` purple #b3618a
+
+**Validation (measured; live on the prototype)** against the three frame surfaces #1d2021 / #282828 / #32302f:
+- Contrast: yellow 9.67/8.69/7.74 · sand 11.75/10.57/9.41 · copper 4.50/4.04/3.60 · blue 7.57/6.80/6.06 · gray 5.23/4.70/4.19 · purple 3.90/3.51/3.12. All ≥3:1 (SC 1.4.11); purple is the floor at 3.12.
+- CB distinguishability: min pairwise ΔE76 under protan/deutan sim — floor is **gray×purple at 21**; all other pairs ≥23, most ≥31. Gruvbox's lighter backgrounds compress the usable gamut (every palette color must stay light enough for 3:1), so the navy scheme's ΔE-24 floor is not reachable; ΔE 21 is above the flag threshold (20).
+- **Canon colors deliberately excluded:** bright green #b8bb26 collapses into yellow under deuteranopia (ΔE 5 — the classic gruvbox CB trap); orange and red are spent on interactive/danger. Sand and gray fill those slots.
+- Base name remains the primary identity everywhere (SC 1.4.1); color reinforces.
+
+### Type
+- Display: **Chakra Petch** 600/700 · headers, panel titles, rollup figure · floor 13px
+- Body/UI: **Space Grotesk** 400/500/600
+- Numerals & labels: **JetBrains Mono** + `font-variant-numeric: tabular-nums` · every quantity, time, kPs figure, micro-label
+- Scale: 11.5 label (mono, ls .12em, caps) / 13 meta / 15 body / 17 emphasis / 20 h3 / 26 h2 / 34 display
+
+### Spacing, radius, control scale
+- Spacing 4/8/12/16/24/32/48 · radius 2px controls, 4px panels
+- One control scale (outfitter #134 discipline): default 40px = 10+10+18+2, 15px font · small 30px = 6+6+16+2, 13px font. Rows never mix steps; coarse pointers grow square targets to 44px.
+
+### Texture (decorative only)
+- Scanline `repeating-linear-gradient(0deg, rgba(251,241,199,.018) 0 1px, transparent 1px 3px)` on `--bg`
+- 24px grid `rgba(235,219,178,.04)` on `--bg-canvas`
+
+## Decisions
+- Method badges (craft/refine/raw — no buy: this is a build planner, not a shopping list) stay **monochrome** — glyph + mono label on `--input-bg`; refine reinforced by dashed edges on canvas. Node cards already carry base-identity frames.
+- Selected base card: aqua ring drawn **inboard** via pseudo-element (never an inset box-shadow — it paints under positioned children; outfitter PR #180 lesson), identity frame untouched.
+- Deficit fix is an action, not a warning: "+ 1 × EM generator (+110)" is a button that appends to the base's build list (prototyped in `Theme Variants.dc.html` 6a).
+
+## Open questions
+1. `--warn` #d79921 vs `--base-1` yellow #fabd2f: a yellow-framed base with an unassigned warning shows two nearby yellows. Mitigation: warnings always carry ⚠ + text, never color alone. Revisit at the base-planner surface review.
+2. `--input-bg` #45403d sits close to `--border` #504945; if fields read as borderless, drop input-bg to #3c3836 and give fields a 1px #504945 border.
+
+## Self-critique / WCAG 2.1 AA findings
+- `--text-muted` fails 4.5:1 on `--panel-raised` (4.17) — rule added above (≥17px or `--text` there).
+- `--danger` as text is 3.82:1 on `--panel` — deficit lines render ≥15px with the ⚠ glyph and a stated quantity, and the meter overdraw segment repeats the fact non-textually; acceptable, flagged.
+- Focus: 2px #8ec07c outline at 2px offset, visible on all surfaces (6.24:1+).
+
+## Files
+- `docs/design/theme/Theme Tokens.dc.html` — living token sheet (live math; CB-sim tweak included)
+- `Theme Variants.dc.html` — scheme exploration (3a–3d, 4a–4b), palette derivation (5a), Base C hi-fi card (6a)
+- Convention source: jonstump/the-outfitter `client/src/styles/global.css`, `docs/design/hunter-loadout-lists/handoff.md`

--- a/docs/design/theme/support.js
+++ b/docs/design/theme/support.js
@@ -1,0 +1,1911 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    if (!window.__resources) {
+      fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+        const raw = t ? parseDcText(t) : null;
+        if (raw?.template) runtime.updateHtml(rootName, raw.template);
+      }).catch(() => {
+      });
+    }
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu",
+    onmousemove: "onMouseMove",
+    onmouseover: "onMouseOver",
+    onmouseout: "onMouseOut",
+    onpointerdown: "onPointerDown",
+    onpointerup: "onPointerUp",
+    onpointermove: "onPointerMove",
+    onpointerenter: "onPointerEnter",
+    onpointerleave: "onPointerLeave",
+    onpointercancel: "onPointerCancel",
+    onpointerover: "onPointerOver",
+    onpointerout: "onPointerOut",
+    ongotpointercapture: "onGotPointerCapture",
+    onlostpointercapture: "onLostPointerCapture",
+    ontouchstart: "onTouchStart",
+    ontouchend: "onTouchEnd",
+    ontouchmove: "onTouchMove",
+    ontouchcancel: "onTouchCancel",
+    ondragstart: "onDragStart",
+    ondragend: "onDragEnd",
+    ondragenter: "onDragEnter",
+    ondragleave: "onDragLeave",
+    ondragover: "onDragOver",
+    onanimationstart: "onAnimationStart",
+    onanimationend: "onAnimationEnd",
+    onanimationiteration: "onAnimationIteration",
+    ontransitionend: "onTransitionEnd"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCamelAttrs(html) {
+    return html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+  }
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = encodeCamelAttrs(html);
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  var SLIDE_ID_VALUE_RE = /^[0-9a-f]{8}$/;
+  var DECK_CONTROL_FLOW_RE = /^(sc-if|sc-for|sc-else|dc-import|x-import)$/;
+  var DECK_AUX_RE = /^(template|script|style|sc-helmet|helmet)$/;
+  function isDeckMountTag(el) {
+    if (el.localName === "deck-stage") return true;
+    return el.localName === "x-import" && (el.getAttribute("component-from-global-scope") || "") === "deck-stage";
+  }
+  function walkDeckChildren(el, host) {
+    const pairs = [...el.childNodes].map((c) => ({ c, b: walk(c, host) })).filter((p) => p.b !== null);
+    const kids = pairs.map((p) => p.b);
+    const seen = /* @__PURE__ */ new Set();
+    const wsSeen = /* @__PURE__ */ new Map();
+    const keys = [];
+    const nextSlideId = new Array(pairs.length);
+    {
+      let upcoming = null;
+      for (let j = pairs.length - 1; j >= 0; j--) {
+        const n = pairs[j].c;
+        if (n.nodeType === Node.ELEMENT_NODE) {
+          const t = n.localName;
+          upcoming = !DECK_AUX_RE.test(t) && !DECK_CONTROL_FLOW_RE.test(t) ? n.getAttribute("data-om-slide-id") : null;
+        }
+        nextSlideId[j] = upcoming;
+      }
+    }
+    for (let j = 0; j < pairs.length; j++) {
+      const { c } = pairs[j];
+      if (c.nodeType === Node.TEXT_NODE) {
+        if ((c.nodeValue ?? "").trim() === "") {
+          const base = nextSlideId[j] ? "omid-ws:" + nextSlideId[j] : "omid-ws:aux";
+          const n = wsSeen.get(base) ?? 0;
+          wsSeen.set(base, n + 1);
+          keys.push(n === 0 ? base : base + ":" + n);
+          continue;
+        }
+        return { kids, keys: null };
+      }
+      if (c.nodeType !== Node.ELEMENT_NODE) {
+        keys.push(j);
+        continue;
+      }
+      const child = c;
+      const tag = child.localName;
+      if (DECK_AUX_RE.test(tag)) {
+        keys.push(j);
+        continue;
+      }
+      if (DECK_CONTROL_FLOW_RE.test(tag)) return { kids, keys: null };
+      const v = child.getAttribute("data-om-slide-id");
+      if (!v || !SLIDE_ID_VALUE_RE.test(v) || seen.has(v)) {
+        return { kids, keys: null };
+      }
+      seen.add(v);
+      keys.push("omid:" + v);
+    }
+    return { kids, keys };
+  }
+  function renderDeckKids(kids, kidKeys, vals, ctx) {
+    return kids.map((b, j) => {
+      const k = kidKeys ? kidKeys[j] : j;
+      const out = b(vals, ctx, k);
+      return kidKeys != null && typeof out === "string" ? h(getReact().Fragment, { key: k }, out) : out;
+    });
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || (el.getAttribute("component-from-global-scope") ? "" : el.getAttribute("src") || el.getAttribute("import") || "");
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const deckKeyed = hasContent && isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : hasContent ? walkChildren(el, host) : [];
+    const kidKeys = deckKeyed?.keys ?? null;
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) {
+        props.children = renderDeckKids(kids, kidKeys, vals, ctx);
+      }
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const deckKeyed = isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : walkChildren(el, host);
+    const kidKeys = deckKeyed?.keys ?? null;
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...renderDeckKids(kids, kidKeys, vals, ctx));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/bundled.ts
+  function bundledBlob(url) {
+    const blobs = window.__resourceBlobs;
+    const b = blobs ? blobs[url.split("#")[0]] : void 0;
+    return b instanceof Blob ? b : null;
+  }
+
+  // src/cdn.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  function cdnScriptFor(url, sri) {
+    const res = window.__resources;
+    const v = res ? res[url] : void 0;
+    return typeof v === "string" && v ? { src: v } : { src: url, integrity: sri };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      const babel = cdnScriptFor(BABEL_URL, BABEL_SRI);
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = babel.src;
+        if (babel.integrity) {
+          s.integrity = babel.integrity;
+          s.crossOrigin = "anonymous";
+        }
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => {
+        const pre = bundledBlob(url);
+        if (pre) return pre.text();
+        return fetch(url).then((r) => {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.text();
+        });
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            if (tag === "LINK") {
+              const rel = (child.getAttribute("rel") || "").toLowerCase().split(/\s+/);
+              const href = (child.getAttribute("href") || "").trim();
+              const res = window.__resources;
+              const pre = res && rel.includes("stylesheet") && !rel.includes("alternate") ? res[href] : void 0;
+              const blob = typeof pre === "string" && pre ? bundledBlob(pre) : null;
+              if (blob) {
+                const el = doc.createElement("style");
+                if (child.hasAttribute("disabled")) {
+                  el.setAttribute("media", "not all");
+                } else if (child.getAttribute("media")) {
+                  el.setAttribute("media", child.getAttribute("media"));
+                }
+                if (child.getAttribute("title"))
+                  el.setAttribute("title", child.getAttribute("title"));
+                void blob.text().then((css) => {
+                  el.textContent = css;
+                });
+                doc.head.appendChild(el);
+                continue;
+              }
+            }
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function scanUnquotedUrl(css, i) {
+    if (css[i] !== "u" && css[i] !== "U" || css.slice(i, i + 4).toLowerCase() !== "url(" || /[a-z0-9_-]/i.test(css[i - 1] ?? "")) {
+      return -1;
+    }
+    let j = i + 4;
+    while (j < css.length && /\s/.test(css[j])) j++;
+    if (css[j] === '"' || css[j] === "'") return -1;
+    while (j < css.length && css[j] !== ")") {
+      if (css[j] === "\\") j++;
+      j++;
+    }
+    return j < css.length ? j + 1 : css.length;
+  }
+  function stripComments(css) {
+    let out = "";
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") {
+          out += c + (css[i + 1] ?? "");
+          i++;
+          continue;
+        }
+        if (c === quote) quote = "";
+        out += c;
+      } else if (c === "'" || c === '"') {
+        quote = c;
+        out += c;
+      } else if (c === "/" && css[i + 1] === "*") {
+        const end = css.indexOf("*/", i + 2);
+        i = end === -1 ? css.length : end + 1;
+        out += " ";
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end === -1) out += c;
+        else {
+          out += css.slice(i, end);
+          i = end - 1;
+        }
+      }
+    }
+    return out;
+  }
+  function importantify(css) {
+    css = stripComments(css);
+    const decls = [];
+    let start = 0;
+    let depth = 0;
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") i++;
+        else if (c === quote) quote = "";
+      } else if (c === "'" || c === '"') quote = c;
+      else if (c === "(") depth++;
+      else if (c === ")") depth = Math.max(0, depth - 1);
+      else if (c === ";" && depth === 0) {
+        decls.push(css.slice(start, i));
+        start = i + 1;
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end !== -1) i = end - 1;
+      }
+    }
+    decls.push(css.slice(start));
+    return decls.map((d) => d.trim()).filter(Boolean).map((d) => /!\s*important$/i.test(d) ? d : d + " !important").join(";");
+  }
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const isPseudoElement = pseudo === "before" || pseudo === "after";
+      const sel = isPseudoElement ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(
+        sel + "{" + (isPseudoElement ? css : importantify(css)) + "}",
+        el.sheet.cssRules.length
+      );
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      const res = window.__resources;
+      const pre = res ? res[url] : void 0;
+      const target = typeof pre === "string" && pre ? pre : url;
+      const blob = bundledBlob(target);
+      (blob ? blob.text() : fetch(target).then((res2) => {
+        if (!res2.ok) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '" failed:',
+            url,
+            "returned",
+            res2.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res2.text();
+      })).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '":',
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          '[dc-runtime] sibling fetch for "' + name + '" threw:',
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/stream-state.ts
+  function createStreamTracker(staleMs = 6e4, now = Date.now) {
+    const since = /* @__PURE__ */ new Map();
+    const liveOne = (n) => {
+      const t = since.get(n);
+      if (t === void 0) return false;
+      if (now() - t > staleMs) {
+        since.delete(n);
+        return false;
+      }
+      return true;
+    };
+    return {
+      push(name, streaming, viewportKey) {
+        if (viewportKey === "dc-model") return;
+        if (streaming) since.set(name, now());
+        else since.delete(name);
+      },
+      live(name) {
+        if (name !== void 0) return liveOne(name);
+        for (const n of [...since.keys()]) if (liveOne(n)) return true;
+        return false;
+      }
+    };
+  }
+
+  // src/index.ts
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      if (integrity) {
+        s.integrity = integrity;
+        s.crossOrigin = "anonymous";
+      }
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    const react = cdnScriptFor(REACT_URL, REACT_SRI);
+    const reactDom = cdnScriptFor(REACT_DOM_URL, REACT_DOM_SRI);
+    return Promise.all([
+      loadScript(react.src, react.integrity),
+      loadScript(reactDom.src, reactDom.integrity)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const streams = createStreamTracker();
+    const api = {
+      __dcUpdate: (name, kind, content, streaming, viewportKey) => {
+        streams.push(name, streaming, viewportKey);
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcStreaming: (name) => streams.live(name),
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`sc-camel-*` attrs,
+       *  `<sc-raw-*>`/`<sc-helmet>` tags); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();

--- a/docs/design/tree-canvas/Tree Canvas.dc.html
+++ b/docs/design/tree-canvas/Tree Canvas.dc.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@600;700&amp;family=Space+Grotesk:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;600&amp;display=swap" rel="stylesheet">
+<style>body{margin:0;background:#1d2021;color:#ebdbb2;font-family:'Space Grotesk',sans-serif}a{color:#8ec07c}a:hover{color:#b8db9c}button:focus-visible{outline:2px solid #8ec07c;outline-offset:2px}select:focus-visible{outline:2px solid #8ec07c;outline-offset:2px}</style>
+</helmet>
+<div style="display:flex;flex-direction:column;min-height:100vh">
+
+<header style="background:#282828;background-image:repeating-linear-gradient(0deg,rgba(251,241,199,.018) 0 1px,transparent 1px 3px);border-bottom:1px solid #504945;padding:14px 24px;display:flex;align-items:center;gap:18px;flex-wrap:wrap">
+  <div style="font:700 17px 'Chakra Petch',sans-serif;letter-spacing:.05em;color:#fbf1c7">TREE CANVAS — STASIS DEVICE <span style="color:#a89984">{{ qtyLabel }}</span></div>
+  <div style="display:flex;gap:12px;align-items:center;margin-left:16px">
+    <a href="../base-planner/Base Planner v2.dc.html" style="font:500 13px 'Space Grotesk',sans-serif;text-decoration:none">view planner →</a>
+    <a href="../bases-map/Bases Map.dc.html" style="font:500 13px 'Space Grotesk',sans-serif;text-decoration:none">view atlas →</a>
+  </div>
+  <span style="flex:1"></span>
+  <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;font:10.5px 'JetBrains Mono',monospace;color:#a89984">
+    <span style="padding:2px 7px;background:#45403d;border:1px solid #504945;border-radius:2px;color:#ebdbb2">▽ RAW</span>
+    <span style="padding:2px 7px;background:#45403d;border:1px solid #504945;border-radius:2px;color:#ebdbb2">⚒ CRAFT</span>
+    <span style="padding:2px 7px;background:#45403d;border:1px solid #504945;border-radius:2px;color:#ebdbb2">◇ REFINE</span>
+    <span style="margin-left:6px">dashed edge = refine input</span>
+    <span style="margin-left:10px;display:inline-flex;align-items:center;gap:5px"><span style="width:9px;height:9px;background:#93b4d1;border-radius:1px"></span>Verdant Moon</span>
+    <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:9px;height:9px;background:#e8543a;border-radius:1px"></span>Gasworks</span>
+    <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:9px;height:9px;background:#b3618a;border-radius:1px"></span>Cobalt Flats</span>
+  </div>
+</header>
+
+<div style="overflow:auto;flex:1">
+<div style="position:relative;width:1490px;height:930px;background-image:linear-gradient(rgba(235,219,178,.04) 1px,transparent 1px),linear-gradient(90deg,rgba(235,219,178,.04) 1px,transparent 1px);background-size:24px 24px">
+  <svg width="1490" height="930" style="position:absolute;left:0;top:0;pointer-events:none">
+    <sc-for list="{{ edges }}" as="e" hint-placeholder-count="10">
+      <path d="{{ e.d }}" stroke="#504945" fill="none" stroke-width="1.5" stroke-dasharray="{{ e.dash }}"></path>
+    </sc-for>
+    <sc-for list="{{ edgeLabels }}" as="e" hint-placeholder-count="10">
+      <text x="{{ e.lx }}" y="{{ e.ly }}" fill="#a89984" font-family="JetBrains Mono,monospace" font-size="10" text-anchor="middle">{{ e.label }}</text>
+    </sc-for>
+  </svg>
+  <sc-for list="{{ nodes }}" as="n" hint-placeholder-count="12">
+    <button onClick="{{ n.onClick }}" aria-label="{{ n.aria }}" style="position:absolute;left:{{ n.x }}px;top:{{ n.y }}px;width:178px;height:52px;background:#3c3836;border:{{ n.border }};border-radius:2px;padding:6px 10px;display:flex;flex-direction:column;justify-content:center;gap:3px;text-align:left;cursor:pointer;font-family:'Space Grotesk',sans-serif" style-hover="filter:brightness(1.12)">
+      <span style="position:absolute;inset:2px;border:{{ n.ringBorder }};pointer-events:none"></span>
+      <span style="display:flex;justify-content:space-between;align-items:baseline;gap:6px"><span style="font:500 12.5px 'Space Grotesk',sans-serif;color:#fbf1c7;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ n.name }}</span><span style="font:600 11.5px 'JetBrains Mono',monospace;color:#ebdbb2;font-variant-numeric:tabular-nums">{{ n.qtyLabel }}</span></span>
+      <span style="display:flex;align-items:center;gap:6px"><span style="font:600 9.5px 'JetBrains Mono',monospace;letter-spacing:.08em;padding:1px 5px;background:#45403d;border:1px solid #504945;border-radius:2px;color:#ebdbb2">{{ n.badge }}</span><span style="font:500 10px 'JetBrains Mono',monospace;color:#d79921">{{ n.warnText }}</span><span style="font:500 9.5px 'JetBrains Mono',monospace;color:#a89984;border:1px dashed #504945;border-radius:2px;padding:1px 5px;display:{{ n.unvDisplay }}" title="community data, not verified in-game">unverified</span></span>
+    </button>
+  </sc-for>
+  <sc-if value="{{ pop }}" hint-placeholder-val="{{ false }}">
+    <div role="dialog" aria-label="Node options" style="position:absolute;left:{{ pop.px }}px;top:{{ pop.py }}px;width:250px;background:#32302f;border:1px solid #665c54;border-radius:4px;padding:12px 14px;display:flex;flex-direction:column;gap:10px;box-shadow:0 6px 20px rgba(0,0,0,.5);z-index:5">
+      <div style="display:flex;justify-content:space-between;align-items:baseline"><span style="font:600 13px 'Space Grotesk',sans-serif;color:#fbf1c7">{{ pop.name }}</span><button onClick="{{ pop.onClose }}" aria-label="Close" style="background:none;border:none;color:#a89984;font:14px 'Space Grotesk',sans-serif;cursor:pointer;padding:2px 4px">✕</button></div>
+      <sc-if value="{{ pop.hasMethods }}" hint-placeholder-val="{{ false }}">
+        <div style="display:flex;flex-direction:column;gap:7px">
+          <div style="display:flex;border:1px solid #504945;border-radius:2px;overflow:hidden;align-self:flex-start">
+            <button onClick="{{ pop.onCraft }}" style="height:30px;padding:0 14px;border:none;background:{{ pop.craftBg }};box-shadow:{{ pop.craftShadow }};color:{{ pop.craftColor }};font:600 13px 'Space Grotesk',sans-serif;cursor:pointer">craft</button>
+            <button onClick="{{ pop.onRefine }}" style="height:30px;padding:0 14px;border:none;border-left:1px solid #504945;background:{{ pop.refineBg }};box-shadow:{{ pop.refineShadow }};color:{{ pop.refineColor }};font:600 13px 'Space Grotesk',sans-serif;cursor:pointer">refine</button>
+          </div>
+          <div style="font:11px 'JetBrains Mono',monospace;color:#a89984;line-height:1.5">{{ pop.preview }}</div>
+        </div>
+      </sc-if>
+      <sc-if value="{{ pop.isLeaf }}" hint-placeholder-val="{{ false }}">
+        <div style="display:flex;flex-direction:column;gap:6px">
+          <label for="assign-sel" style="font:600 10px 'JetBrains Mono',monospace;letter-spacing:.12em;color:#7c6f64">ASSIGN TO BASE</label>
+          <select id="assign-sel" value="{{ pop.assign }}" onChange="{{ pop.onAssign }}" style="height:30px;padding:0 8px;background:#45403d;border:1px solid #504945;border-radius:2px;color:#ebdbb2;font:500 13px 'Space Grotesk',sans-serif">
+            <option value="none">— unassigned —</option>
+            <option value="a">Verdant Moon</option>
+            <option value="b">Gasworks</option>
+            <option value="c">Cobalt Flats</option>
+          </select>
+          <div style="font:11px 'Space Grotesk',sans-serif;color:{{ pop.assignNoteColor }}">{{ pop.assignNote }}</div>
+        </div>
+      </sc-if>
+      <sc-if value="{{ pop.unv }}" hint-placeholder-val="{{ false }}">
+        <div style="font:11px 'Space Grotesk',sans-serif;color:#a89984;border-top:1px solid #3a3634;padding-top:8px">Ratios from community data — not verified in-game. <span style="color:#ebdbb2">Report a correction</span> keeps the badge honest.</div>
+      </sc-if>
+    </div>
+  </sc-if>
+</div>
+</div>
+
+<footer style="background:#282828;border-top:1px solid #504945;padding:10px 24px;display:flex;gap:18px;align-items:baseline;flex-wrap:wrap">
+  <span aria-live="polite" style="font:italic 12.5px 'Space Grotesk',sans-serif;color:#8ec07c;min-height:16px">{{ announcement }}</span>
+  <span style="flex:1"></span>
+  <span style="font:11px 'JetBrains Mono',monospace;color:#7c6f64">34 nodes · layout: elkjs layered LTR in production · pan/zoom: React Flow · this file is the design reference</span>
+</footer>
+
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;qty&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:1,&quot;min&quot;:1,&quot;max&quot;:10,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Plan&quot;}}">
+class Component extends DCLogic {
+  state = { sel: null, method: {}, assign: { fc:'a',sol:'a',cf:'a',sb:'a',gr:'a',fae:'a',sul:'b',cc:'b',nit:'b',rad:'b',par:'c',pho:'c',dio:'c',ion:'none' }, announcement: 'Sample plan loaded: 1 × Stasis Device across 3 bases. Ionised Cobalt is unassigned.' };
+  data() {
+    const cols=[24,290,556,800,1044,1288];
+    const N=(id,name,qty,c,y,o={})=>({id,name,qty,x:cols[c],y,method:o.m||'craft',methods:o.mm||null,leaf:!!o.leaf,unv:!!o.unv,preview:o.pv||null});
+    const raws=[['fc','Frost Crystal',300],['sol','Solanium',200],['cf','Cactus Flesh',100],['sb','Star Bulb',200],['gr','Gamma Root',400],['fae','Faecium',50],['sul','Sulphurine',500],['cc','Condensed Carbon',300],['nit','Nitrogen',500],['rad','Radon',500],['par','Paraffinium',50],['pho','Phosphorus',50],['dio','Dioxite',50],['ion','Ionised Cobalt',150]];
+    const nodes=[
+      ...raws.map(([id,name,q],i)=>N(id,name,q,0,20+i*63,{m:'raw',leaf:true})),
+      N('hc','Heat Capacitor',1,1,40),
+      N('gla','Glass',5,1,120,{mm:['craft','refine'],unv:true,pv:{craft:'craft: 40 Frost Crystal each (×200 total)',refine:'refiner: 250 Frost Crystal each — no blueprint needed, slower'}}),
+      N('pf','Poly Fibre',1,1,195),
+      N('lub','Lubricant',1,1,300),
+      N('ec','Enriched Carbon',2,1,420,{mm:['craft','refine'],pv:{craft:'craft: 250 Sulphurine + 50 Condensed Carbon each',refine:'refiner: 300 Sulphurine each — drops the carbon input'}}),
+      N('ns','Nitrogen Salt',2,1,495,{mm:['craft','refine'],pv:{craft:'craft: 250 Nitrogen + 50 Condensed Carbon each',refine:'refiner: 300 Nitrogen each — drops the carbon input'}}),
+      N('tc','Thermic Condensate',2,1,570,{mm:['craft','refine'],pv:{craft:'craft: 250 Radon + 50 Condensed Carbon each',refine:'refiner: 300 Radon each — drops the carbon input'}}),
+      N('aro','Aronium',1,1,660),N('mg','Magno-Gold',1,1,725),N('gra','Grantine',1,1,790),
+      N('cb','Circuit Board',1,2,115),N('lg','Living Glass',1,2,215),
+      N('hi','Hot Ice',1,2,450,{unv:true}),N('sem','Semiconductor',1,2,535),
+      N('sup','Superconductor',1,3,465),N('cp','Cryo-Pump',1,3,545),
+      N('qp','Quantum Processor',1,4,285),N('cry','Cryogenic Chamber',1,4,385),N('iri','Iridesite',1,4,720),
+      N('sd','Stasis Device',1,5,460)
+    ];
+    const E=(s,d,l)=>({s,d,l});
+    const edges=[E('fc','hc','×100'),E('sol','hc','×200'),E('fc','gla','×200'),E('cf','pf','×100'),E('sb','pf','×200'),E('fae','lub','×50'),E('gr','lub','×400'),E('sul','ec','×500'),E('cc','ec','×100'),E('nit','ns','×500'),E('cc','ns','×100'),E('rad','tc','×500'),E('cc','tc','×100'),E('par','aro','×50'),E('ion','aro','×50'),E('pho','mg','×50'),E('ion','mg','×50'),E('dio','gra','×50'),E('ion','gra','×50'),E('hc','cb','×1'),E('pf','cb','×1'),E('gla','lg','×5'),E('lub','lg','×1'),E('tc','sem','×1'),E('ns','sem','×1'),E('ns','hi','×1'),E('ec','hi','×1'),E('sem','sup','×1'),E('ec','sup','×1'),E('hi','cp','×1'),E('tc','cp','×1'),E('cb','qp','×1'),E('sup','qp','×1'),E('lg','cry','×1'),E('cp','cry','×1'),E('aro','iri','×1'),E('mg','iri','×1'),E('gra','iri','×1'),E('qp','sd','×1'),E('cry','sd','×1'),E('iri','sd','×1')];
+    return {nodes,edges};
+  }
+  renderVals() {
+    const {nodes,edges}=this.data();
+    const mult=Math.max(1,Math.min(10,this.props.qty??1));
+    const baseColor={a:'#93b4d1',b:'#e8543a',c:'#b3618a'};
+    const baseName={a:'Verdant Moon',b:'Gasworks',c:'Cobalt Flats',none:'unassigned'};
+    const byId={};nodes.forEach(n=>byId[n.id]=n);
+    const methodOf=n=>this.state.method[n.id]||n.method;
+    const outNodes=nodes.map(n=>{
+      const m=methodOf(n);
+      const asg=n.leaf?(this.state.assign[n.id]||'none'):null;
+      let border='1px solid #504945';
+      if(n.leaf)border=asg!=='none'?('3px solid '+baseColor[asg]):'3px dashed #504945';
+      const badge=m==='raw'?'▽ RAW':m==='refine'?'◇ REFINE':'⚒ CRAFT';
+      return {
+        name:n.name, x:n.x, y:n.y,
+        qtyLabel:'×'+(n.qty*mult).toLocaleString(),
+        badge, border,
+        ringBorder:this.state.sel===n.id?'2px solid #8ec07c':'0px solid transparent',
+        warnText:(n.leaf&&asg==='none')?'⚠':'',
+        unvDisplay:n.unv?'inline':'none',
+        aria:n.name+', '+(n.qty*mult).toLocaleString()+' needed, method '+m+(n.leaf?(', base '+baseName[asg]):'')+'. Press Enter for options.',
+        onClick:()=>this.setState(s=>({sel:s.sel===n.id?null:n.id}))
+      };
+    });
+    const outEdges=edges.map(e=>{
+      const a=byId[e.s],b=byId[e.d];
+      const x1=a.x+178,y1=a.y+26,x2=b.x,y2=b.y+26;
+      return {
+        d:`M ${x1} ${y1} C ${x1+42} ${y1}, ${x2-42} ${y2}, ${x2} ${y2}`,
+        dash:methodOf(b)==='refine'?'5 4':'none',
+        lx:(x1+x2)/2, ly:(y1+y2)/2-5, label:e.l
+      };
+    });
+    let pop=null;
+    if(this.state.sel){
+      const n=byId[this.state.sel];
+      const m=methodOf(n);
+      const asg=n.leaf?(this.state.assign[n.id]||'none'):null;
+      const on='rgba(142,192,124,.16)',off='#45403d';
+      pop={
+        name:n.name,
+        px:n.x>1050?n.x-262:n.x+188, py:Math.max(8,n.y-8),
+        hasMethods:!!n.methods, isLeaf:n.leaf, unv:n.unv,
+        craftBg:m==='craft'?on:off, refineBg:m==='refine'?on:off,
+        craftShadow:m==='craft'?'inset 0 -2px 0 #8ec07c':'none',
+        refineShadow:m==='refine'?'inset 0 -2px 0 #8ec07c':'none',
+        craftColor:m==='craft'?'#b8db9c':'#a89984', refineColor:m==='refine'?'#b8db9c':'#a89984',
+        preview:n.preview?n.preview[m]:'',
+        assign:asg,
+        assignNote:asg==='none'?'⚠ unassigned — not counted in any base plan':'harvested at '+baseName[asg],
+        assignNoteColor:asg==='none'?'#d79921':'#a89984',
+        onCraft:()=>{this.setState(s=>({method:{...s.method,[n.id]:'craft'},announcement:n.name+' set to craft. Inputs redrawn.'}));},
+        onRefine:()=>{this.setState(s=>({method:{...s.method,[n.id]:'refine'},announcement:n.name+' set to refine. Input edges now dashed.'}));},
+        onAssign:(e)=>{const v=e.target.value;this.setState(s=>({assign:{...s.assign,[n.id]:v},announcement:n.name+' assigned to '+baseName[v]+'.'}));},
+        onClose:()=>this.setState({sel:null})
+      };
+    }
+    return {nodes:outNodes,edges:outEdges,edgeLabels:outEdges,pop,announcement:this.state.announcement,qtyLabel:'×'+mult};
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/tree-canvas/handoff.md
+++ b/docs/design/tree-canvas/handoff.md
@@ -1,0 +1,60 @@
+# Handoff: Tree Canvas (NMS Base & Resource Planner)
+
+> Convention note: where this document and a later spec disagree, **the spec wins**.
+
+## Overview
+The dependency-tree surface: pick a target item + quantity, see the full crafting/refining tree as a left-to-right flowchart, toggle method per node, assign leaf resources to bases. Prototyped with the **real Stasis Device tree — 34 nodes** (Quantum Processor + Cryogenic Chamber + Iridesite branches), quantities per 1 device.
+
+**No "buy" method** (user decision): this is a build planner, not a shopping list. Methods are craft / refine / raw.
+
+## About the Design Files
+`Tree Canvas.dc.html` is a **design reference created in HTML**, not production code. Production: React Flow (`@xyflow/react`) custom HTML/CSS nodes + elkjs auto-layout (layered, left-to-right, raws leftmost). The prototype's hand-tuned column layout stands in for elkjs; its SVG edges stand in for React Flow edge routing. Pan/zoom is React Flow's; the prototype scrolls.
+
+## Fidelity
+High-fidelity for node cards, edges, popover, states, colors (all mapped to `docs/design/theme/` tokens). Layout positions are illustrative — elkjs decides in production.
+
+## Node card
+- 178px wide, `--panel-raised` #3c3836 bg, radius 2px, padding 8×10.
+- Name (Space Grotesk 500 12.5px `--text-bright`), total qty (JetBrains Mono 12px tabular, `--text`), method badge (mono 9.5px caps: ▽ RAW / ⚒ CRAFT / ◇ REFINE, on `--input-bg`).
+- **Leaf frame = assigned base color, 3px** (`--base-*`). Unassigned leaf: 3px dashed `--border` + `--warn` dot. Non-leaf: 1px `--border`.
+- **Nothing else writes to the border** (outfitter #132): hover = `filter:brightness(1.12)`, focus = 2px `--ok` outline outboard, selected = 2px `--ok` ring **inboard** (overlay element, not inset box-shadow — inset shadows paint under positioned children; outfitter PR #180).
+- `unverified` badge: dashed 1px chip, `--text-muted`, title text "community data, not verified in-game" — subtle, honest, non-alarming.
+
+## Method popover (core interaction)
+- Opens on click / Enter. Segmented craft|refine (30px small step); disabled option rendered but inert with reason. Preview line states the consequence ("refiner ratio differs: 300 gas → 1, no Condensed Carbon").
+- Leaves get an assign-to-base `<select>` instead (dropdown chosen over drag per brief; drag leaf-chips onto base cards noted as enhancement).
+- Method changes recompute edge styles + announce via `aria-live="polite"`.
+
+## Edges
+- 1.5px `--border`-colored beziers, quantity label (mono 10px `--text-muted`) at midpoint.
+- **Inputs to a refine-method node are dashed** (5 4) — method is readable from the wiring, not just the badge.
+
+## Density / layout
+- 6 layers: 14 raws → 10 tier-1 → 4 tier-2 → 2 tier-3 → 3 components → device. Column x fixed, ~62px vertical rhythm in the raw column.
+- Sample base assignment: crops → Verdant Moon (blue), gases+carbon → Gasworks (copper), minerals → Cobalt Flats (purple).
+
+## Keyboard & a11y
+- Nodes are `<button>`s in topological order (raws first, device last) = tab order. Enter/Space opens the popover; Escape closes (prototype: close button + backdrop click; production must trap focus in popover and return it to the node).
+- Recompute announcements: `aria-live="polite"` region, e.g. "Enriched Carbon set to refine. Totals updated."
+- Base assignment fully operable via the popover select (no pointer needed).
+- Color never sole carrier: method has glyph+text, base identity has the name in the popover/base panel, unassigned has the ⚠ dot + popover text.
+
+## State management notes
+- Node method + leaf assignment are plan state (URL-hash-shareable per brief; **no localStorage in prototypes** — persistence expectations: plan serializes into the share hash).
+- Tweaks panel exposes device quantity (×1–×10) — all totals scale; production recomputes via the dependency graph.
+
+## Data (verified against community sources, 2026-08)
+Stasis Device = Quantum Processor + Cryogenic Chamber + Iridesite. QP = Circuit Board (Heat Capacitor: 100 Frost Crystal + 200 Solanium; Poly Fibre: 100 Cactus Flesh + 200 Star Bulb) + Superconductor (Semiconductor: Thermic Condensate + Nitrogen Salt; + Enriched Carbon). CryoChamber = Living Glass (5 Glass: 200 Frost Crystal; Lubricant: 50 Faecium + 400 Gamma Root) + Cryo-Pump (Hot Ice: Nitrogen Salt + Enriched Carbon; + Thermic Condensate). Gas products: 250 gas + 50 Condensed Carbon each (×2 each → 500 Sulphurine/Nitrogen/Radon, 300 CC). Iridesite = Aronium (50 Paraffinium + 50 Ionised Cobalt) + Magno-Gold (50 Phosphorus + …) + Grantine (50 Dioxite + …). Glass and Hot Ice carry the `unverified` badge in the prototype as the worked example (refiner-variant ratios differ by source).
+
+## Open questions
+1. Edge labels at 34 nodes are legible; at 60+ (Fusion Ignitor + Stasis combined) labels may need hover-only. Flag for elkjs spacing tests.
+2. Popover vs side-panel for method control on phone — phone is view-only per brief, so deferred to app-shell surface.
+
+## Self-critique / WCAG 2.1 AA findings
+- Edge labels `--text-muted` on `--bg-canvas` = 5.9:1 ✓; edge strokes are decorative reinforcement (badge carries the fact) ✓.
+- Focus outline `--ok` on `--bg-canvas` 7.0:1 ✓. Node buttons ≥44px tall at zoom 1? They are 52px — ✓.
+- Fixed: unassigned-leaf state initially color-only (dashed border); added ⚠ dot + popover text.
+
+## Files
+- `docs/design/tree-canvas/Tree Canvas.dc.html` — interactive prototype
+- Depends on: `docs/design/theme/handoff.md` tokens

--- a/docs/design/tree-canvas/support.js
+++ b/docs/design/tree-canvas/support.js
@@ -1,0 +1,1911 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    if (!window.__resources) {
+      fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+        const raw = t ? parseDcText(t) : null;
+        if (raw?.template) runtime.updateHtml(rootName, raw.template);
+      }).catch(() => {
+      });
+    }
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu",
+    onmousemove: "onMouseMove",
+    onmouseover: "onMouseOver",
+    onmouseout: "onMouseOut",
+    onpointerdown: "onPointerDown",
+    onpointerup: "onPointerUp",
+    onpointermove: "onPointerMove",
+    onpointerenter: "onPointerEnter",
+    onpointerleave: "onPointerLeave",
+    onpointercancel: "onPointerCancel",
+    onpointerover: "onPointerOver",
+    onpointerout: "onPointerOut",
+    ongotpointercapture: "onGotPointerCapture",
+    onlostpointercapture: "onLostPointerCapture",
+    ontouchstart: "onTouchStart",
+    ontouchend: "onTouchEnd",
+    ontouchmove: "onTouchMove",
+    ontouchcancel: "onTouchCancel",
+    ondragstart: "onDragStart",
+    ondragend: "onDragEnd",
+    ondragenter: "onDragEnter",
+    ondragleave: "onDragLeave",
+    ondragover: "onDragOver",
+    onanimationstart: "onAnimationStart",
+    onanimationend: "onAnimationEnd",
+    onanimationiteration: "onAnimationIteration",
+    ontransitionend: "onTransitionEnd"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCamelAttrs(html) {
+    return html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+  }
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = encodeCamelAttrs(html);
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  var SLIDE_ID_VALUE_RE = /^[0-9a-f]{8}$/;
+  var DECK_CONTROL_FLOW_RE = /^(sc-if|sc-for|sc-else|dc-import|x-import)$/;
+  var DECK_AUX_RE = /^(template|script|style|sc-helmet|helmet)$/;
+  function isDeckMountTag(el) {
+    if (el.localName === "deck-stage") return true;
+    return el.localName === "x-import" && (el.getAttribute("component-from-global-scope") || "") === "deck-stage";
+  }
+  function walkDeckChildren(el, host) {
+    const pairs = [...el.childNodes].map((c) => ({ c, b: walk(c, host) })).filter((p) => p.b !== null);
+    const kids = pairs.map((p) => p.b);
+    const seen = /* @__PURE__ */ new Set();
+    const wsSeen = /* @__PURE__ */ new Map();
+    const keys = [];
+    const nextSlideId = new Array(pairs.length);
+    {
+      let upcoming = null;
+      for (let j = pairs.length - 1; j >= 0; j--) {
+        const n = pairs[j].c;
+        if (n.nodeType === Node.ELEMENT_NODE) {
+          const t = n.localName;
+          upcoming = !DECK_AUX_RE.test(t) && !DECK_CONTROL_FLOW_RE.test(t) ? n.getAttribute("data-om-slide-id") : null;
+        }
+        nextSlideId[j] = upcoming;
+      }
+    }
+    for (let j = 0; j < pairs.length; j++) {
+      const { c } = pairs[j];
+      if (c.nodeType === Node.TEXT_NODE) {
+        if ((c.nodeValue ?? "").trim() === "") {
+          const base = nextSlideId[j] ? "omid-ws:" + nextSlideId[j] : "omid-ws:aux";
+          const n = wsSeen.get(base) ?? 0;
+          wsSeen.set(base, n + 1);
+          keys.push(n === 0 ? base : base + ":" + n);
+          continue;
+        }
+        return { kids, keys: null };
+      }
+      if (c.nodeType !== Node.ELEMENT_NODE) {
+        keys.push(j);
+        continue;
+      }
+      const child = c;
+      const tag = child.localName;
+      if (DECK_AUX_RE.test(tag)) {
+        keys.push(j);
+        continue;
+      }
+      if (DECK_CONTROL_FLOW_RE.test(tag)) return { kids, keys: null };
+      const v = child.getAttribute("data-om-slide-id");
+      if (!v || !SLIDE_ID_VALUE_RE.test(v) || seen.has(v)) {
+        return { kids, keys: null };
+      }
+      seen.add(v);
+      keys.push("omid:" + v);
+    }
+    return { kids, keys };
+  }
+  function renderDeckKids(kids, kidKeys, vals, ctx) {
+    return kids.map((b, j) => {
+      const k = kidKeys ? kidKeys[j] : j;
+      const out = b(vals, ctx, k);
+      return kidKeys != null && typeof out === "string" ? h(getReact().Fragment, { key: k }, out) : out;
+    });
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || (el.getAttribute("component-from-global-scope") ? "" : el.getAttribute("src") || el.getAttribute("import") || "");
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const deckKeyed = hasContent && isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : hasContent ? walkChildren(el, host) : [];
+    const kidKeys = deckKeyed?.keys ?? null;
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) {
+        props.children = renderDeckKids(kids, kidKeys, vals, ctx);
+      }
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const deckKeyed = isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : walkChildren(el, host);
+    const kidKeys = deckKeyed?.keys ?? null;
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...renderDeckKids(kids, kidKeys, vals, ctx));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/bundled.ts
+  function bundledBlob(url) {
+    const blobs = window.__resourceBlobs;
+    const b = blobs ? blobs[url.split("#")[0]] : void 0;
+    return b instanceof Blob ? b : null;
+  }
+
+  // src/cdn.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  function cdnScriptFor(url, sri) {
+    const res = window.__resources;
+    const v = res ? res[url] : void 0;
+    return typeof v === "string" && v ? { src: v } : { src: url, integrity: sri };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      const babel = cdnScriptFor(BABEL_URL, BABEL_SRI);
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = babel.src;
+        if (babel.integrity) {
+          s.integrity = babel.integrity;
+          s.crossOrigin = "anonymous";
+        }
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => {
+        const pre = bundledBlob(url);
+        if (pre) return pre.text();
+        return fetch(url).then((r) => {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.text();
+        });
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            if (tag === "LINK") {
+              const rel = (child.getAttribute("rel") || "").toLowerCase().split(/\s+/);
+              const href = (child.getAttribute("href") || "").trim();
+              const res = window.__resources;
+              const pre = res && rel.includes("stylesheet") && !rel.includes("alternate") ? res[href] : void 0;
+              const blob = typeof pre === "string" && pre ? bundledBlob(pre) : null;
+              if (blob) {
+                const el = doc.createElement("style");
+                if (child.hasAttribute("disabled")) {
+                  el.setAttribute("media", "not all");
+                } else if (child.getAttribute("media")) {
+                  el.setAttribute("media", child.getAttribute("media"));
+                }
+                if (child.getAttribute("title"))
+                  el.setAttribute("title", child.getAttribute("title"));
+                void blob.text().then((css) => {
+                  el.textContent = css;
+                });
+                doc.head.appendChild(el);
+                continue;
+              }
+            }
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function scanUnquotedUrl(css, i) {
+    if (css[i] !== "u" && css[i] !== "U" || css.slice(i, i + 4).toLowerCase() !== "url(" || /[a-z0-9_-]/i.test(css[i - 1] ?? "")) {
+      return -1;
+    }
+    let j = i + 4;
+    while (j < css.length && /\s/.test(css[j])) j++;
+    if (css[j] === '"' || css[j] === "'") return -1;
+    while (j < css.length && css[j] !== ")") {
+      if (css[j] === "\\") j++;
+      j++;
+    }
+    return j < css.length ? j + 1 : css.length;
+  }
+  function stripComments(css) {
+    let out = "";
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") {
+          out += c + (css[i + 1] ?? "");
+          i++;
+          continue;
+        }
+        if (c === quote) quote = "";
+        out += c;
+      } else if (c === "'" || c === '"') {
+        quote = c;
+        out += c;
+      } else if (c === "/" && css[i + 1] === "*") {
+        const end = css.indexOf("*/", i + 2);
+        i = end === -1 ? css.length : end + 1;
+        out += " ";
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end === -1) out += c;
+        else {
+          out += css.slice(i, end);
+          i = end - 1;
+        }
+      }
+    }
+    return out;
+  }
+  function importantify(css) {
+    css = stripComments(css);
+    const decls = [];
+    let start = 0;
+    let depth = 0;
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") i++;
+        else if (c === quote) quote = "";
+      } else if (c === "'" || c === '"') quote = c;
+      else if (c === "(") depth++;
+      else if (c === ")") depth = Math.max(0, depth - 1);
+      else if (c === ";" && depth === 0) {
+        decls.push(css.slice(start, i));
+        start = i + 1;
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end !== -1) i = end - 1;
+      }
+    }
+    decls.push(css.slice(start));
+    return decls.map((d) => d.trim()).filter(Boolean).map((d) => /!\s*important$/i.test(d) ? d : d + " !important").join(";");
+  }
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const isPseudoElement = pseudo === "before" || pseudo === "after";
+      const sel = isPseudoElement ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(
+        sel + "{" + (isPseudoElement ? css : importantify(css)) + "}",
+        el.sheet.cssRules.length
+      );
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      const res = window.__resources;
+      const pre = res ? res[url] : void 0;
+      const target = typeof pre === "string" && pre ? pre : url;
+      const blob = bundledBlob(target);
+      (blob ? blob.text() : fetch(target).then((res2) => {
+        if (!res2.ok) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '" failed:',
+            url,
+            "returned",
+            res2.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res2.text();
+      })).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '":',
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          '[dc-runtime] sibling fetch for "' + name + '" threw:',
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/stream-state.ts
+  function createStreamTracker(staleMs = 6e4, now = Date.now) {
+    const since = /* @__PURE__ */ new Map();
+    const liveOne = (n) => {
+      const t = since.get(n);
+      if (t === void 0) return false;
+      if (now() - t > staleMs) {
+        since.delete(n);
+        return false;
+      }
+      return true;
+    };
+    return {
+      push(name, streaming, viewportKey) {
+        if (viewportKey === "dc-model") return;
+        if (streaming) since.set(name, now());
+        else since.delete(name);
+      },
+      live(name) {
+        if (name !== void 0) return liveOne(name);
+        for (const n of [...since.keys()]) if (liveOne(n)) return true;
+        return false;
+      }
+    };
+  }
+
+  // src/index.ts
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      if (integrity) {
+        s.integrity = integrity;
+        s.crossOrigin = "anonymous";
+      }
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    const react = cdnScriptFor(REACT_URL, REACT_SRI);
+    const reactDom = cdnScriptFor(REACT_DOM_URL, REACT_DOM_SRI);
+    return Promise.all([
+      loadScript(react.src, react.integrity),
+      loadScript(reactDom.src, reactDom.integrity)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const streams = createStreamTracker();
+    const api = {
+      __dcUpdate: (name, kind, content, streaming, viewportKey) => {
+        streams.push(name, streaming, viewportKey);
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcStreaming: (name) => streams.live(name),
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`sc-camel-*` attrs,
+       *  `<sc-raw-*>`/`<sc-helmet>` tags); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();

--- a/docs/openspec/specs/rollup-engine/design.md
+++ b/docs/openspec/specs/rollup-engine/design.md
@@ -65,7 +65,7 @@ Rounding up is not an arithmetic preference but a physical fact: you cannot buil
 
 ### Tier 2 constants injected, never hardcoded
 
-**Choice**: All economy constants — yields, dome capacity, extractor rates per class, generator outputs, class multipliers, draws, depot thresholds, battery ratios — arrive as a parameter.
+**Choice**: All economy constants — crop yields, dome capacity, extractor rates per class, generator outputs, class multipliers, draws, depot thresholds and capacities, battery ratios, fauna yield per collection cycle, cycle durations, and steps per nutrient processor — arrive as a parameter.
 
 **Rationale**: ADR-0001 marks these as provisional and hand-curated; the game rebalances. The base-planner handoff already treats them as tweakable: *"`emOutput` (kPs, default 110) — swap in real game data without touching code."* Injection also makes every producer and power scenario testable with small synthetic constant sets rather than the full production dataset.
 
@@ -120,7 +120,7 @@ graph TD
 - **Rational arithmetic is slower than float** → Irrelevant at this scale, and correctness is worth far more than nanoseconds here.
 - **Tier 2 injection means every caller must supply constants** → Mitigated by shipping a canonical constants loader alongside the artifact, so callers pass a parsed dataset rather than assembling one.
 - **Taint propagation may over-flag** → Accepted deliberately. If most figures end up flagged, that is a signal that Tier 2 needs verification work, not that the rule is wrong.
-- **The 34-node acceptance test could ossify** → It asserts against community-sourced data that may change with game updates. Keep the fixture pinned to a stated game version so a failure reads as "data changed" rather than "engine broke".
+- **The 34-node acceptance test could ossify** → It asserts against community-sourced data that may change with game updates. The spec's Dependency Graph Resolution requirement makes the version pin normative: a fixture asserting exact counts must name the game version it was captured against, so a failure reads as "data changed" rather than "engine broke".
 
 ## Migration Plan
 

--- a/docs/openspec/specs/rollup-engine/design.md
+++ b/docs/openspec/specs/rollup-engine/design.md
@@ -1,0 +1,139 @@
+# Design: Rollup Engine
+
+## Context
+
+The base planner's two surfaces are both views over one computation: resolve a target item into a dependency graph, propagate quantities, group leaves by base, and turn each base's share into producer counts and a power budget.
+
+The design prototypes each implemented this math independently, with their own sample constants — `docs/design/tree-canvas/handoff.md` for graph structure, `docs/design/base-planner/handoff.md` for the producer and power rollup. Both handoffs are explicit that their numbers are illustrative and that production reads real game data. That divergence is the problem this spec closes: one implementation, two consumers.
+
+ADR-0003 places this engine in a Go package that imports no `syscall/js`. That constraint is what makes it shared with the ingestion CLI and testable with plain `go test`. ADR-0001 supplies its inputs as two tiers with different confidence levels — an extracted recipe graph and hand-curated economy constants — which is why provenance is a first-class concern here rather than a UI decoration.
+
+Nothing is implemented yet. This is a greenfield design.
+
+## Goals / Non-Goals
+
+### Goals
+
+- One graph and rollup implementation shared by the tree canvas, the base planner, and the ingestion CLI
+- Exact arithmetic, so displayed counts are trustworthy and tests are stable
+- Deterministic output, which plan-sharing and testing both depend on
+- Tier 2 constants injected at call time so game-balance changes need no code change
+- Provenance carried through derivation, so the `unverified` badge is data-driven
+- Testable against the handoffs' known-correct values without a browser
+
+### Non-Goals
+
+- Save file parsing (ADR-0002, separate spec)
+- Plan serialization to and from the URL hash (separate spec)
+- Layout — node positioning is elkjs's job in the view layer
+- Rendering, styling, and accessibility (ADR-0004, view layer)
+- Mixed-type power grids at one base (see Open Questions)
+- Persistence of any kind
+
+## Decisions
+
+### Pure function pipeline over an immutable plan input
+
+**Choice**: The engine exposes a computation from an immutable `PlanInput` to a `PlanResult`. No internal mutable state persists between calls.
+
+**Rationale**: Determinism (a spec requirement) falls out for free. It makes the WASM boundary trivial — the adapter marshals one value in and one value out, with no lifecycle to manage across the JS/Go divide. And it makes every scenario in the spec expressible as a table-driven test.
+
+**Alternatives considered**:
+- *Stateful engine object with incremental updates*: would allow finer-grained recomputation, but introduces cache-invalidation bugs precisely where correctness matters most, and complicates the WASM boundary. At this scale (34 nodes, a handful of bases) full recomputation is cheap enough that incrementalism buys nothing.
+- *Streaming/observable API*: unnecessary for a computation that completes in well under a frame.
+
+### Three sequential stages with explicit boundaries
+
+**Choice**: `resolve` (graph) → `rollup` (producers) → `power` (budget). Each stage takes the prior stage's output plus its own configuration.
+
+**Rationale**: The tree canvas needs only stage one. The base planner needs all three. Separating them means the canvas does not pay for producer math, and each stage is independently testable. It also localizes the Tier 2 dependency — stage one needs only Tier 1 data, so graph resolution can be tested with no economy constants at all.
+
+**Alternatives considered**:
+- *Single monolithic computation*: simpler signature, but couples the canvas to constants it does not use and makes failures harder to localize.
+
+### Exact integer and rational arithmetic
+
+**Choice**: Quantities are integers throughout. Non-integer multipliers (class multipliers of ×0.5/1/1.5/2, fill durations) are applied as exact rationals. Rounding happens only at named physical boundaries and always rounds up.
+
+**Rationale**: This is the decision most likely to be regretted if made casually. Binary floating point accumulating across a 6-level graph can produce a leaf total of 499.9999999 where 500 is correct, and `ceil` then yields a wrong producer count — an off-by-one that surfaces as a wrong build checklist and is miserable to debug. Integers make the handoffs' known values (500 gases, 300 Condensed Carbon) exactly assertable.
+
+Rounding up is not an arithmetic preference but a physical fact: you cannot build 0.4 of a biodome, and rounding down would under-provision the base.
+
+**Alternatives considered**:
+- *Floating point with epsilon comparison*: pushes tolerance decisions into every test and every comparison, and the epsilon is a lie that eventually bites.
+- *Fixed-point decimal*: workable, but rationals express the class multipliers more directly and Go's `math/big.Rat` is available without a dependency.
+
+### Tier 2 constants injected, never hardcoded
+
+**Choice**: All economy constants — yields, dome capacity, extractor rates per class, generator outputs, class multipliers, draws, depot thresholds, battery ratios — arrive as a parameter.
+
+**Rationale**: ADR-0001 marks these as provisional and hand-curated; the game rebalances. The base-planner handoff already treats them as tweakable: *"`emOutput` (kPs, default 110) — swap in real game data without touching code."* Injection also makes every producer and power scenario testable with small synthetic constant sets rather than the full production dataset.
+
+### Byproducts offset demand rather than generating construction
+
+**Choice**: When an item's demand at a base is satisfied by a byproduct of another producer at that base, the engine reports it as requiring no construction, contributing neither producer count nor power draw.
+
+**Rationale**: This matches the handoff's specified behavior (Condensed Carbon from gas refining renders as "nothing to build"). Modelling it as an offset in the rollup stage — rather than as a graph edge — keeps the graph a pure dependency structure and confines the accounting to where it belongs.
+
+**Alternatives considered**:
+- *Representing byproducts as negative demand in the graph*: conflates dependency structure with resource accounting and makes the canvas harder to reason about.
+
+### Provenance propagates by taint
+
+**Choice**: Every computed figure carries a verified/unverified flag. Any unverified input taints every figure derived from it.
+
+**Rationale**: The `unverified` badge is a designed UI affordance with specific honest-labelling intent, and ADR-0001 establishes two data tiers with genuinely different confidence. Computing provenance in the engine rather than the view means the rule is applied once and consistently. Taint propagation is the conservative direction — over-flagging is honest, under-flagging presents guesses as facts.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph inputs["Inputs"]
+        T1["Tier 1 artifact<br/>recipe graph + provenance"]
+        T2["Tier 2 constants<br/>yields · rates · outputs · draws"]
+        PI["PlanInput<br/>target · qty · methods<br/>assignments · site config"]
+    end
+
+    T1 --> R
+    PI --> R
+    R["Stage 1: resolve<br/>graph build · method resolution<br/>quantity propagation · cycle detect"]
+    R --> G["ResolvedGraph<br/>nodes · totals · provenance"]
+
+    G --> RU
+    T2 --> RU
+    PI --> RU
+    RU["Stage 2: rollup<br/>group by base · producer counts<br/>byproduct offset"]
+    RU --> B["BaseRollups<br/>farm · extractor · ranch · kitchen"]
+
+    B --> P
+    T2 --> P
+    P["Stage 3: power<br/>generation · draw · deficit sizing"]
+    P --> RES["PlanResult"]
+
+    G -.->|"stage 1 only"| TC["Tree canvas"]
+    RES --> BP["Base planner"]
+```
+
+## Risks / Trade-offs
+
+- **Full recomputation on every interaction** → At the specced scale (34 nodes, ~3 bases) this completes far inside a frame, and the pure-function design makes it correct by construction. If a future target produces a much larger tree, memoize at the stage boundary rather than introducing incremental invalidation.
+- **Rational arithmetic is slower than float** → Irrelevant at this scale, and correctness is worth far more than nanoseconds here.
+- **Tier 2 injection means every caller must supply constants** → Mitigated by shipping a canonical constants loader alongside the artifact, so callers pass a parsed dataset rather than assembling one.
+- **Taint propagation may over-flag** → Accepted deliberately. If most figures end up flagged, that is a signal that Tier 2 needs verification work, not that the rule is wrong.
+- **The 34-node acceptance test could ossify** → It asserts against community-sourced data that may change with game updates. Keep the fixture pinned to a stated game version so a failure reads as "data changed" rather than "engine broke".
+
+## Migration Plan
+
+Greenfield — no migration. Build order: stage 1 with the Stasis Device fixture, then stage 2 against the base-planner handoff's worked examples, then stage 3.
+
+Stage 1 is independently valuable: it unblocks the tree canvas without any Tier 2 constants existing yet, which matters because ADR-0001 leaves Tier 2 as a provisional finding pending the extraction spike.
+
+## Open Questions
+
+Carried from the design handoffs, all deferred rather than resolved:
+
+1. **Mixed power grids.** The base-planner handoff models one power type per base and notes production likely needs a generator list instead of a type toggle. This spec follows the mock (single type per base). Revisit before implementing stage 3 in earnest.
+2. **Per-row extractor class override.** Deferred in the handoff pending a user asking for it; this spec specifies site-level class only.
+3. **Where refining time is charged.** The handoff notes `ready ~t` ignores refine time at the collector base and leaves placement to the app-shell surface. This spec does not yet compute a `ready` duration for that reason.
+4. **Large-tree behavior.** The handoff flags that a 60+ node tree may need edge labels on hover only. That is a view concern, but it suggests the engine should be benchmarked against a combined Fusion Ignitor plus Stasis Device tree before assuming full recomputation stays cheap.
+5. **Whether Tier 2 survives the extraction spike.** If the economy constants turn out to be extractable from game files after all (ADR-0001's provisional finding), the injected-constants decision stands but the provenance model simplifies considerably.

--- a/docs/openspec/specs/rollup-engine/spec.md
+++ b/docs/openspec/specs/rollup-engine/spec.md
@@ -24,10 +24,17 @@ The engine MUST resolve a target item and quantity into a directed acyclic graph
 
 The graph MUST be derived from the Tier 1 artifact. The engine MUST NOT contain hardcoded recipe data.
 
+Fixtures asserting exact node counts or exact leaf totals MUST name the game version of the Tier 1 artifact they were captured against, so that a failure is attributable to changed game data rather than to a regression in the engine.
+
 #### Scenario: Resolving the Stasis Device tree
 
-- **WHEN** the target is Stasis Device at quantity 1 with default methods
+- **WHEN** the target is Stasis Device at quantity 1 with default methods, against a Tier 1 artifact stamped with the fixture's recorded game version
 - **THEN** the engine returns a graph of exactly 34 distinct nodes spanning the Quantum Processor, Cryogenic Chamber, and Iridesite branches
+
+#### Scenario: Fixture game version is asserted
+
+- **WHEN** a pinned fixture is evaluated against a Tier 1 artifact whose game version differs from the one the fixture records
+- **THEN** the failure identifies the version mismatch rather than reporting only a node-count or total mismatch
 
 #### Scenario: Terminal nodes are not expanded
 
@@ -59,6 +66,11 @@ The engine MUST report which methods are legal for a given node so the view can 
 
 - **WHEN** any input requests the method `buy`
 - **THEN** the engine returns an error indicating the method is not part of the vocabulary
+
+#### Scenario: Cook method expands a nutrient processor recipe
+
+- **WHEN** a node resolves to method `cook` and the Tier 1 artifact holds a nutrient processor recipe for it
+- **THEN** the node gains child edges for that recipe's inputs, and its quantities propagate exactly as for `craft` and `refine`
 
 ### Requirement: Quantity Propagation and Aggregation
 
@@ -94,7 +106,7 @@ The engine MUST detect cycles during graph resolution and MUST return an error n
 
 All item quantities MUST be represented as exact integers. Multipliers that are not integers (such as extractor and generator class multipliers) MUST be applied as exact rational arithmetic. The engine MUST NOT accumulate binary floating-point error across the graph.
 
-Rounding MUST occur only at stated physical boundaries, and MUST round up, because partial physical units cannot be built. The boundaries are: plants per crop, biodomes per crop, extractors per resource, supply depots per resource, generators per base, and batteries per base.
+Rounding MUST occur only at stated physical boundaries, and MUST round up, because partial physical units cannot be built. The boundaries are: plants per crop, biodomes per crop, extractors per resource, supply depots per resource, fauna per fauna product, nutrient processors per base, generators per base, and batteries per base.
 
 #### Scenario: Plants round up
 
@@ -134,7 +146,13 @@ The engine MUST accept an assignment of leaf items to bases and MUST group leaf 
 
 For each base, the engine MUST convert assigned leaf totals into producer requirements by producer type: `farm`, `extractor`, `ranch`, and `kitchen`. Producer counts MUST derive from Tier 2 constants supplied at call time and MUST NOT be hardcoded.
 
-Farm rows MUST report plant count and biodome count. Extractor rows MUST report extractor count sized so the required quantity is produced within a configured fill duration at the site's configured class, together with the resulting fill time, and MUST report supply depots when the required quantity exceeds the configured depot threshold.
+Farm rows MUST report plant count and biodome count.
+
+Extractor rows MUST report extractor count sized so the required quantity is produced within a configured fill duration at the site's configured class, together with the resulting fill time. Where the required quantity exceeds the configured depot threshold, the row MUST additionally report a supply depot count of `ceil(required quantity / depot capacity)`, where both the threshold and the capacity are Tier 2 constants. Below the threshold the row MUST report no depots.
+
+Ranch rows MUST report the fauna count required to yield the required quantity within one configured collection cycle, together with the resulting cycle time. Where any fauna product assigned to a base requires feeding, the base MUST report a pellet feeder. Feeders MUST be reported once per base rather than once per row, because one feeder serves every fed fauna product at that base.
+
+Kitchen rows MUST report each processing step's input-to-output ratio and its process duration, and MUST distinguish intermediate steps from the step that produces the plan target. Nutrient processor count MUST be reported once per base as `ceil(step count / steps per processor)` from a Tier 2 constant, and MUST NOT be the sum of per-row processor counts.
 
 Extractor class MUST be configured per site, not per row.
 
@@ -154,6 +172,36 @@ Items whose demand is satisfied by a byproduct of another producer at the same b
 
 - **WHEN** the extractor class at a base changes from B to S
 - **THEN** every extractor row at that base recomputes its count and fill time, and no other base is affected
+
+#### Scenario: Supply depots sized above the threshold
+
+- **WHEN** a base is assigned a resource requiring 2500 units, at a depot threshold of 1000 units and a depot capacity of 1000 units
+- **THEN** the engine reports 3 supply depots for that row
+
+#### Scenario: No depots below the threshold
+
+- **WHEN** a base is assigned a resource requiring 800 units at a depot threshold of 1000 units
+- **THEN** the engine reports no supply depots for that row
+
+#### Scenario: Ranch rollup
+
+- **WHEN** a base is assigned a fauna product requiring 100 units at a yield of 12 units per creature per collection cycle
+- **THEN** the engine reports 9 fauna for that product, together with the cycle time
+
+#### Scenario: Feeder is reported once per base
+
+- **WHEN** a base is assigned two distinct fauna products that both require feeding
+- **THEN** the engine reports 1 pellet feeder for that base, not one per row
+
+#### Scenario: Kitchen rollup sizes processors per base
+
+- **WHEN** a base carries 4 nutrient processor steps at a Tier 2 rate of 2 steps per processor
+- **THEN** the engine reports 2 nutrient processors once for that base, not a processor count on each of the 4 rows
+
+#### Scenario: Final kitchen step is distinguished
+
+- **WHEN** a base's kitchen steps include the one producing the plan target
+- **THEN** that step is marked as the final step and the remaining steps are marked intermediate
 
 #### Scenario: Byproduct satisfies demand
 

--- a/docs/openspec/specs/rollup-engine/spec.md
+++ b/docs/openspec/specs/rollup-engine/spec.md
@@ -1,0 +1,243 @@
+---
+status: draft
+date: 2026-08-17
+implements: [ADR-0001, ADR-0003]
+---
+
+# SPEC-0001: Rollup Engine
+
+## Overview
+
+The rollup engine is the computational core of the base planner. Given a target item and quantity, it resolves the full crafting/refining/cooking dependency graph, propagates quantities down that graph, aggregates leaf resources, assigns them to bases, and converts each base's assignment into concrete producer counts and a power budget.
+
+Both surfaces are views over this engine: the tree canvas renders its graph, and the base planner renders its per-base rollup. The design prototypes each reimplemented this math independently with sample constants; this spec defines the single implementation both surfaces consume.
+
+Per ADR-0003 the engine lives in a Go package that imports no `syscall/js`, making it usable unchanged by the ingestion CLI and testable without a browser. Per ADR-0001 it consumes a two-tier dataset: an extracted recipe graph (Tier 1) and hand-curated economy constants (Tier 2).
+
+Save file import (ADR-0002) and plan URL serialization are separate capabilities and are out of scope here.
+
+## Requirements
+
+### Requirement: Dependency Graph Resolution
+
+The engine MUST resolve a target item and quantity into a directed acyclic graph of nodes, where each node carries an item identity, a resolved method, and a total required quantity. Expansion MUST terminate at nodes whose resolved method is terminal (`raw`), and MUST NOT expand beyond them.
+
+The graph MUST be derived from the Tier 1 artifact. The engine MUST NOT contain hardcoded recipe data.
+
+#### Scenario: Resolving the Stasis Device tree
+
+- **WHEN** the target is Stasis Device at quantity 1 with default methods
+- **THEN** the engine returns a graph of exactly 34 distinct nodes spanning the Quantum Processor, Cryogenic Chamber, and Iridesite branches
+
+#### Scenario: Terminal nodes are not expanded
+
+- **WHEN** a node's resolved method is `raw`
+- **THEN** the node has no child edges, even when the Tier 1 artifact contains a recipe that could produce it
+
+#### Scenario: Unknown target
+
+- **WHEN** the requested target item ID is absent from the Tier 1 artifact
+- **THEN** the engine returns an error identifying the missing ID, and returns no partial graph
+
+### Requirement: Method Resolution
+
+Each node MUST resolve to exactly one method from the set `craft`, `refine`, `raw`, `cook`. The engine MUST NOT define, accept, or produce a `buy` method — this is a build planner, not a shopping list.
+
+The engine MUST report which methods are legal for a given node so the view can render unavailable options as inert rather than hiding them. Changing a node's method MUST change that node's expansion, and MUST trigger recomputation of all totals derived from it.
+
+#### Scenario: Method change alters expansion
+
+- **WHEN** a node's method changes from `raw` to `refine`
+- **THEN** the node gains child edges for its refine inputs, and all ancestor quantities are recomputed
+
+#### Scenario: Illegal method rejected
+
+- **WHEN** a method is requested for a node that has no recipe of that kind in the Tier 1 artifact
+- **THEN** the engine returns an error naming the node and the illegal method, and the plan is left unchanged
+
+#### Scenario: No buy method exists
+
+- **WHEN** any input requests the method `buy`
+- **THEN** the engine returns an error indicating the method is not part of the vocabulary
+
+### Requirement: Quantity Propagation and Aggregation
+
+The engine MUST propagate required quantities from the target downward, multiplying each edge's per-unit quantity by its parent's total. Where the same item is required by multiple parents, the engine MUST aggregate those demands into a single total for that item.
+
+Totals MUST scale linearly with the target quantity.
+
+#### Scenario: Shared inputs aggregate
+
+- **WHEN** the target is Stasis Device at quantity 1
+- **THEN** Condensed Carbon totals 300 units, aggregated across all six recipes that consume 50 each
+
+#### Scenario: Gas totals at quantity 1
+
+- **WHEN** the target is Stasis Device at quantity 1
+- **THEN** Sulphurine, Nitrogen, and Radon each total 500 units, each arising from two recipes consuming 250
+
+#### Scenario: Linear scaling
+
+- **WHEN** the target quantity changes from 1 to 10
+- **THEN** every leaf total is exactly ten times its value at quantity 1
+
+### Requirement: Cycle Detection
+
+The engine MUST detect cycles during graph resolution and MUST return an error naming the participating nodes rather than recursing without bound. Refining relationships in the source data are capable of forming cycles, so this is a runtime condition and MUST NOT be assumed away.
+
+#### Scenario: Cyclic method selection
+
+- **WHEN** a combination of method selections would cause a node to appear as its own ancestor
+- **THEN** the engine returns a cycle error listing the node IDs forming the cycle, and returns no graph
+
+### Requirement: Exact Arithmetic and Rounding Discipline
+
+All item quantities MUST be represented as exact integers. Multipliers that are not integers (such as extractor and generator class multipliers) MUST be applied as exact rational arithmetic. The engine MUST NOT accumulate binary floating-point error across the graph.
+
+Rounding MUST occur only at stated physical boundaries, and MUST round up, because partial physical units cannot be built. The boundaries are: plants per crop, biodomes per crop, extractors per resource, supply depots per resource, generators per base, and batteries per base.
+
+#### Scenario: Plants round up
+
+- **WHEN** a crop requires 250 units at a yield of 32 units per plant
+- **THEN** the engine reports 8 plants, not 7.8125
+
+#### Scenario: Domes round up from plants
+
+- **WHEN** a crop requires 17 plants at a dome capacity of 16
+- **THEN** the engine reports 2 biodomes
+
+#### Scenario: No intermediate rounding
+
+- **WHEN** a quantity passes through multiple graph levels before reaching a leaf
+- **THEN** the leaf total equals the exact product of the per-edge quantities, with no rounding applied at intermediate levels
+
+### Requirement: Leaf Assignment to Bases
+
+The engine MUST accept an assignment of leaf items to bases and MUST group leaf totals by their assigned base. Leaves with no assignment MUST be reported in a distinct unassigned group rather than being silently dropped or attributed to a default base.
+
+#### Scenario: Leaves group by base
+
+- **WHEN** crops are assigned to one base and gases to another
+- **THEN** each base's rollup contains only its assigned leaf items
+
+#### Scenario: Unassigned leaves are surfaced
+
+- **WHEN** a leaf item has no base assignment
+- **THEN** it appears in the unassigned group with its full required total
+
+#### Scenario: Reassignment recomputes both bases
+
+- **WHEN** a leaf is reassigned from one base to another
+- **THEN** both the origin and destination base rollups are recomputed, including their power budgets
+
+### Requirement: Producer Rollup
+
+For each base, the engine MUST convert assigned leaf totals into producer requirements by producer type: `farm`, `extractor`, `ranch`, and `kitchen`. Producer counts MUST derive from Tier 2 constants supplied at call time and MUST NOT be hardcoded.
+
+Farm rows MUST report plant count and biodome count. Extractor rows MUST report extractor count sized so the required quantity is produced within a configured fill duration at the site's configured class, together with the resulting fill time, and MUST report supply depots when the required quantity exceeds the configured depot threshold.
+
+Extractor class MUST be configured per site, not per row.
+
+Items whose demand is satisfied by a byproduct of another producer at the same base MUST be reported as requiring no construction, and MUST NOT contribute a producer count or a power draw.
+
+#### Scenario: Farm rollup
+
+- **WHEN** a base is assigned a crop requiring 200 units at a yield of 25 per plant and a dome capacity of 16
+- **THEN** the engine reports 8 plants and 1 biodome for that crop
+
+#### Scenario: Extractor sized to fill duration
+
+- **WHEN** a base is assigned a gas requiring 500 units, with a class-B rate of 200 units per hour and a target fill duration of 1.5 hours
+- **THEN** the engine reports 2 extractors and the resulting fill time
+
+#### Scenario: Site class applies to all rows
+
+- **WHEN** the extractor class at a base changes from B to S
+- **THEN** every extractor row at that base recomputes its count and fill time, and no other base is affected
+
+#### Scenario: Byproduct satisfies demand
+
+- **WHEN** a base's Condensed Carbon demand is met by the byproduct of gas refining at that same base
+- **THEN** the engine reports that item as requiring no construction, with no producer count and no power draw
+
+### Requirement: Power Computation
+
+For each base the engine MUST compute total generation, total draw, and the resulting surplus or deficit, using Tier 2 constants supplied at call time.
+
+Generation MUST support two source types. Electromagnetic generators MUST apply a class multiplier to a base output. Solar panels MUST be classless and MUST additionally require batteries at a configured ratio for night coverage.
+
+When draw exceeds generation, the engine MUST report the deficit and MUST report the number of additional generation units required to clear it, so the view can present the fix as an action rather than a warning.
+
+#### Scenario: EM generation by class
+
+- **WHEN** a base has 3 electromagnetic generators at class A, with a class-B base output of 110 kPs and a class-A multiplier of 1.5
+- **THEN** the engine reports 495 kPs of generation
+
+#### Scenario: Solar requires batteries
+
+- **WHEN** a base is powered by 5 solar panels at a ratio of 1 battery per 2 panels
+- **THEN** the engine reports 3 batteries as required
+
+#### Scenario: Deficit reports the fix
+
+- **WHEN** a base draws 400 kPs against 330 kPs of generation from class-B electromagnetic generators producing 110 kPs each
+- **THEN** the engine reports a deficit of 70 kPs and reports that 1 additional generator clears it
+
+#### Scenario: Downgrade reopens a deficit
+
+- **WHEN** a base at surplus has its generator class downgraded such that generation falls below draw
+- **THEN** the engine reports a deficit and the required additional unit count
+
+### Requirement: Provenance Propagation
+
+Every computed figure MUST carry provenance indicating whether all inputs contributing to it were verified. Where any contributing node or constant is marked unverified in the source data, the derived figure MUST be marked unverified.
+
+The engine MUST NOT silently present unverified-derived values as verified.
+
+#### Scenario: Unverified input taints derived total
+
+- **WHEN** a node in a leaf's ancestry is marked unverified in the Tier 1 artifact
+- **THEN** that leaf's total is marked unverified
+
+#### Scenario: Unverified constant taints producer count
+
+- **WHEN** a Tier 2 constant used in a producer calculation lacks a verified date
+- **THEN** the resulting producer count is marked unverified
+
+### Requirement: Determinism
+
+Given identical inputs — target, quantity, method selections, base assignments, site configurations, and the Tier 1 and Tier 2 datasets — the engine MUST produce identical output. Iteration over unordered collections MUST NOT leak into output ordering.
+
+#### Scenario: Repeated computation is stable
+
+- **WHEN** the same plan input is computed twice in the same process
+- **THEN** the two outputs are byte-identical when serialized
+
+#### Scenario: Stable ordering
+
+- **WHEN** a rollup contains multiple items within a producer section
+- **THEN** those items appear in a deterministic order that does not vary between runs
+
+### Requirement: Error Handling Standards
+
+All error-producing operations MUST follow structured error handling:
+
+- Errors MUST be wrapped with contextual information at each layer boundary (e.g., "resolving Stasis Device: expanding Cryo-Pump: unknown item ID prod999")
+- Sentinel errors MUST be defined for domain-specific failure modes that callers need to distinguish programmatically — at minimum: unknown item, illegal method, cycle detected, and missing constant
+- Silent error swallowing MUST NOT occur — every error MUST be either returned to the caller, logged with sufficient context, or explicitly handled with a documented reason for suppression
+- Structured logging MUST be used for error reporting (key-value pairs, not string interpolation)
+
+#### Scenario: Errors carry the resolution path
+
+- **WHEN** graph resolution fails at a node several levels deep
+- **THEN** the returned error names the chain of items from the target to the failing node
+
+#### Scenario: Missing constant is distinguishable
+
+- **WHEN** a Tier 2 constant required by a producer calculation is absent
+- **THEN** the engine returns an error matching the missing-constant sentinel, naming the constant
+
+#### Scenario: No partial results on failure
+
+- **WHEN** any stage of computation returns an error
+- **THEN** the engine returns no partial rollup alongside that error


### PR DESCRIPTION
Establishes the architecture for the NMS base and resource planner, ahead of any implementation. Everything here is documentation — no production source yet.

## What's here

**Design handoff bundle** (`docs/design/`) — four surfaces: tree canvas, base planner, Base Atlas, and the gruvbox token sheet. Updated to the 2026-08-17 bundle, which adds the Atlas surface and the 8-bit restyle. `theme/` and `tree-canvas/` handoffs are unchanged from the first bundle, so tokens and graph structure are stable.

**ADRs 0001–0004** — all `status: proposed`.

| ADR | Decision |
|---|---|
| [0001](docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md) | Two-tier data ingestion — Go CLI + MBINCompiler for the recipe graph, hand-curated economy constants |
| [0002](docs/adrs/ADR-0002-client-side-save-import.md) | Client-side save import — read-only, never leaves the browser |
| [0003](docs/adrs/ADR-0003-go-wasm-domain-core.md) | Go/WASM domain core with a thin view layer |
| [0004](docs/adrs/ADR-0004-react-view-layer.md) | React + TypeScript + Vite for the view |

**[SPEC-0001 Rollup Engine](docs/openspec/specs/rollup-engine/spec.md)** — 11 requirements, 39 scenarios, paired with a design.md. All four producer types (`farm`, `extractor`, `ranch`, `kitchen`) and both plan targets (STASIS, CAKE) now have specified row shapes and scenarios; supply depots have a count rule rather than only a reporting threshold; and fixtures asserting exact node counts must name the game version they were captured against.

## Decisions worth a second look

**Licensing.** MBINCompiler is LGPL-3.0 and invoked as a subprocess, so extracted output carries no copyleft. Vendoring AssistantNMS's JSON was rejected because it is GPL-3.0 — and it would not have closed the economy-constants gap regardless, since their `Buildings.lang.json` schema has no power or yield fields.

**Save-file privacy.** A save is the player's whole game state — discovered systems, base locations, inventory, platform UID. ADR-0002 keeps parsing client-side and read-only, with two structural guarantees rather than conventions: no network call on the import path (asserted by test), and no save-writing function anywhere in the codebase (confirmed by grep). This repo is public, so `.gitignore` also covers `.hg` files and decoded dumps.

**The `no-syscall/js` boundary** in ADR-0003 is what makes the domain package shared with the ingestion CLI and testable with plain `go test`. If it erodes, the decision has failed even if the app works.

**Exact arithmetic** in SPEC-0001 is a hard requirement, not implementation taste. Float error accumulating across six graph levels produces 499.9999999 where 500 is correct; `ceil` then yields a wrong extractor count and a wrong build checklist.

## Known-provisional

ADR-0001's Tier 2 finding — that generator kPs, extractor rates, biodome capacity, and crop yields are absent from the game files — is a *searched hard, did not find it* result, **not proof of absence**. The search covered every numeric field matching a keyword set, all 208 `GcStatsTypes` entries, `GcBuildingGlobals`, and `GcMaintenanceComponentData`, but libMBIN exposes field names and types rather than values.

**ADR-0001 and ADR-0002 should not move to `accepted` until an extraction spike confirms this against real MBIN files.** That spike runs on Linux, where the game is installed and where MBINCompiler ships first-class binaries.

SPEC-0001 stage 1 needs only Tier 1 data, so the tree canvas is buildable before that question is settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
