### PR TITLE
Accept ADR-0003/0004 and configure the GitHub tracker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,27 @@ These comments help future sessions (and `/sdd:check`) trace implementation back
 ### Session Coordination
 
 When orchestrating multiple SDD plugin skills in a single session (e.g., running `/sdd:work` on several issues), use `TeamCreate` to coordinate agents. Do not spawn ad-hoc background agents for work that requires coordination — `SendMessage` only works within a Team, and isolated agents cannot see sibling file claims or type creations.
+
+### SDD Configuration
+
+#### Tracker
+- **Type**: github
+- **Owner**: jonstump
+- **Repo**: nms-base-planner
+
+#### Branch Conventions
+- **Enabled**: true
+- **Prefix**: feat
+- **Epic Prefix**: epic
+- **Slug Max Length**: 50
+
+#### PR Conventions
+- **Enabled**: true
+- **Close Keyword**: Closes
+- **Ref Keyword**: Part of
+- **Include Spec Reference**: true
+
+#### Review
+- **Max Pairs**: 2
+- **Merge Strategy**: squash
+- **Auto Cleanup**: false

--- a/docs/adrs/ADR-0003-go-wasm-domain-core.md
+++ b/docs/adrs/ADR-0003-go-wasm-domain-core.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-08-17
 decision-makers: [Jon Stump]
 extends: [ADR-0001, ADR-0002]

--- a/docs/adrs/ADR-0004-react-view-layer.md
+++ b/docs/adrs/ADR-0004-react-view-layer.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-08-17
 decision-makers: [Jon Stump]
 extends: [ADR-0003]


### PR DESCRIPTION
Governance only — no code changes.

## ADR acceptance

| ADR | Status | Why |
|---|---|---|
| [0001](docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md) | stays `proposed` | Writes its own gate: must not be accepted until the Tier 2 finding is confirmed against real MBIN files |
| [0002](docs/adrs/ADR-0002-client-side-save-import.md) | stays `proposed` | No self-imposed gate, but its stage-2 premise — the `ObjectID` join to the parts catalog — is unproven |
| [0003](docs/adrs/ADR-0003-go-wasm-domain-core.md) | → **`accepted`** | Central claim validated by the stage 1 merge |
| [0004](docs/adrs/ADR-0004-react-view-layer.md) | → **`accepted`** | Stack choice, nothing gates it |

I checked each ADR for an explicit acceptance gate rather than assuming one. Only ADR-0001 has one.

On ADR-0003: its WASM half is still unproven — no WASM build exists yet. `accepted` here means the decision is made, not that every consequence is measured. What the stage 1 merge did validate is the load-bearing part: the domain package holds its `no-syscall/js` boundary, is shareable with the ingestion CLI, and tests under plain `go test`. If WASM proves unworkable in practice, ADR-0002 already documents the TypeScript fallback and this decision gets revised rather than superseded.

Only the `status` field changed; `date` stays as the creation date.

## Tracker configuration

Adds the `### SDD Configuration` section to `CLAUDE.md`. Its absence is why `/sdd:plan` could not run at all — it resolves the tracker from that section, and `/sdd:init` only creates one when migrating a legacy JSON config, which this repo never had.

Values match what the repo already does rather than inventing conventions: squash merges, `feat` branch prefix, `Closes` / `Part of` keywords, spec references in PR bodies.

Two side effects:

- `/sdd:index` will now create a fourth collection, `nms-base-planner-issues`, syncing from GitHub. Every prior run skipped it for want of a tracker. It stays empty until issues exist.
- `Review > Max Pairs: 2` is inert on this harness — `TeamCreate` is unavailable, so `/sdd:review` always runs single-agent. Set to the documented default rather than something misleading.

## What this unblocks

`/sdd:plan`. The next artifact gap is a spec for the WASM boundary — ADR-0003 names the adapter package as the only `syscall/js` code and stops there, so nothing yet specifies what crosses it, in what shape, or how sentinel errors survive the crossing. That is what scaffolding would implement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)