### PR TITLE
Rollup engine stage 1: dependency graph resolution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jonstump/nms-base-planner
+
+go 1.26.6

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -1,0 +1,39 @@
+// Package domain holds the planner's computational core: dependency graph
+// resolution, producer rollup, and power budgeting.
+//
+// Governing: ADR-0003 (Go/WASM domain core). This package MUST NOT import
+// syscall/js — that boundary is what lets the ingestion CLI share it and what
+// makes it testable under plain `go test`. If it erodes, the decision has
+// failed even if the app works.
+package domain
+
+import "errors"
+
+// Sentinel errors for the domain-specific failure modes callers need to
+// distinguish programmatically.
+//
+// Governing: SPEC-0001 REQ "Error Handling Standards" — "Sentinel errors MUST
+// be defined for domain-specific failure modes that callers need to
+// distinguish programmatically — at minimum: unknown item, illegal method,
+// cycle detected, and missing constant".
+var (
+	// ErrUnknownItem reports an item ID absent from the Tier 1 artifact.
+	ErrUnknownItem = errors.New("unknown item")
+
+	// ErrIllegalMethod reports a method requested for a node that has no
+	// recipe of that kind, or a method outside the vocabulary entirely.
+	ErrIllegalMethod = errors.New("illegal method")
+
+	// ErrCycleDetected reports that method selection made a node its own
+	// ancestor.
+	ErrCycleDetected = errors.New("cycle detected")
+
+	// ErrMissingConstant reports an absent Tier 2 economy constant. Stage 1
+	// never returns it; it is defined here so the sentinel set is complete
+	// and stable across stages.
+	ErrMissingConstant = errors.New("missing constant")
+
+	// ErrInvalidArtifact reports a Tier 1 artifact that failed structural
+	// validation at load time.
+	ErrInvalidArtifact = errors.New("invalid tier 1 artifact")
+)

--- a/internal/domain/resolve.go
+++ b/internal/domain/resolve.go
@@ -1,0 +1,302 @@
+package domain
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+	"strings"
+)
+
+// PlanInput is the immutable input to stage 1.
+//
+// Governing: SPEC-0001 design.md "Pure function pipeline over an immutable
+// plan input" — no internal mutable state persists between calls, so
+// determinism falls out for free and the WASM boundary marshals one value in
+// and one value out.
+type PlanInput struct {
+	// Target is the item ID being planned.
+	Target string
+
+	// Quantity is how many of Target are wanted. Must be positive.
+	Quantity int64
+
+	// Methods overrides the per-item default method. Items absent from the
+	// map use their Tier 1 default.
+	Methods map[string]Method
+}
+
+// Edge is one resolved dependency, carrying the per-unit-of-parent quantity.
+type Edge struct {
+	// From is the consuming (parent) item ID.
+	From string
+	// To is the consumed (child) item ID.
+	To string
+	// PerUnit is how many To are needed per single unit of From.
+	PerUnit int64
+}
+
+// Node is one item in the resolved graph, with its aggregated total.
+type Node struct {
+	ItemID string
+	Name   string
+
+	// Method is the single resolved method for this node.
+	Method Method
+
+	// LegalMethods lists every method available to this item, sorted, so the
+	// view can render unavailable options as inert rather than hiding them.
+	LegalMethods []Method
+
+	// Terminal reports that expansion stopped here (method raw).
+	Terminal bool
+
+	// Children are the edges to this node's inputs, sorted by child item ID.
+	// Empty for terminal nodes.
+	Children []Edge
+
+	// Verified is false when this node's total is derived from anything
+	// marked unverified in the Tier 1 artifact — the node itself, its
+	// resolved recipe, or any ancestor.
+	//
+	// Governing: SPEC-0001 REQ "Provenance Propagation".
+	Verified bool
+
+	total *big.Rat
+}
+
+// Total returns the aggregated required quantity as an exact rational.
+//
+// Governing: SPEC-0001 REQ "Exact Arithmetic and Rounding Discipline" — "The
+// engine MUST NOT accumulate binary floating-point error across the graph."
+func (n *Node) Total() *big.Rat { return new(big.Rat).Set(n.total) }
+
+// TotalInt returns the total as an integer, reporting whether it was exact.
+func (n *Node) TotalInt() (int64, bool) {
+	if !n.total.IsInt() {
+		return 0, false
+	}
+	return n.total.Num().Int64(), true
+}
+
+// ResolvedGraph is stage 1's output.
+type ResolvedGraph struct {
+	// Target is the planned item ID.
+	Target string
+	// Quantity is the planned target quantity.
+	Quantity int64
+	// GameVersion is copied from the Tier 1 artifact, so a fixture failure is
+	// attributable to changed game data rather than to an engine regression.
+	GameVersion string
+
+	// Nodes are in topological order: terminals first, target last. This is
+	// the tab order the tree canvas handoff specifies.
+	Nodes []*Node
+
+	byID map[string]*Node
+}
+
+// Node looks up a resolved node by item ID.
+func (g *ResolvedGraph) Node(id string) (*Node, bool) {
+	n, ok := g.byID[id]
+	return n, ok
+}
+
+// Leaves returns the terminal nodes, in graph order.
+func (g *ResolvedGraph) Leaves() []*Node {
+	var out []*Node
+	for _, n := range g.Nodes {
+		if n.Terminal {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// dfsState tracks node colour for cycle detection.
+type dfsState uint8
+
+const (
+	unvisited dfsState = iota
+	inProgress
+	done
+)
+
+// Resolve runs stage 1: it resolves target and quantity into a directed
+// acyclic graph, propagates quantities down it, and aggregates shared demand.
+//
+// It returns no partial graph alongside an error.
+//
+// Governing: SPEC-0001 REQ "Dependency Graph Resolution", REQ "Method
+// Resolution", REQ "Quantity Propagation and Aggregation", REQ "Cycle
+// Detection", REQ "Provenance Propagation", REQ "Determinism".
+func Resolve(t *Tier1, in PlanInput) (*ResolvedGraph, error) {
+	if t == nil {
+		return nil, fmt.Errorf("%w: nil tier 1 artifact", ErrInvalidArtifact)
+	}
+	if in.Quantity <= 0 {
+		return nil, fmt.Errorf("resolving %s: quantity must be positive, got %d", in.Target, in.Quantity)
+	}
+	targetItem, ok := t.Item(in.Target)
+	if !ok {
+		return nil, fmt.Errorf("resolving %s: %w: %q", in.Target, ErrUnknownItem, in.Target)
+	}
+
+	r := &resolver{t: t, in: in, state: map[string]dfsState{}, nodes: map[string]*Node{}}
+	if err := r.walk(in.Target, nil); err != nil {
+		return nil, fmt.Errorf("resolving %s: %w", targetItem.Name, err)
+	}
+
+	g := &ResolvedGraph{
+		Target:      in.Target,
+		Quantity:    in.Quantity,
+		GameVersion: t.GameVersion,
+		byID:        r.nodes,
+	}
+	// r.order is DFS post-order: every node appears after all of its
+	// descendants, so terminals come first and the target comes last.
+	g.Nodes = make([]*Node, 0, len(r.order))
+	for _, id := range r.order {
+		g.Nodes = append(g.Nodes, r.nodes[id])
+	}
+
+	r.propagate(g)
+	return g, nil
+}
+
+type resolver struct {
+	t     *Tier1
+	in    PlanInput
+	state map[string]dfsState
+	nodes map[string]*Node
+	order []string
+}
+
+// method resolves the single method for an item, validating it against the
+// vocabulary and against what the artifact actually offers.
+func (r *resolver) method(it Item) (Method, error) {
+	m, overridden := r.in.Methods[it.ID]
+	if !overridden {
+		return it.DefaultMethod, nil
+	}
+	if !m.Valid() {
+		// Catches "buy" specifically: it is not part of the vocabulary.
+		return "", fmt.Errorf("%w: %q is not part of the method vocabulary (craft, refine, raw, cook)", ErrIllegalMethod, m)
+	}
+	if !r.t.methodAvailable(it, m) {
+		return "", fmt.Errorf("%w: %s has no %s recipe", ErrIllegalMethod, it.Name, m)
+	}
+	return m, nil
+}
+
+// walk performs the depth-first traversal, detecting cycles and building the
+// node and edge structure. Quantities are not computed here.
+func (r *resolver) walk(id string, path []string) error {
+	switch r.state[id] {
+	case inProgress:
+		return fmt.Errorf("%w: %s", ErrCycleDetected, r.cyclePath(path, id))
+	case done:
+		return nil
+	}
+
+	it, ok := r.t.Item(id)
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrUnknownItem, id)
+	}
+
+	m, err := r.method(it)
+	if err != nil {
+		return err
+	}
+
+	r.state[id] = inProgress
+
+	n := &Node{
+		ItemID:       id,
+		Name:         it.Name,
+		Method:       m,
+		LegalMethods: r.t.LegalMethods(id),
+		Terminal:     m == MethodRaw,
+		Verified:     it.IsVerified(),
+		total:        new(big.Rat),
+	}
+
+	if !n.Terminal {
+		rc, ok := r.t.Recipe(id, m)
+		if !ok {
+			// Unreachable via method(), which already validated availability.
+			return fmt.Errorf("expanding %s: %w: no %s recipe", it.Name, ErrIllegalMethod, m)
+		}
+		if !rc.IsVerified() {
+			n.Verified = false
+		}
+
+		// Sorted so traversal order — and therefore the emitted node order —
+		// never depends on artifact ordering or map iteration.
+		// Governing: SPEC-0001 REQ "Determinism".
+		inputs := make([]Input, len(rc.Inputs))
+		copy(inputs, rc.Inputs)
+		sort.Slice(inputs, func(a, b int) bool { return inputs[a].Item < inputs[b].Item })
+
+		child := append(append([]string{}, path...), id)
+		for _, input := range inputs {
+			n.Children = append(n.Children, Edge{From: id, To: input.Item, PerUnit: input.Quantity})
+			if err := r.walk(input.Item, child); err != nil {
+				if len(path) == 0 {
+					// The target's own frame; Resolve supplies the
+					// "resolving <target>" head, so naming it again here
+					// would double it.
+					return err
+				}
+				return fmt.Errorf("expanding %s: %w", it.Name, err)
+			}
+		}
+	}
+
+	r.state[id] = done
+	r.nodes[id] = n
+	r.order = append(r.order, id)
+	return nil
+}
+
+// cyclePath renders the participating node IDs, from the first occurrence of
+// the repeated node through to its recurrence.
+func (r *resolver) cyclePath(path []string, repeated string) string {
+	start := 0
+	for i, id := range path {
+		if id == repeated {
+			start = i
+			break
+		}
+	}
+	cycle := append(append([]string{}, path[start:]...), repeated)
+	return strings.Join(cycle, " -> ")
+}
+
+// propagate walks the graph parents-first, multiplying each edge's per-unit
+// quantity by its parent's running total and accumulating shared demand.
+// Provenance taints along the same direction, since a total derived through
+// an unverified node is itself unverified.
+//
+// Governing: SPEC-0001 REQ "Quantity Propagation and Aggregation",
+// REQ "Provenance Propagation".
+func (r *resolver) propagate(g *ResolvedGraph) {
+	target := g.byID[g.Target]
+	target.total.SetInt64(g.Quantity)
+
+	// g.Nodes is terminals-first; reverse it to get parents before children.
+	for i := len(g.Nodes) - 1; i >= 0; i-- {
+		parent := g.Nodes[i]
+		for _, e := range parent.Children {
+			child := g.byID[e.To]
+
+			contribution := new(big.Rat).Mul(parent.total, new(big.Rat).SetInt64(e.PerUnit))
+			child.total.Add(child.total, contribution)
+
+			// Over-flagging is the honest direction: any unverified
+			// contributor taints every figure derived from it.
+			if !parent.Verified {
+				child.Verified = false
+			}
+		}
+	}
+}

--- a/internal/domain/resolve.go
+++ b/internal/domain/resolve.go
@@ -70,9 +70,17 @@ type Node struct {
 // engine MUST NOT accumulate binary floating-point error across the graph."
 func (n *Node) Total() *big.Rat { return new(big.Rat).Set(n.total) }
 
-// TotalInt returns the total as an integer, reporting whether it was exact.
+// TotalInt returns the total as an int64, reporting whether that conversion
+// was exact. It is inexact both when the total is fractional and when it is
+// integral but outside int64 range — big.Rat.IsInt only reports a denominator
+// of 1, and big.Int.Int64 is undefined out of range, so checking IsInt alone
+// would return a wrapped (possibly negative) value flagged as exact.
+//
+// Governing: SPEC-0001 REQ "Exact Arithmetic and Rounding Discipline",
+// REQ "Error Handling Standards" — a silently wrong count is the failure this
+// bool exists to prevent.
 func (n *Node) TotalInt() (int64, bool) {
-	if !n.total.IsInt() {
+	if !n.total.IsInt() || !n.total.Num().IsInt64() {
 		return 0, false
 	}
 	return n.total.Num().Int64(), true

--- a/internal/domain/resolve_test.go
+++ b/internal/domain/resolve_test.go
@@ -1,0 +1,496 @@
+package domain
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The fixture's recorded game version. Asserted so a failure reads as "data
+// changed" rather than "engine broke".
+//
+// Governing: SPEC-0001 REQ "Dependency Graph Resolution" — "Fixtures asserting
+// exact node counts or exact leaf totals MUST name the game version of the
+// Tier 1 artifact they were captured against".
+const fixtureGameVersion = "community-2026-08"
+
+func loadFixture(t *testing.T) *Tier1 {
+	t.Helper()
+	f, err := os.Open("testdata/stasis-device.tier1.json")
+	if err != nil {
+		t.Fatalf("opening fixture: %v", err)
+	}
+	defer f.Close()
+	a1, err := LoadTier1(f)
+	if err != nil {
+		t.Fatalf("loading fixture: %v", err)
+	}
+	return a1
+}
+
+func resolveStasis(t *testing.T, qty int64, methods map[string]Method) *ResolvedGraph {
+	t.Helper()
+	g, err := Resolve(loadFixture(t), PlanInput{Target: "sd", Quantity: qty, Methods: methods})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	return g
+}
+
+func totalOf(t *testing.T, g *ResolvedGraph, id string) int64 {
+	t.Helper()
+	n, ok := g.Node(id)
+	if !ok {
+		t.Fatalf("node %q missing from graph", id)
+	}
+	v, exact := n.TotalInt()
+	if !exact {
+		t.Fatalf("node %q total %s is not an exact integer", id, n.Total().RatString())
+	}
+	return v
+}
+
+// Governing: SPEC-0001 REQ "Dependency Graph Resolution" —
+// Scenario "Fixture game version is asserted".
+func TestFixtureGameVersionIsPinned(t *testing.T) {
+	a1 := loadFixture(t)
+	if a1.GameVersion != fixtureGameVersion {
+		t.Fatalf("fixture game version = %q, want %q — the Tier 1 data changed; re-verify the expected totals below before updating this constant", a1.GameVersion, fixtureGameVersion)
+	}
+	if a1.Extracted {
+		t.Error("fixture claims extracted:true, but it is community-sourced; the extraction spike has not run")
+	}
+}
+
+// Governing: SPEC-0001 REQ "Dependency Graph Resolution" —
+// Scenario "Resolving the Stasis Device tree".
+func TestResolveStasisDeviceTree(t *testing.T) {
+	g := resolveStasis(t, 1, nil)
+
+	if got := len(g.Nodes); got != 34 {
+		t.Errorf("node count = %d, want 34", got)
+	}
+	for _, branch := range []string{"qp", "cry", "iri"} {
+		if _, ok := g.Node(branch); !ok {
+			t.Errorf("branch root %q missing", branch)
+		}
+	}
+	if g.GameVersion != fixtureGameVersion {
+		t.Errorf("graph game version = %q, want %q", g.GameVersion, fixtureGameVersion)
+	}
+	// Terminals first, target last — the tab order the canvas handoff wants.
+	if last := g.Nodes[len(g.Nodes)-1]; last.ItemID != "sd" {
+		t.Errorf("last node = %q, want target sd", last.ItemID)
+	}
+	if first := g.Nodes[0]; !first.Terminal {
+		t.Errorf("first node %q is not terminal", first.ItemID)
+	}
+}
+
+// Governing: SPEC-0001 REQ "Quantity Propagation and Aggregation" —
+// Scenarios "Shared inputs aggregate" and "Gas totals at quantity 1".
+func TestStasisDeviceLeafTotals(t *testing.T) {
+	g := resolveStasis(t, 1, nil)
+
+	want := map[string]int64{
+		"fc": 300, "sol": 200, "cf": 100, "sb": 200, "gr": 400, "fae": 50,
+		"sul": 500, "cc": 300, "nit": 500, "rad": 500,
+		"par": 50, "pho": 50, "dio": 50, "ion": 150,
+	}
+	for id, exp := range want {
+		if got := totalOf(t, g, id); got != exp {
+			t.Errorf("%s total = %d, want %d", id, got, exp)
+		}
+	}
+
+	// The intermediates the aggregation actually turns on: each gas product
+	// is needed twice, which is what makes Condensed Carbon 6 x 50 = 300.
+	for _, id := range []string{"ec", "ns", "tc"} {
+		if got := totalOf(t, g, id); got != 2 {
+			t.Errorf("%s total = %d, want 2", id, got)
+		}
+	}
+	if got := totalOf(t, g, "gla"); got != 5 {
+		t.Errorf("gla total = %d, want 5", got)
+	}
+}
+
+// Governing: SPEC-0001 REQ "Quantity Propagation and Aggregation" —
+// Scenario "Linear scaling".
+func TestLinearScaling(t *testing.T) {
+	one := resolveStasis(t, 1, nil)
+	ten := resolveStasis(t, 10, nil)
+
+	for _, leaf := range one.Leaves() {
+		got := totalOf(t, ten, leaf.ItemID)
+		want := totalOf(t, one, leaf.ItemID) * 10
+		if got != want {
+			t.Errorf("%s at qty 10 = %d, want %d (10x its value at qty 1)", leaf.ItemID, got, want)
+		}
+	}
+}
+
+// Governing: SPEC-0001 REQ "Exact Arithmetic and Rounding Discipline" —
+// Scenario "No intermediate rounding". Frost Crystal reaches its total
+// through Glass, six graph levels below the target.
+func TestNoIntermediateRounding(t *testing.T) {
+	g := resolveStasis(t, 3, nil)
+
+	// 3 devices -> 3 Living Glass -> 15 Glass -> 15 x 40 = 600 Frost Crystal
+	// via the Glass branch, plus 3 x 100 via Heat Capacitor = 900.
+	if got := totalOf(t, g, "fc"); got != 900 {
+		t.Errorf("fc total = %d, want 900", got)
+	}
+	n, _ := g.Node("fc")
+	if !n.Total().IsInt() {
+		t.Errorf("fc total %s is not exact", n.Total().RatString())
+	}
+	// Every total in the graph must be an exact integer at this stage.
+	for _, node := range g.Nodes {
+		if _, exact := node.TotalInt(); !exact {
+			t.Errorf("%s total %s is not an exact integer", node.ItemID, node.Total().RatString())
+		}
+	}
+}
+
+// Governing: SPEC-0001 REQ "Dependency Graph Resolution" —
+// Scenario "Terminal nodes are not expanded".
+func TestTerminalNodesAreNotExpanded(t *testing.T) {
+	g := resolveStasis(t, 1, nil)
+	for _, n := range g.Nodes {
+		if n.Terminal && len(n.Children) > 0 {
+			t.Errorf("terminal node %q has %d children", n.ItemID, len(n.Children))
+		}
+		if n.Terminal && n.Method != MethodRaw {
+			t.Errorf("terminal node %q method = %q, want raw", n.ItemID, n.Method)
+		}
+	}
+
+	// The scenario's real bite: Condensed Carbon is mineable *and* refinable
+	// from Carbon. Resolved to raw it must not expand, even though the
+	// artifact holds a recipe that could produce it.
+	cc, ok := g.Node("cc")
+	if !ok {
+		t.Fatal("cc missing from graph")
+	}
+	if !cc.Terminal || len(cc.Children) != 0 {
+		t.Errorf("cc terminal = %v with %d children, want terminal with none", cc.Terminal, len(cc.Children))
+	}
+	if _, hasRecipe := loadFixture(t).Recipe("cc", MethodRefine); !hasRecipe {
+		t.Fatal("fixture no longer holds a cc refine recipe, so this scenario is not being exercised")
+	}
+	if got, want := cc.LegalMethods, []Method{MethodRaw, MethodRefine}; !equalMethods(got, want) {
+		t.Errorf("cc legal methods = %v, want %v", got, want)
+	}
+	if _, reached := g.Node("car"); reached {
+		t.Error("Carbon was expanded into the graph; cc resolved to raw must terminate there")
+	}
+
+	// Switching it off raw does expand it, which is what makes the
+	// non-expansion above meaningful rather than incidental.
+	expanded := resolveStasis(t, 1, map[string]Method{"cc": MethodRefine})
+	if _, reached := expanded.Node("car"); !reached {
+		t.Error("Carbon missing after switching cc to refine")
+	}
+	// 300 Condensed Carbon at 2 Carbon each.
+	if got := totalOf(t, expanded, "car"); got != 600 {
+		t.Errorf("car total = %d, want 600", got)
+	}
+}
+
+// An item that is not raw-obtainable cannot be pinned to raw.
+func TestRawRequiresRawObtainable(t *testing.T) {
+	_, err := Resolve(loadFixture(t), PlanInput{
+		Target: "sd", Quantity: 1,
+		Methods: map[string]Method{"gla": MethodRaw},
+	})
+	if !errors.Is(err, ErrIllegalMethod) {
+		t.Fatalf("error = %v, want ErrIllegalMethod", err)
+	}
+}
+
+// Governing: SPEC-0001 REQ "Dependency Graph Resolution" —
+// Scenario "Unknown target".
+func TestUnknownTarget(t *testing.T) {
+	_, err := Resolve(loadFixture(t), PlanInput{Target: "prod999", Quantity: 1})
+	if !errors.Is(err, ErrUnknownItem) {
+		t.Fatalf("error = %v, want ErrUnknownItem", err)
+	}
+	if !strings.Contains(err.Error(), "prod999") {
+		t.Errorf("error %q does not identify the missing ID", err)
+	}
+}
+
+// Governing: SPEC-0001 REQ "Method Resolution" —
+// Scenario "Method change alters expansion".
+func TestMethodChangeAltersExpansion(t *testing.T) {
+	base := resolveStasis(t, 1, nil)
+	refined := resolveStasis(t, 1, map[string]Method{"ec": MethodRefine})
+
+	// Crafting Enriched Carbon takes 250 Sulphurine + 50 Condensed Carbon per
+	// unit; refining takes 300 Sulphurine and drops the carbon entirely.
+	if got, want := totalOf(t, base, "sul"), int64(500); got != want {
+		t.Errorf("baseline sul = %d, want %d", got, want)
+	}
+	if got, want := totalOf(t, refined, "sul"), int64(600); got != want {
+		t.Errorf("refined sul = %d, want %d", got, want)
+	}
+	// Condensed Carbon loses Enriched Carbon's 2 x 50 contribution.
+	if got, want := totalOf(t, refined, "cc"), int64(200); got != want {
+		t.Errorf("refined cc = %d, want %d", got, want)
+	}
+
+	ec, _ := refined.Node("ec")
+	if len(ec.Children) != 1 || ec.Children[0].To != "sul" {
+		t.Errorf("refined ec children = %+v, want a single sul edge", ec.Children)
+	}
+}
+
+// Governing: SPEC-0001 REQ "Method Resolution" —
+// Scenario "Illegal method rejected".
+func TestIllegalMethodRejected(t *testing.T) {
+	// Heat Capacitor has only a craft recipe and is not raw-obtainable.
+	_, err := Resolve(loadFixture(t), PlanInput{
+		Target: "sd", Quantity: 1,
+		Methods: map[string]Method{"hc": MethodRefine},
+	})
+	if !errors.Is(err, ErrIllegalMethod) {
+		t.Fatalf("error = %v, want ErrIllegalMethod", err)
+	}
+	if !strings.Contains(err.Error(), "Heat Capacitor") {
+		t.Errorf("error %q does not name the node", err)
+	}
+}
+
+// Governing: SPEC-0001 REQ "Method Resolution" —
+// Scenario "No buy method exists".
+func TestNoBuyMethod(t *testing.T) {
+	if Method("buy").Valid() {
+		t.Fatal(`Method("buy") reports valid; "buy" must not be part of the vocabulary`)
+	}
+	_, err := Resolve(loadFixture(t), PlanInput{
+		Target: "sd", Quantity: 1,
+		Methods: map[string]Method{"gla": Method("buy")},
+	})
+	if !errors.Is(err, ErrIllegalMethod) {
+		t.Fatalf("error = %v, want ErrIllegalMethod", err)
+	}
+	if !strings.Contains(err.Error(), "vocabulary") {
+		t.Errorf("error %q does not explain that the method is outside the vocabulary", err)
+	}
+}
+
+// Governing: SPEC-0001 REQ "Method Resolution" — legal methods are reported so
+// the view can render unavailable options as inert rather than hiding them.
+func TestLegalMethodsReported(t *testing.T) {
+	g := resolveStasis(t, 1, nil)
+
+	gla, _ := g.Node("gla")
+	if got, want := gla.LegalMethods, []Method{MethodCraft, MethodRefine}; !equalMethods(got, want) {
+		t.Errorf("gla legal methods = %v, want %v", got, want)
+	}
+	hc, _ := g.Node("hc")
+	if got, want := hc.LegalMethods, []Method{MethodCraft}; !equalMethods(got, want) {
+		t.Errorf("hc legal methods = %v, want %v", got, want)
+	}
+	fc, _ := g.Node("fc")
+	if got, want := fc.LegalMethods, []Method{MethodRaw}; !equalMethods(got, want) {
+		t.Errorf("fc legal methods = %v, want %v", got, want)
+	}
+}
+
+func equalMethods(a, b []Method) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Governing: SPEC-0001 REQ "Cycle Detection" —
+// Scenario "Cyclic method selection".
+func TestCycleDetection(t *testing.T) {
+	// A deliberately cyclic artifact: refining A yields B and refining B
+	// yields A, which is a shape the real refining data is capable of.
+	const cyclic = `{
+	  "schema_version": 1, "game_version": "test-cycle",
+	  "items": [
+	    {"id":"a","name":"Alpha","default_method":"refine"},
+	    {"id":"b","name":"Beta","default_method":"refine"}
+	  ],
+	  "recipes": [
+	    {"output":"a","method":"refine","inputs":[{"item":"b","quantity":1}]},
+	    {"output":"b","method":"refine","inputs":[{"item":"a","quantity":1}]}
+	  ]
+	}`
+	a1, err := LoadTier1(strings.NewReader(cyclic))
+	if err != nil {
+		t.Fatalf("loading cyclic artifact: %v", err)
+	}
+	g, err := Resolve(a1, PlanInput{Target: "a", Quantity: 1})
+	if !errors.Is(err, ErrCycleDetected) {
+		t.Fatalf("error = %v, want ErrCycleDetected", err)
+	}
+	if g != nil {
+		t.Error("a graph was returned alongside a cycle error; must be nil")
+	}
+	for _, id := range []string{"a", "b"} {
+		if !strings.Contains(err.Error(), id) {
+			t.Errorf("error %q does not list participating node %q", err, id)
+		}
+	}
+}
+
+// Governing: SPEC-0001 REQ "Provenance Propagation" —
+// Scenario "Unverified input taints derived total".
+func TestProvenanceTaint(t *testing.T) {
+	g := resolveStasis(t, 1, nil)
+
+	// Glass and Hot Ice are the fixture's unverified nodes (refiner-variant
+	// ratios differ between community sources). Taint flows the same
+	// direction as quantity: down, from a node to everything derived below it.
+	unverified := map[string]bool{
+		"gla": true, "fc": true, // Glass taints Frost Crystal
+		"hi": true, "ns": true, "ec": true, // Hot Ice taints its inputs
+		"nit": true, "sul": true, "cc": true, // ...and theirs
+	}
+	for _, n := range g.Nodes {
+		want := !unverified[n.ItemID]
+		if n.Verified != want {
+			t.Errorf("%s (%s) verified = %v, want %v", n.ItemID, n.Name, n.Verified, want)
+		}
+	}
+
+	// Radon arrives only through Thermic Condensate, which is untainted.
+	if rad, _ := g.Node("rad"); !rad.Verified {
+		t.Error("rad should be verified: its only path avoids both unverified nodes")
+	}
+}
+
+// Governing: SPEC-0001 REQ "Determinism" —
+// Scenarios "Repeated computation is stable" and "Stable ordering".
+func TestDeterminism(t *testing.T) {
+	type wire struct {
+		ID       string   `json:"id"`
+		Method   Method   `json:"method"`
+		Total    string   `json:"total"`
+		Verified bool     `json:"verified"`
+		Children []Edge   `json:"children"`
+		Legal    []Method `json:"legal"`
+	}
+	serialize := func(g *ResolvedGraph) string {
+		out := make([]wire, 0, len(g.Nodes))
+		for _, n := range g.Nodes {
+			out = append(out, wire{n.ItemID, n.Method, n.Total().RatString(), n.Verified, n.Children, n.LegalMethods})
+		}
+		b, err := json.Marshal(out)
+		if err != nil {
+			t.Fatalf("marshalling: %v", err)
+		}
+		return string(b)
+	}
+
+	first := serialize(resolveStasis(t, 4, nil))
+	for i := 0; i < 25; i++ {
+		if got := serialize(resolveStasis(t, 4, nil)); got != first {
+			t.Fatalf("run %d differs from the first run; map iteration is leaking into output ordering", i+2)
+		}
+	}
+}
+
+// Governing: SPEC-0001 REQ "Error Handling Standards" —
+// Scenarios "Errors carry the resolution path" and "No partial results on
+// failure".
+func TestErrorCarriesResolutionPath(t *testing.T) {
+	// Break a node several levels down: Cryo-Pump gains an input that does
+	// not exist. Structural validation catches it at load, so build the
+	// artifact past validation and confirm the walk reports the path.
+	a1 := loadFixture(t)
+	a1.recipesByOut["cp"][MethodCraft] = Recipe{
+		Output: "cp", Method: MethodCraft,
+		Inputs: []Input{{Item: "prod999", Quantity: 1}},
+	}
+
+	g, err := Resolve(a1, PlanInput{Target: "sd", Quantity: 1})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if g != nil {
+		t.Error("a graph was returned alongside an error; must be nil")
+	}
+	if !errors.Is(err, ErrUnknownItem) {
+		t.Errorf("error = %v, want ErrUnknownItem", err)
+	}
+	for _, want := range []string{"resolving Stasis Device", "Cryogenic Chamber", "Cryo-Pump", "prod999"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q is missing %q from the resolution path", err, want)
+		}
+	}
+}
+
+// Governing: SPEC-0001 REQ "Error Handling Standards" — the sentinel set is
+// distinguishable by callers.
+func TestSentinelsAreDistinct(t *testing.T) {
+	all := []error{ErrUnknownItem, ErrIllegalMethod, ErrCycleDetected, ErrMissingConstant, ErrInvalidArtifact}
+	for i, a := range all {
+		for j, b := range all {
+			if i != j && errors.Is(a, b) {
+				t.Errorf("sentinel %v matches %v; callers cannot distinguish them", a, b)
+			}
+		}
+	}
+}
+
+func TestTier1ValidationRejectsMissingGameVersion(t *testing.T) {
+	const noVersion = `{
+	  "schema_version": 1,
+	  "items": [{"id":"a","name":"Alpha","raw_obtainable":true,"default_method":"raw"}],
+	  "recipes": []
+	}`
+	_, err := LoadTier1(strings.NewReader(noVersion))
+	if !errors.Is(err, ErrInvalidArtifact) {
+		t.Fatalf("error = %v, want ErrInvalidArtifact", err)
+	}
+	if !strings.Contains(err.Error(), "game_version") {
+		t.Errorf("error %q does not name the missing field", err)
+	}
+}
+
+func TestQuantityMustBePositive(t *testing.T) {
+	for _, q := range []int64{0, -1} {
+		if _, err := Resolve(loadFixture(t), PlanInput{Target: "sd", Quantity: q}); err == nil {
+			t.Errorf("quantity %d was accepted", q)
+		}
+	}
+}
+
+// Exact rational arithmetic is available for the non-integer multipliers
+// stages 2 and 3 introduce, and does not drift the way binary floats do.
+//
+// Governing: SPEC-0001 REQ "Exact Arithmetic and Rounding Discipline".
+func TestRationalArithmeticIsExact(t *testing.T) {
+	// The float trap the design calls out: 0.1 summed ten times is not 1.
+	var f float64
+	for i := 0; i < 10; i++ {
+		f += 0.1
+	}
+	if f == 1.0 {
+		t.Skip("float arithmetic is exact on this platform; the rational check below is moot")
+	}
+
+	r := new(big.Rat)
+	tenth := big.NewRat(1, 10)
+	for i := 0; i < 10; i++ {
+		r.Add(r, tenth)
+	}
+	if r.Cmp(big.NewRat(1, 1)) != 0 {
+		t.Errorf("rational sum = %s, want 1", r.RatString())
+	}
+}

--- a/internal/domain/resolve_test.go
+++ b/internal/domain/resolve_test.go
@@ -9,13 +9,22 @@ import (
 	"testing"
 )
 
-// The fixture's recorded game version. Asserted so a failure reads as "data
-// changed" rather than "engine broke".
+// Each fixture's recorded game version, pinned per fixture rather than shared.
+// They hold the same value today because both are community-sourced
+// placeholders of the same vintage, but they move independently: the
+// extraction spike replaces the Stasis fixture with a real extracted artifact
+// at a real game version, and the cake fixture stays a placeholder. A shared
+// constant would make that re-extraction fail the cake tests too, reporting a
+// data change in a fixture nothing touched — the misattribution the pin exists
+// to prevent.
 //
 // Governing: SPEC-0001 REQ "Dependency Graph Resolution" — "Fixtures asserting
 // exact node counts or exact leaf totals MUST name the game version of the
 // Tier 1 artifact they were captured against".
-const fixtureGameVersion = "community-2026-08"
+const (
+	stasisFixtureGameVersion = "community-2026-08"
+	cakeFixtureGameVersion   = "community-2026-08"
+)
 
 func loadFixture(t *testing.T) *Tier1 {
 	t.Helper()
@@ -57,8 +66,8 @@ func totalOf(t *testing.T, g *ResolvedGraph, id string) int64 {
 // Scenario "Fixture game version is asserted".
 func TestFixtureGameVersionIsPinned(t *testing.T) {
 	a1 := loadFixture(t)
-	if a1.GameVersion != fixtureGameVersion {
-		t.Fatalf("fixture game version = %q, want %q — the Tier 1 data changed; re-verify the expected totals below before updating this constant", a1.GameVersion, fixtureGameVersion)
+	if a1.GameVersion != stasisFixtureGameVersion {
+		t.Fatalf("fixture game version = %q, want %q — the Tier 1 data changed; re-verify the expected totals below before updating this constant", a1.GameVersion, stasisFixtureGameVersion)
 	}
 	if a1.Extracted {
 		t.Error("fixture claims extracted:true, but it is community-sourced; the extraction spike has not run")
@@ -78,8 +87,8 @@ func TestResolveStasisDeviceTree(t *testing.T) {
 			t.Errorf("branch root %q missing", branch)
 		}
 	}
-	if g.GameVersion != fixtureGameVersion {
-		t.Errorf("graph game version = %q, want %q", g.GameVersion, fixtureGameVersion)
+	if g.GameVersion != stasisFixtureGameVersion {
+		t.Errorf("graph game version = %q, want %q", g.GameVersion, stasisFixtureGameVersion)
 	}
 	// Terminals first, target last — the tab order the canvas handoff wants.
 	if last := g.Nodes[len(g.Nodes)-1]; last.ItemID != "sd" {
@@ -506,8 +515,11 @@ func loadCakeFixture(t *testing.T) *Tier1 {
 	if err != nil {
 		t.Fatalf("loading cake fixture: %v", err)
 	}
-	if a1.GameVersion != fixtureGameVersion {
-		t.Fatalf("cake fixture game version = %q, want %q — the Tier 1 data changed", a1.GameVersion, fixtureGameVersion)
+	if a1.GameVersion != cakeFixtureGameVersion {
+		t.Fatalf("cake fixture game version = %q, want %q — the Tier 1 data changed", a1.GameVersion, cakeFixtureGameVersion)
+	}
+	if a1.Extracted {
+		t.Error("cake fixture claims extracted:true, but it is community-sourced; the extraction spike has not run")
 	}
 	return a1
 }

--- a/internal/domain/resolve_test.go
+++ b/internal/domain/resolve_test.go
@@ -494,3 +494,126 @@ func TestRationalArithmeticIsExact(t *testing.T) {
 		t.Errorf("rational sum = %s, want 1", r.RatString())
 	}
 }
+
+func loadCakeFixture(t *testing.T) *Tier1 {
+	t.Helper()
+	f, err := os.Open("testdata/hexaberry-cake.tier1.json")
+	if err != nil {
+		t.Fatalf("opening cake fixture: %v", err)
+	}
+	defer f.Close()
+	a1, err := LoadTier1(f)
+	if err != nil {
+		t.Fatalf("loading cake fixture: %v", err)
+	}
+	if a1.GameVersion != fixtureGameVersion {
+		t.Fatalf("cake fixture game version = %q, want %q — the Tier 1 data changed", a1.GameVersion, fixtureGameVersion)
+	}
+	return a1
+}
+
+// The Stasis Device tree is entirely industrial, so it cannot reach the cook
+// method at all. This exercises it on the CAKE target the base-planner handoff
+// specifies, through a multi-level chain so propagation is covered too, not
+// just expansion.
+//
+// Governing: SPEC-0001 REQ "Method Resolution" —
+// Scenario "Cook method expands a nutrient processor recipe".
+func TestCookMethodExpandsNutrientProcessorRecipe(t *testing.T) {
+	g, err := Resolve(loadCakeFixture(t), PlanInput{Target: "cake", Quantity: 1})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	cake, ok := g.Node("cake")
+	if !ok {
+		t.Fatal("cake node missing from graph")
+	}
+	if cake.Method != MethodCook {
+		t.Errorf("cake method = %q, want %q", cake.Method, MethodCook)
+	}
+	if cake.Terminal {
+		t.Error("cake is terminal; a cook node with a recipe must expand")
+	}
+
+	// THEN the node gains child edges for that recipe's inputs.
+	gotEdges := map[string]int64{}
+	for _, e := range cake.Children {
+		gotEdges[e.To] = e.PerUnit
+	}
+	wantEdges := map[string]int64{"batter": 1, "butter": 1}
+	if len(gotEdges) != len(wantEdges) {
+		t.Errorf("cake has %d child edges, want %d", len(gotEdges), len(wantEdges))
+	}
+	for to, per := range wantEdges {
+		if gotEdges[to] != per {
+			t.Errorf("cake -> %s per-unit = %d, want %d", to, gotEdges[to], per)
+		}
+	}
+
+	// AND its quantities propagate exactly as for craft and refine.
+	// flour = 1 batter x 2; wheat = 2 flour x 5; milk = 1 butter x 4.
+	for id, want := range map[string]int64{
+		"batter": 1, "butter": 1, "flour": 2, "egg": 3, "milk": 4, "wheat": 10,
+	} {
+		if got := totalOf(t, g, id); got != want {
+			t.Errorf("%s total = %d, want %d", id, got, want)
+		}
+	}
+
+	// Terminals only: wheat, milk, egg.
+	var leaves []string
+	for _, n := range g.Leaves() {
+		leaves = append(leaves, n.ItemID)
+	}
+	if len(leaves) != 3 {
+		t.Errorf("leaves = %v, want exactly wheat, milk, egg", leaves)
+	}
+}
+
+// Cook chains taint downward the same as craft and refine do.
+//
+// Governing: SPEC-0001 REQ "Provenance Propagation".
+func TestCookProvenanceTaint(t *testing.T) {
+	g, err := Resolve(loadCakeFixture(t), PlanInput{Target: "cake", Quantity: 1})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	for _, id := range []string{"cake", "batter", "butter", "flour", "wheat", "milk", "egg"} {
+		n, ok := g.Node(id)
+		if !ok {
+			t.Fatalf("node %q missing", id)
+		}
+		if n.Verified {
+			t.Errorf("%s is verified; the unverified cake node must taint everything below it", id)
+		}
+	}
+}
+
+// A total outside int64 range is integral but not representable, so TotalInt
+// must report it as inexact rather than returning a wrapped value.
+//
+// Governing: SPEC-0001 REQ "Exact Arithmetic and Rounding Discipline".
+func TestTotalIntRejectsOutOfRange(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rat  *big.Rat
+		want bool
+	}{
+		{"in range", new(big.Rat).SetInt64(500), true},
+		{"max int64", new(big.Rat).SetInt(new(big.Int).SetUint64(1<<63 - 1)), true},
+		{"one past max int64", new(big.Rat).SetInt(new(big.Int).Lsh(big.NewInt(1), 63)), false},
+		{"fractional", big.NewRat(1, 2), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &Node{total: tc.rat}
+			got, exact := n.TotalInt()
+			if exact != tc.want {
+				t.Errorf("TotalInt() exact = %v, want %v (returned %d for %s)", exact, tc.want, got, tc.rat.RatString())
+			}
+			if !exact && got != 0 {
+				t.Errorf("TotalInt() returned %d alongside exact=false; want 0", got)
+			}
+		})
+	}
+}

--- a/internal/domain/testdata/hexaberry-cake.tier1.json
+++ b/internal/domain/testdata/hexaberry-cake.tier1.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "game_version": "community-2026-08",
+  "extracted": false,
+  "source": "docs/design/base-planner/handoff.md (v2 CAKE target: RANCH rows + KITCHEN Nutrient Processor steps)",
+  "note": "Placeholder standing in for a real extracted artifact (ADR-0001 Tier 1). Exists to exercise the cook method, which the Stasis Device fixture cannot reach because that tree is entirely industrial. Quantities are illustrative and are not claimed to match the game; what is asserted against this fixture is expansion and propagation behaviour, never real recipe values. The cake plan carries the unverified chip in the design, so the cake node is marked unverified here.",
+
+  "items": [
+    { "id": "wheat", "name": "Wheat",          "raw_obtainable": true, "default_method": "raw" },
+    { "id": "milk",  "name": "Wild Milk",      "raw_obtainable": true, "default_method": "raw" },
+    { "id": "egg",   "name": "Proto-Egg",      "raw_obtainable": true, "default_method": "raw" },
+
+    { "id": "flour", "name": "Flour",          "raw_obtainable": false, "default_method": "cook" },
+    { "id": "butter","name": "Butter",         "raw_obtainable": false, "default_method": "cook" },
+    { "id": "batter","name": "Batter",         "raw_obtainable": false, "default_method": "cook" },
+    { "id": "cake",  "name": "Hexaberry Cake", "raw_obtainable": false, "default_method": "cook", "verified": false }
+  ],
+
+  "recipes": [
+    { "output": "flour",  "method": "cook", "inputs": [{ "item": "wheat", "quantity": 5 }] },
+    { "output": "butter", "method": "cook", "inputs": [{ "item": "milk",  "quantity": 4 }] },
+    { "output": "batter", "method": "cook", "inputs": [{ "item": "flour", "quantity": 2 }, { "item": "egg", "quantity": 3 }] },
+    { "output": "cake",   "method": "cook", "inputs": [{ "item": "batter", "quantity": 1 }, { "item": "butter", "quantity": 1 }] }
+  ]
+}

--- a/internal/domain/testdata/stasis-device.tier1.json
+++ b/internal/domain/testdata/stasis-device.tier1.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "game_version": "community-2026-08",
+  "extracted": false,
+  "source": "docs/design/tree-canvas/handoff.md + Tree Canvas.dc.html",
+  "note": "Placeholder standing in for a real extracted artifact (ADR-0001 Tier 1). Community-sourced, not decoded from MBIN files; extracted:false marks that. Replace via the extraction spike. Prototype edge labels were aggregate totals at target quantity 1 and are recorded here as per-unit quantities. Carbon and the Condensed Carbon refine recipe are outside the 34-node Stasis tree: Condensed Carbon defaults to raw, so the recipe exists but is never expanded, which is the worked example for the terminal-node requirement.",
+
+  "items": [
+    { "id": "fc",  "name": "Frost Crystal",      "raw_obtainable": true, "default_method": "raw" },
+    { "id": "sol", "name": "Solanium",           "raw_obtainable": true, "default_method": "raw" },
+    { "id": "cf",  "name": "Cactus Flesh",       "raw_obtainable": true, "default_method": "raw" },
+    { "id": "sb",  "name": "Star Bulb",          "raw_obtainable": true, "default_method": "raw" },
+    { "id": "gr",  "name": "Gamma Root",         "raw_obtainable": true, "default_method": "raw" },
+    { "id": "fae", "name": "Faecium",            "raw_obtainable": true, "default_method": "raw" },
+    { "id": "sul", "name": "Sulphurine",         "raw_obtainable": true, "default_method": "raw" },
+    { "id": "cc",  "name": "Condensed Carbon",   "raw_obtainable": true, "default_method": "raw" },
+    { "id": "nit", "name": "Nitrogen",           "raw_obtainable": true, "default_method": "raw" },
+    { "id": "rad", "name": "Radon",              "raw_obtainable": true, "default_method": "raw" },
+    { "id": "par", "name": "Paraffinium",        "raw_obtainable": true, "default_method": "raw" },
+    { "id": "pho", "name": "Phosphorus",         "raw_obtainable": true, "default_method": "raw" },
+    { "id": "dio", "name": "Dioxite",            "raw_obtainable": true, "default_method": "raw" },
+    { "id": "ion", "name": "Ionised Cobalt",     "raw_obtainable": true, "default_method": "raw" },
+    { "id": "car", "name": "Carbon",             "raw_obtainable": true, "default_method": "raw" },
+
+    { "id": "hc",  "name": "Heat Capacitor",     "default_method": "craft" },
+    { "id": "gla", "name": "Glass",              "default_method": "craft", "verified": false },
+    { "id": "pf",  "name": "Poly Fibre",         "default_method": "craft" },
+    { "id": "lub", "name": "Lubricant",          "default_method": "craft" },
+    { "id": "ec",  "name": "Enriched Carbon",    "default_method": "craft" },
+    { "id": "ns",  "name": "Nitrogen Salt",      "default_method": "craft" },
+    { "id": "tc",  "name": "Thermic Condensate", "default_method": "craft" },
+    { "id": "aro", "name": "Aronium",            "default_method": "craft" },
+    { "id": "mg",  "name": "Magno-Gold",         "default_method": "craft" },
+    { "id": "gra", "name": "Grantine",           "default_method": "craft" },
+    { "id": "cb",  "name": "Circuit Board",      "default_method": "craft" },
+    { "id": "lg",  "name": "Living Glass",       "default_method": "craft" },
+    { "id": "hi",  "name": "Hot Ice",            "default_method": "craft", "verified": false },
+    { "id": "sem", "name": "Semiconductor",      "default_method": "craft" },
+    { "id": "sup", "name": "Superconductor",     "default_method": "craft" },
+    { "id": "cp",  "name": "Cryo-Pump",          "default_method": "craft" },
+    { "id": "qp",  "name": "Quantum Processor",  "default_method": "craft" },
+    { "id": "cry", "name": "Cryogenic Chamber",  "default_method": "craft" },
+    { "id": "iri", "name": "Iridesite",          "default_method": "craft" },
+    { "id": "sd",  "name": "Stasis Device",      "default_method": "craft" }
+  ],
+
+  "recipes": [
+    { "output": "hc",  "method": "craft",  "inputs": [{ "item": "fc", "quantity": 100 }, { "item": "sol", "quantity": 200 }] },
+
+    { "output": "cc",  "method": "refine", "inputs": [{ "item": "car", "quantity": 2 }] },
+
+    { "output": "gla", "method": "craft",  "inputs": [{ "item": "fc", "quantity": 40 }] },
+    { "output": "gla", "method": "refine", "inputs": [{ "item": "fc", "quantity": 250 }] },
+
+    { "output": "pf",  "method": "craft",  "inputs": [{ "item": "cf", "quantity": 100 }, { "item": "sb", "quantity": 200 }] },
+    { "output": "lub", "method": "craft",  "inputs": [{ "item": "fae", "quantity": 50 }, { "item": "gr", "quantity": 400 }] },
+
+    { "output": "ec",  "method": "craft",  "inputs": [{ "item": "sul", "quantity": 250 }, { "item": "cc", "quantity": 50 }] },
+    { "output": "ec",  "method": "refine", "inputs": [{ "item": "sul", "quantity": 300 }] },
+
+    { "output": "ns",  "method": "craft",  "inputs": [{ "item": "nit", "quantity": 250 }, { "item": "cc", "quantity": 50 }] },
+    { "output": "ns",  "method": "refine", "inputs": [{ "item": "nit", "quantity": 300 }] },
+
+    { "output": "tc",  "method": "craft",  "inputs": [{ "item": "rad", "quantity": 250 }, { "item": "cc", "quantity": 50 }] },
+    { "output": "tc",  "method": "refine", "inputs": [{ "item": "rad", "quantity": 300 }] },
+
+    { "output": "aro", "method": "craft",  "inputs": [{ "item": "par", "quantity": 50 }, { "item": "ion", "quantity": 50 }] },
+    { "output": "mg",  "method": "craft",  "inputs": [{ "item": "pho", "quantity": 50 }, { "item": "ion", "quantity": 50 }] },
+    { "output": "gra", "method": "craft",  "inputs": [{ "item": "dio", "quantity": 50 }, { "item": "ion", "quantity": 50 }] },
+
+    { "output": "cb",  "method": "craft",  "inputs": [{ "item": "hc", "quantity": 1 }, { "item": "pf", "quantity": 1 }] },
+    { "output": "lg",  "method": "craft",  "inputs": [{ "item": "gla", "quantity": 5 }, { "item": "lub", "quantity": 1 }] },
+    { "output": "hi",  "method": "craft",  "inputs": [{ "item": "ns", "quantity": 1 }, { "item": "ec", "quantity": 1 }] },
+    { "output": "sem", "method": "craft",  "inputs": [{ "item": "tc", "quantity": 1 }, { "item": "ns", "quantity": 1 }] },
+
+    { "output": "sup", "method": "craft",  "inputs": [{ "item": "sem", "quantity": 1 }, { "item": "ec", "quantity": 1 }] },
+    { "output": "cp",  "method": "craft",  "inputs": [{ "item": "hi", "quantity": 1 }, { "item": "tc", "quantity": 1 }] },
+
+    { "output": "qp",  "method": "craft",  "inputs": [{ "item": "cb", "quantity": 1 }, { "item": "sup", "quantity": 1 }] },
+    { "output": "cry", "method": "craft",  "inputs": [{ "item": "lg", "quantity": 1 }, { "item": "cp", "quantity": 1 }] },
+    { "output": "iri", "method": "craft",  "inputs": [{ "item": "aro", "quantity": 1 }, { "item": "mg", "quantity": 1 }, { "item": "gra", "quantity": 1 }] },
+
+    { "output": "sd",  "method": "craft",  "inputs": [{ "item": "qp", "quantity": 1 }, { "item": "cry", "quantity": 1 }, { "item": "iri", "quantity": 1 }] }
+  ]
+}

--- a/internal/domain/tier1.go
+++ b/internal/domain/tier1.go
@@ -1,0 +1,222 @@
+package domain
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+)
+
+// Method is the vocabulary a node can resolve to.
+//
+// Governing: SPEC-0001 REQ "Method Resolution" — "Each node MUST resolve to
+// exactly one method from the set craft, refine, raw, cook. The engine MUST
+// NOT define, accept, or produce a buy method — this is a build planner, not
+// a shopping list."
+type Method string
+
+const (
+	MethodCraft  Method = "craft"
+	MethodRefine Method = "refine"
+	MethodRaw    Method = "raw"
+	MethodCook   Method = "cook"
+)
+
+// validMethods is the whole vocabulary. Note the deliberate absence of "buy".
+var validMethods = map[Method]bool{
+	MethodCraft:  true,
+	MethodRefine: true,
+	MethodRaw:    true,
+	MethodCook:   true,
+}
+
+// Valid reports whether m is part of the method vocabulary.
+func (m Method) Valid() bool { return validMethods[m] }
+
+// Item is one node identity in the Tier 1 artifact.
+type Item struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+
+	// RawObtainable marks an item that can be gathered directly. An item may
+	// be both raw-obtainable and have recipes; resolving it to raw terminates
+	// expansion regardless.
+	RawObtainable bool `json:"raw_obtainable"`
+
+	// DefaultMethod is the method used when the plan does not select one.
+	DefaultMethod Method `json:"default_method"`
+
+	// Verified records whether this item's data was confirmed in-game. The
+	// zero value of a *bool is nil, which we read as verified; only an
+	// explicit `"verified": false` marks an item unverified, so the common
+	// case needs no field.
+	Verified *bool `json:"verified,omitempty"`
+}
+
+// IsVerified reports the item's provenance, defaulting to verified when the
+// artifact says nothing.
+func (i Item) IsVerified() bool { return i.Verified == nil || *i.Verified }
+
+// Input is one edge of a recipe, in per-unit-of-output quantity.
+type Input struct {
+	Item     string `json:"item"`
+	Quantity int64  `json:"quantity"`
+}
+
+// Recipe produces one unit of Output by Method from Inputs.
+type Recipe struct {
+	Output   string  `json:"output"`
+	Method   Method  `json:"method"`
+	Inputs   []Input `json:"inputs"`
+	Verified *bool   `json:"verified,omitempty"`
+}
+
+// IsVerified reports the recipe's provenance, defaulting to verified.
+func (r Recipe) IsVerified() bool { return r.Verified == nil || *r.Verified }
+
+// Tier1 is the extracted recipe graph.
+//
+// Governing: ADR-0001 (two-tier ingestion) — Tier 1 is machine-extracted and
+// regenerated per game version; it is never hand-edited in production.
+type Tier1 struct {
+	SchemaVersion int    `json:"schema_version"`
+	GameVersion   string `json:"game_version"`
+	Extracted     bool   `json:"extracted"`
+	Source        string `json:"source"`
+	Note          string `json:"note"`
+
+	Items   []Item   `json:"items"`
+	Recipes []Recipe `json:"recipes"`
+
+	// Derived indexes, built by Validate.
+	itemsByID    map[string]Item
+	recipesByOut map[string]map[Method]Recipe
+	legalMethods map[string][]Method
+}
+
+// LoadTier1 reads and validates a Tier 1 artifact.
+func LoadTier1(r io.Reader) (*Tier1, error) {
+	var t Tier1
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&t); err != nil {
+		return nil, fmt.Errorf("%w: decoding: %w", ErrInvalidArtifact, err)
+	}
+	if err := t.Validate(); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+// Validate checks structural integrity and builds the lookup indexes.
+func (t *Tier1) Validate() error {
+	if t.GameVersion == "" {
+		// Governing: SPEC-0001 REQ "Dependency Graph Resolution" — fixtures
+		// asserting exact node counts or leaf totals must name the game
+		// version they were captured against, so a failure is attributable
+		// to changed game data rather than to an engine regression.
+		return fmt.Errorf("%w: game_version is required", ErrInvalidArtifact)
+	}
+
+	t.itemsByID = make(map[string]Item, len(t.Items))
+	for _, it := range t.Items {
+		if it.ID == "" {
+			return fmt.Errorf("%w: item with empty id", ErrInvalidArtifact)
+		}
+		if _, dup := t.itemsByID[it.ID]; dup {
+			return fmt.Errorf("%w: duplicate item id %q", ErrInvalidArtifact, it.ID)
+		}
+		if !it.DefaultMethod.Valid() {
+			return fmt.Errorf("%w: item %q: %w: %q", ErrInvalidArtifact, it.ID, ErrIllegalMethod, it.DefaultMethod)
+		}
+		t.itemsByID[it.ID] = it
+	}
+
+	t.recipesByOut = make(map[string]map[Method]Recipe)
+	for _, rc := range t.Recipes {
+		if _, ok := t.itemsByID[rc.Output]; !ok {
+			return fmt.Errorf("%w: recipe output %q: %w", ErrInvalidArtifact, rc.Output, ErrUnknownItem)
+		}
+		if !rc.Method.Valid() {
+			return fmt.Errorf("%w: recipe for %q: %w: %q", ErrInvalidArtifact, rc.Output, ErrIllegalMethod, rc.Method)
+		}
+		if rc.Method == MethodRaw {
+			return fmt.Errorf("%w: recipe for %q declares method raw, which is terminal by definition", ErrInvalidArtifact, rc.Output)
+		}
+		if len(rc.Inputs) == 0 {
+			return fmt.Errorf("%w: recipe for %q has no inputs", ErrInvalidArtifact, rc.Output)
+		}
+		for _, in := range rc.Inputs {
+			if _, ok := t.itemsByID[in.Item]; !ok {
+				return fmt.Errorf("%w: recipe for %q input %q: %w", ErrInvalidArtifact, rc.Output, in.Item, ErrUnknownItem)
+			}
+			if in.Quantity <= 0 {
+				return fmt.Errorf("%w: recipe for %q input %q: quantity must be positive, got %d", ErrInvalidArtifact, rc.Output, in.Item, in.Quantity)
+			}
+		}
+		byMethod, ok := t.recipesByOut[rc.Output]
+		if !ok {
+			byMethod = make(map[Method]Recipe)
+			t.recipesByOut[rc.Output] = byMethod
+		}
+		if _, dup := byMethod[rc.Method]; dup {
+			return fmt.Errorf("%w: duplicate %s recipe for %q", ErrInvalidArtifact, rc.Method, rc.Output)
+		}
+		byMethod[rc.Method] = rc
+	}
+
+	// An item's default method must actually be available to it.
+	for _, it := range t.Items {
+		if !t.methodAvailable(it, it.DefaultMethod) {
+			return fmt.Errorf("%w: item %q default method %q: %w", ErrInvalidArtifact, it.ID, it.DefaultMethod, ErrIllegalMethod)
+		}
+	}
+
+	t.legalMethods = make(map[string][]Method, len(t.Items))
+	for _, it := range t.Items {
+		var ms []Method
+		if it.RawObtainable {
+			ms = append(ms, MethodRaw)
+		}
+		for m := range t.recipesByOut[it.ID] {
+			ms = append(ms, m)
+		}
+		// Sorted so output ordering never depends on map iteration.
+		// Governing: SPEC-0001 REQ "Determinism".
+		sort.Slice(ms, func(a, b int) bool { return ms[a] < ms[b] })
+		t.legalMethods[it.ID] = ms
+	}
+	return nil
+}
+
+func (t *Tier1) methodAvailable(it Item, m Method) bool {
+	if m == MethodRaw {
+		return it.RawObtainable
+	}
+	_, ok := t.recipesByOut[it.ID][m]
+	return ok
+}
+
+// Item looks up an item by ID.
+func (t *Tier1) Item(id string) (Item, bool) {
+	it, ok := t.itemsByID[id]
+	return it, ok
+}
+
+// LegalMethods reports the methods available to an item, sorted.
+//
+// Governing: SPEC-0001 REQ "Method Resolution" — "The engine MUST report which
+// methods are legal for a given node so the view can render unavailable
+// options as inert rather than hiding them."
+func (t *Tier1) LegalMethods(id string) []Method {
+	ms := t.legalMethods[id]
+	out := make([]Method, len(ms))
+	copy(out, ms)
+	return out
+}
+
+// Recipe returns the recipe producing id by method m.
+func (t *Tier1) Recipe(id string, m Method) (Recipe, bool) {
+	rc, ok := t.recipesByOut[id][m]
+	return rc, ok
+}


### PR DESCRIPTION
First implementation in the repo. Stage 1 of [SPEC-0001](docs/openspec/specs/rollup-engine/spec.md) only — resolve a target into a DAG, propagate and aggregate quantities. Stages 2 (producer rollup) and 3 (power) are untouched.

Stage 1 is what design.md's build order puts first, and it is the only stage needing no Tier 2 constants — so it is buildable now, before the extraction spike settles whether the economy constants exist in the game files at all.

## What's here

| File | |
|---|---|
| [`internal/domain/tier1.go`](internal/domain/tier1.go) | Tier 1 artifact schema, loader, structural validation |
| [`internal/domain/resolve.go`](internal/domain/resolve.go) | Stage 1: graph walk, method resolution, quantity propagation, cycle detection, provenance |
| [`internal/domain/errors.go`](internal/domain/errors.go) | Sentinel errors |
| [`internal/domain/testdata/stasis-device.tier1.json`](internal/domain/testdata/stasis-device.tier1.json) | The 34-node Stasis Device fixture |

20 tests, one per stage-1 spec scenario plus validation cases. 89.6% statement coverage. `go vet` and `gofmt` clean. No module dependencies.

It resolves the real tree — 34 nodes, every total matching ADR-0001's Confirmation section (500 each Sulphurine/Nitrogen/Radon, 300 Condensed Carbon aggregated across six recipes, 300 Frost Crystal, 150 Ionised Cobalt):

```
 Stasis Device             1  craft
   Cryogenic Chamber         1  craft
     Cryo-Pump                 1  craft
      ~Hot Ice                   1  craft
        ~Enriched Carbon           2  craft
          ~Condensed Carbon        300  raw
          ~Sulphurine              500  raw
```

`~` is the propagated unverified flag.

## Decisions worth a second look

**Quantities propagate as `math/big.Rat`, not float.** Stage 1's arithmetic is entirely integral, so this buys nothing yet. It is here because stages 2 and 3 introduce class multipliers of ×0.5/1.5 and fractional fill durations, and retrofitting exactness after the fact is precisely how the 499.9999999 bug design.md warns about gets in.

**Provenance taints downward**, the same direction quantities propagate: a total derived *through* an unverified node is itself unverified. Glass and Hot Ice carry the fixture's flags, so Frost Crystal, Sulphurine, Nitrogen and Condensed Carbon all inherit it. Frost Crystal shows unverified even under Heat Capacitor, because it is one aggregated node and Glass reaches it. Over-flagging is the honest direction per the spec.

**The ADR-0003 `no-syscall/js` boundary is enforced by construction**, not convention: `syscall/js` exists only on `js/wasm`, so the package building for darwin/arm64 *is* the check.

**Node order is DFS post-order with children sorted by ID** — terminals first, target last. Deterministic, and also the tab order the tree-canvas handoff asks for.

## The fixture is a placeholder, and says so

It carries `extracted: false` and `game_version: "community-2026-08"`, transcribed from the design handoff and prototype rather than decoded from MBIN files. Per SPEC-0001's version-pin requirement, `TestFixtureGameVersionIsPinned` fails loudly with "the Tier 1 data changed" rather than silently drifting. **It gets replaced by real extraction output when the spike runs on Linux.**

Two transformations applied to the prototype data, both worth checking:

1. **Edge labels converted to per-unit quantities.** The prototype's labels are aggregate totals at quantity 1 (`E('sul','ec','×500')`), but the spec requires per-unit quantities multiplied by parent totals — so 250 per unit of Enriched Carbon, of which 2 are needed. The reconciliation checks out in every branch, which is the strongest evidence the fixture is faithful.

2. **Carbon and a Condensed Carbon refine recipe added, deliberately outside the 34-node tree.** The spec requires that a raw-resolved node not expand "even when the Tier 1 artifact contains a recipe that could produce it" — and nothing in the original fixture was both mineable and craftable, so that scenario had nothing to bite on. Condensed Carbon is exactly that item in the real game (mineable, and refined 2:1 from Carbon). It defaults to `raw`, so the graph stays at 34 nodes.

## What this is not

There is no canvas on screen yet — no React app, no WASM bridge, no `cmd/`. Stage 1 is the data layer the canvas renders. The next increment is the Vite + React Flow + elkjs scaffold from ADR-0004 plus the WASM adapter marshalling `PlanInput` in and `ResolvedGraph` out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)