### PR TITLE
SPEC-0002: WASM boundary

### DIFF
--- a/docs/openspec/specs/wasm-boundary/design.md
+++ b/docs/openspec/specs/wasm-boundary/design.md
@@ -1,0 +1,137 @@
+# Design: WASM Boundary
+
+## Context
+
+ADR-0003 splits the application: a Go domain package that imports no `syscall/js`, and a thin adapter that is the only code permitted to touch `js.Value`. The domain half exists and is merged — SPEC-0001 stage 1 resolves the 34-node Stasis Device tree, holds the import boundary, and tests under plain `go test`. The adapter does not exist, and nothing yet specifies what crosses it.
+
+Three facts about the current code shape this design:
+
+- **The domain types carry no JSON tags.** `PlanInput`, `ResolvedGraph`, `Node`, and `Edge` are plain Go structs with no serialization annotations. Nothing can be marshalled by reflection without first deciding a wire shape.
+- **`Node.total` is unexported.** The authoritative quantity is a `*big.Rat` reachable only through `Total()` and `TotalInt()`. Reflection-based marshalling cannot see it at all.
+- **JavaScript cannot represent Go's integer range.** `Number.MAX_SAFE_INTEGER` is 2^53−1; `int64` reaches 2^63−1. A ~1000× gap where values silently lose precision.
+
+That last fact is why this spec exists in the shape it does. SPEC-0001 went to real lengths for exactness — integers throughout, rationals for multipliers, rounding only at named physical boundaries, and a `TotalInt` that refuses to report an out-of-range value as exact. All of it is undone by one careless `float64` at the boundary.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Preserve SPEC-0001's exactness guarantee across the boundary, not just inside the engine
+- Make the ADR-0003 import boundary verifiable rather than aspirational
+- Keep encoding and decoding testable without a browser or WASM toolchain
+- Give the view a failure contract it can branch on without parsing prose
+- Keep crossings coarse, so the boundary is not a per-node chatter surface
+
+### Non-Goals
+
+- Stage 2 and 3 payload shapes — reserved, and specified when those stages exist
+- Save file import across the boundary (ADR-0002, separate spec)
+- Plan URL-hash serialization (separate spec) — a different serialization with different constraints
+- Bundle size and lazy-loading strategy beyond the SHOULD in the spec — a view-layer build concern
+- Running the domain in a Web Worker
+
+## Decisions
+
+### JSON strings across the boundary, not `js.Value` construction
+
+**Choice**: Entry points accept a JSON string and return a JSON string. The adapter marshals and unmarshals; it does not build `js.Value` object graphs field by field.
+
+**Rationale**: The decisive property is testability. A JSON-string boundary is exercisable under plain `go test` — marshal, unmarshal, assert — with no browser and no WASM build, which is what REQ "Domain Purity Preservation" demands. Building `js.Value` trees is only testable inside a running WASM instance, which would make the most correctness-critical code in the module the least testable.
+
+It also gives precision a place to live: a JSON string can carry an arbitrary-precision decimal as a string field, where a `js.Value` number cannot.
+
+**Alternatives considered**:
+- *`js.Value` object construction*: avoids a serialize/parse round-trip, but is only testable in a browser and offers no escape from float64 for numeric fields.
+- *A binary format*: unnecessary at this scale and unreadable in devtools, which matters more than bytes for a 34-node graph.
+
+### Every quantity crosses as a decimal string
+
+**Choice**: Node totals, edge per-unit quantities, target quantity, and every later derived count encode as strings. Uniformly — not "number when it fits, string when it doesn't."
+
+**Rationale**: A conditional contract is a contract consumers get wrong. If a field is *sometimes* a number and *sometimes* a string, every consumer needs a type check, and the code path that handles the string case is the one that never runs in testing and breaks in production on the one large value.
+
+Uniform strings also match what the view actually does with quantities: it displays them. The design handoffs render every figure in JetBrains Mono with `tabular-nums` — display text, not operands. SPEC-0001 already forbids the view from recomputing domain values, so arithmetic on the JS side is out of scope by construction. A consumer that genuinely needs arithmetic opts into `BigInt` explicitly, which is the correct amount of friction for that operation.
+
+**Alternatives considered**:
+- *Number when within safe-integer range, string otherwise*: smaller payloads and more ergonomic in the common case, but creates exactly the rarely-exercised branch described above.
+- *Always a number*: discards SPEC-0001's guarantee outright. Rejected on the spec's own terms.
+- *`{num, denom}` pairs*: exact and unambiguous, but verbose, and pushes rational reconstruction onto a consumer that only wants to print the value.
+
+### Stable error codes decoupled from Go error text
+
+**Choice**: Each sentinel maps to a fixed identifier carried in the error payload. The wrapped Go message crosses alongside it as an unstructured human-readable field.
+
+**Rationale**: Go's error wrapping produces excellent diagnostics — SPEC-0001 requires the chain from target to failing node — but `errors.Is` does not survive a boundary crossing, and matching on message text is the classic brittle coupling. A stable code lets the view branch on failure kind while the message stays free to improve.
+
+The reserved unclassified code matters more than it appears: silently mapping an unrecognized error onto the nearest sentinel would make the view branch confidently on a wrong kind. Better to be explicitly unclassified.
+
+### The adapter holds no domain logic
+
+**Choice**: Encoding, decoding, and error mapping only. No traversal, no arithmetic, no provenance rules.
+
+**Rationale**: This is what keeps ADR-0003's claim true rather than nominal. Logic that drifts into the adapter is logic the ingestion CLI cannot share and that plain `go test` cannot reach without a WASM build — which is the erosion ADR-0003 warned would mean the decision "has failed even if the app works."
+
+The concrete temptation is rounding. It will be tempting to round a rational to something display-friendly in the adapter. Rounding is a domain rule — SPEC-0001 names exactly which physical boundaries round and in which direction — and it belongs in the domain.
+
+### An explicit readiness signal, with artifact loading separate from instantiation
+
+**Choice**: Module start and Tier 1 artifact load are distinct steps, with an explicit readiness signal gating entry points.
+
+**Rationale**: They fail for unrelated reasons and deserve unrelated diagnostics. A malformed artifact is a data problem the extraction spike may cause; a failed instantiation is a build or delivery problem. Collapsing them produces a message that helps with neither. Separation also lets a future flow swap artifacts — a re-extracted Tier 1 — without re-instantiating the module.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant V as View (React)
+    participant A as Adapter (syscall/js)
+    participant D as Domain (no syscall/js)
+
+    V->>A: load module
+    A-->>V: instantiated
+    V->>A: init(tier1 JSON)
+    A->>D: LoadTier1 + Validate
+    alt artifact invalid
+        D-->>A: ErrInvalidArtifact
+        A-->>V: {ok:false, code:"invalid_artifact"}
+    else valid
+        D-->>A: *Tier1
+        A-->>V: ready
+    end
+
+    V->>A: resolve(planInput JSON)
+    A->>A: decode → PlanInput
+    A->>D: Resolve(t, in)
+    alt domain error
+        D-->>A: wrapped err + sentinel
+        A->>A: map sentinel → stable code
+        A-->>V: {ok:false, error:{code, message}}
+    else success
+        D-->>A: *ResolvedGraph
+        A->>D: Total() / TotalInt() per node
+        A->>A: encode quantities as strings
+        A-->>V: {ok:true, data:{nodes[…]}, contractVersion}
+    end
+    V->>V: render — no recomputation (ADR-0004)
+```
+
+## Risks / Trade-offs
+
+- **Serialize/parse cost on every crossing** → Irrelevant at 34 nodes and one crossing per interaction. Revisit only if a combined tree pushes payloads far beyond current scale, and measure before optimizing.
+- **String quantities are less ergonomic for consumers** → Accepted deliberately. The view displays rather than computes, so the ergonomic cost lands almost nowhere, and the alternative reintroduces the precision bug this spec exists to prevent.
+- **Adapter logic drift** → The strongest defence is that the domain package stays independently testable; if a rule migrates to the adapter, its domain test disappears. Worth watching in review rather than trusting to discipline.
+- **Contract version becomes ceremonial** → A version nobody bumps is worse than none, because it asserts a compatibility that was never checked. Tie the bump to the shapes named in the requirement and check it in review.
+- **WASM payload delays first paint** → Lazy loading is a SHOULD here and a view-layer build concern; ADR-0003 already records payload as a known cost to measure rather than assume.
+
+## Migration Plan
+
+Greenfield. Build order: the encoding and decoding layer first, tested in plain Go against the existing Stasis and cake fixtures; then the `syscall/js` registration; then the view's consumption path.
+
+The first two steps need no WASM toolchain at all, which means the boundary's correctness-critical half can be built and tested before the WASM build is proven — and if the WASM build proves unworkable, that work transfers directly to the TypeScript fallback ADR-0002 records.
+
+## Open Questions
+
+1. **Synchronous or asynchronous entry points.** The spec requires event-loop safety and expresses a preference for async when a call could become long-running, without settling it. At current scale a synchronous call returns well inside a frame. Settle when the first real timing exists rather than guessing.
+2. **Where the Tier 1 artifact is fetched.** The view could fetch it and pass it in, or the module could fetch it itself. Passing it in keeps the module free of network concerns and is the assumed shape here, but it has not been decided.
+3. **Whether stages 2 and 3 are separate crossings or one composed call.** Separate crossings match the staged design and let the canvas skip producer math; a composed call halves the crossings for the base planner. Decide when stage 2 exists.
+4. **Contract version format.** An integer is sufficient and hard to misuse; semantic versioning would let additive changes avoid a hard failure. Unresolved, and cheap to change before the first consumer ships.

--- a/docs/openspec/specs/wasm-boundary/spec.md
+++ b/docs/openspec/specs/wasm-boundary/spec.md
@@ -1,0 +1,211 @@
+---
+status: draft
+date: 2026-08-18
+implements: [ADR-0003, ADR-0004]
+requires: [SPEC-0001]
+---
+
+# SPEC-0002: WASM Boundary
+
+## Overview
+
+The boundary between the Go domain core and the JavaScript view layer. ADR-0003 places the dependency graph, rollup engine, power math, save parsing, and plan serialization in a Go package that imports no `syscall/js`, and names a thin adapter package as the only code permitted to touch `js.Value`. This spec defines what that adapter exposes and what crosses it.
+
+The boundary is where SPEC-0001's guarantees are most easily lost. That spec requires exact integer and rational arithmetic and forbids accumulating floating-point error across the graph — and JavaScript's only numeric type is IEEE-754 double, exact for integers only up to 2^53−1 against Go's int64 range of 2^63−1. A naive marshalling step discards at the last moment precisely what the engine was built to preserve. The encoding requirement below exists for that reason.
+
+Per ADR-0004 the view renders and never recomputes domain values, so this boundary is also the mechanism by which that separation is enforceable rather than merely intended.
+
+## Requirements
+
+### Requirement: Boundary Surface
+
+The adapter MUST expose a single named entry point per domain stage, registered on a single namespace object rather than scattered across the global scope. Stage 1 (`resolve`) is REQUIRED; `rollup` and `power` are RESERVED for stages 2 and 3 and MUST follow the same contract when added.
+
+The surface MUST be coarse-grained: one call performs one complete stage. The adapter MUST NOT expose per-node, per-edge, or otherwise incremental accessors that would require repeated boundary crossings to assemble one result.
+
+The adapter MUST NOT expose any function that mutates domain state. Every entry point is a pure computation from an input value to a result value.
+
+#### Scenario: Single namespace
+
+- **WHEN** the module has initialized
+- **THEN** exactly one namespace object is registered, carrying the stage entry points, and no domain function is reachable from the global scope directly
+
+#### Scenario: One crossing per stage
+
+- **WHEN** the view resolves a plan and renders 34 nodes
+- **THEN** exactly one boundary crossing occurred, and node data was read from the single returned value
+
+#### Scenario: Reserved stages follow the same contract
+
+- **WHEN** `rollup` or `power` is added in a later stage
+- **THEN** it accepts and returns the same envelope shape defined by REQ "Result Envelope", with no bespoke calling convention
+
+### Requirement: Exact Quantity Encoding
+
+Every quantity crossing the boundary MUST be encoded as a decimal string, never as a JavaScript number. This applies to node totals, edge per-unit quantities, target quantity, and every derived count added by later stages.
+
+The adapter MUST NOT convert a quantity to `float64` at any point in the encoding path. Where a total is not an exact integer, it MUST be encoded as an exact decimal or rational string that round-trips without loss.
+
+Where the domain reports a value as inexact — `TotalInt` returning `false` per SPEC-0001 REQ "Exact Arithmetic and Rounding Discipline" — the adapter MUST NOT substitute a truncated, wrapped, or approximated value. It MUST encode the exact value as a string.
+
+#### Scenario: Ordinary total crosses as a string
+
+- **WHEN** Condensed Carbon resolves to a total of 300
+- **THEN** the encoded value is the string `"300"`, not the number `300`
+
+#### Scenario: Value beyond JavaScript safe-integer range survives
+
+- **WHEN** a total exceeds 2^53−1, which JavaScript cannot represent exactly as a number
+- **THEN** the encoded string carries the exact value, and parsing it as a `BigInt` on the consuming side yields that value unchanged
+
+#### Scenario: Non-integer total is not rounded
+
+- **WHEN** a later stage produces a total that is exactly one and a half
+- **THEN** the encoded value represents that quantity exactly, and no rounding or truncation is applied at the boundary
+
+#### Scenario: No float in the encoding path
+
+- **WHEN** the adapter encodes any quantity
+- **THEN** no conversion through `float64` occurs, verified by the absence of such conversions in the encoding code
+
+### Requirement: Result Envelope
+
+Every entry point MUST return a single envelope carrying an explicit success flag, exactly one of a result payload or an error payload, and the contract version. The envelope MUST NOT signal failure by returning a falsy value, an empty result, or by throwing a JavaScript exception carrying an unstructured string.
+
+A failed call MUST NOT return a partial result alongside its error, consistent with SPEC-0001 REQ "Error Handling Standards".
+
+#### Scenario: Success carries a payload and no error
+
+- **WHEN** a call succeeds
+- **THEN** the envelope reports success, carries the result payload, and carries no error payload
+
+#### Scenario: Failure carries an error and no payload
+
+- **WHEN** graph resolution fails
+- **THEN** the envelope reports failure, carries the error payload, and carries no result payload — not an empty one
+
+### Requirement: Sentinel Error Preservation
+
+Each error crossing the boundary MUST carry a stable machine-readable code that identifies its domain sentinel, so a consumer can branch on failure kind without parsing prose. The code set MUST cover every sentinel defined by SPEC-0001 REQ "Error Handling Standards": unknown item, illegal method, cycle detected, missing constant, and invalid artifact.
+
+Codes MUST be stable identifiers independent of Go error text — changing an error's message MUST NOT change its code. The human-readable message, including the wrapped resolution path, MUST also cross, but as a separate field that carries no contractual guarantee of format.
+
+An error matching no known sentinel MUST cross with a distinct code reserved for unclassified failures rather than being silently mapped onto an unrelated sentinel.
+
+#### Scenario: Sentinel is distinguishable without string parsing
+
+- **WHEN** a plan names an item absent from the Tier 1 artifact
+- **THEN** the error payload carries the code for unknown item, and the consumer branches on that code alone
+
+#### Scenario: Message change does not change the code
+
+- **WHEN** a domain error's wrapped message text is reworded
+- **THEN** the code it crosses with is unchanged
+
+#### Scenario: Unclassified error is not mislabelled
+
+- **WHEN** an error matches none of the defined sentinels
+- **THEN** it crosses with the reserved unclassified code, not with the code of an unrelated sentinel
+
+### Requirement: Module Lifecycle and Readiness
+
+The module MUST expose an explicit readiness signal that resolves only after the WASM instance has started and the Tier 1 artifact has been loaded and validated. Calling any entry point before readiness MUST fail with a defined error rather than returning an undefined value or hanging.
+
+Artifact loading MUST be a distinct step from module instantiation, so an invalid artifact is reported as an artifact failure rather than a module failure.
+
+The module SHOULD be loadable lazily, so that first paint does not wait on it.
+
+#### Scenario: Calls before readiness fail cleanly
+
+- **WHEN** an entry point is called before the readiness signal has resolved
+- **THEN** it returns a failure envelope with the not-ready code, and does not hang or return undefined
+
+#### Scenario: Invalid artifact is attributed correctly
+
+- **WHEN** the module instantiates successfully but the supplied Tier 1 artifact fails validation
+- **THEN** the failure is reported as an invalid-artifact error, not as a module load failure
+
+### Requirement: Domain Purity Preservation
+
+The domain package MUST NOT import `syscall/js`. The adapter package MUST be the only package in the module that does.
+
+The adapter MUST NOT contain domain logic. It performs encoding, decoding, and error mapping only — no graph traversal, no quantity arithmetic, no provenance derivation. Any rule that determines a domain value MUST live in the domain package where it is testable without a browser.
+
+The adapter's encoding and decoding MUST be testable without a browser and without a WASM toolchain, so the boundary's correctness does not depend on an integration environment.
+
+#### Scenario: Import boundary holds
+
+- **WHEN** the module's dependency graph is inspected
+- **THEN** `syscall/js` is reachable only through the adapter package
+
+#### Scenario: Adapter performs no arithmetic
+
+- **WHEN** the adapter is inspected for quantity arithmetic, graph traversal, or provenance rules
+- **THEN** none are present; it delegates every such determination to the domain package
+
+#### Scenario: Encoding is testable in plain Go
+
+- **WHEN** the encoding and decoding paths are exercised
+- **THEN** they run under plain `go test` with no browser and no WASM build
+
+### Requirement: Event Loop Safety
+
+An entry point MUST NOT block the JavaScript event loop indefinitely, and MUST NOT re-enter JavaScript synchronously from within a call in a way that can deadlock the Go runtime's single WASM thread.
+
+Where a computation could become long-running, the boundary SHOULD present an asynchronous contract rather than a synchronous one, so the page remains responsive.
+
+#### Scenario: Page stays responsive during a call
+
+- **WHEN** a resolve call executes
+- **THEN** the page does not become unresponsive, and no deadlock occurs between the Go runtime and the JavaScript event loop
+
+### Requirement: Contract Versioning
+
+The boundary contract MUST carry a version, reported in every result envelope. The consuming view MUST verify that version against the one it was built for, and MUST fail with a clear diagnostic on mismatch rather than proceeding against an unexpected shape.
+
+The version MUST change whenever the envelope shape, the encoding of quantities, or the sentinel code set changes.
+
+#### Scenario: Mismatch is detected, not tolerated
+
+- **WHEN** the view is built against one contract version and loads a module reporting another
+- **THEN** it reports a version mismatch naming both versions, and does not attempt to consume the payload
+
+### Requirement: Determinism Across the Boundary
+
+Identical inputs MUST produce byte-identical encoded output, preserving the determinism SPEC-0001 REQ "Determinism" requires of the engine. Encoding MUST NOT introduce ordering that varies between runs, and MUST preserve the node ordering the domain produced.
+
+Provenance flags MUST cross unchanged. A value the domain marked unverified MUST arrive marked unverified.
+
+#### Scenario: Encoding is byte-stable
+
+- **WHEN** the same plan input is resolved and encoded twice in the same process
+- **THEN** the two encoded outputs are byte-identical
+
+#### Scenario: Node order survives
+
+- **WHEN** an encoded graph is decoded by the consumer
+- **THEN** node order matches the domain's order — terminals first, target last
+
+#### Scenario: Provenance survives
+
+- **WHEN** a node is marked unverified by the domain
+- **THEN** it arrives at the consumer marked unverified
+
+### Requirement: Error Handling Standards
+
+All error-producing operations MUST follow structured error handling:
+
+- Errors MUST be wrapped with contextual information at each layer boundary (e.g., "decoding plan input: quantity must be positive, got -1")
+- Sentinel errors MUST be defined for domain-specific failure modes that callers need to distinguish programmatically — at minimum, the boundary adds: not ready, malformed input, and contract version mismatch
+- Silent error swallowing MUST NOT occur — every error MUST be either returned to the caller, logged with sufficient context, or explicitly handled with a documented reason for suppression
+- Structured logging MUST be used for error reporting (key-value pairs, not string interpolation)
+
+#### Scenario: Malformed input is rejected with context
+
+- **WHEN** the view passes input that cannot be decoded into a valid plan
+- **THEN** the failure names what could not be decoded, and no computation is attempted
+
+#### Scenario: Boundary sentinels are distinguishable
+
+- **WHEN** a call fails because the module is not ready, versus because the input was malformed
+- **THEN** the two failures carry different codes


### PR DESCRIPTION
Specifies the boundary between the Go domain core and the JavaScript view. Documentation only — no code.

ADR-0003 named the adapter package as the only `syscall/js` code and stopped there. Nothing said what crosses it, in what shape, or how failures survive the crossing — and that gap is exactly what scaffolding would have implemented.

`implements: [ADR-0003, ADR-0004]` · `requires: [SPEC-0001]`

## The requirement this spec exists for

JavaScript's `MAX_SAFE_INTEGER` is 2^53−1. Go's `int64` reaches 2^63−1. A ~1000× gap where values silently lose precision.

[SPEC-0001](docs/openspec/specs/rollup-engine/spec.md) went to real lengths for exactness — integers throughout, rationals for class multipliers, rounding only at named physical boundaries, and a `TotalInt` that refuses to report an out-of-range value as exact (a defect [#2](https://github.com/jonstump/nms-base-planner/pull/2) actually caught). One careless `float64` in the encoder discards all of it at the last step.

So **every quantity crosses as a decimal string** — uniformly, not "number when it fits, string when it doesn't." A field that is sometimes a number and sometimes a string creates a branch that never runs in testing and breaks in production on the first large value. This is comfortable because the view *displays* quantities rather than computing with them; SPEC-0001 already forbids it from recomputing domain values, and the handoffs render every figure as `tabular-nums` display text.

## Three constraints confirmed in the code first

| Fact | Consequence |
|---|---|
| Domain types carry **no JSON tags** | Nothing marshals by reflection; a wire shape must be decided |
| **`Node.total` is unexported** | Reflection cannot see the authoritative quantity at all — only `Total()` / `TotalInt()` reach it |
| JS cannot represent Go's integer range | The encoding requirement above |

Together they mean the adapter needs explicit DTOs, which is architecturally right anyway — the wire format should not be the domain's concern.

## Other load-bearing requirements

- **Stable sentinel codes decoupled from Go error text.** `errors.Is` does not survive a boundary crossing, and matching on message prose is the classic brittle coupling. A reserved *unclassified* code ensures an unrecognised error is never silently mapped onto the nearest sentinel — that would make the view branch confidently on a wrong kind.
- **The adapter holds no domain logic**, with rounding named specifically as the concrete temptation. Rounding is a domain rule; SPEC-0001 already says which physical boundaries round and in which direction.
- **Module readiness separate from artifact loading** — a malformed Tier 1 artifact and a failed instantiation fail for unrelated reasons and deserve unrelated diagnostics.

## Why JSON strings over `js.Value`

Testability. A JSON boundary is exercisable under plain `go test`; `js.Value` trees are only testable inside a running WASM instance, which would make the most correctness-critical code in the module the least testable.

That yields a useful build order: the encoding layer first, tested against the existing Stasis and cake fixtures, **before any WASM toolchain is proven**. If the WASM build turns out unworkable, that work transfers directly to the TypeScript fallback ADR-0002 records.

## Scope

10 requirements, 24 scenarios. Not web-facing (no endpoints, routes, or server — the module is delivered over HTTP but that is asset delivery) and not UI-facing (it renders nothing), so no security or accessibility sections. Backend error-handling standards apply.

Four open questions are carried rather than guessed: sync vs async entry points, who fetches the Tier 1 artifact, whether stages 2–3 are separate crossings, and the contract version format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)