### PR TITLE
PSARC reader and nmsextract CLI

### DIFF
--- a/cmd/nmsextract/main.go
+++ b/cmd/nmsextract/main.go
@@ -1,0 +1,147 @@
+// Command nmsextract unpacks No Man's Sky .pak archives.
+//
+// The .pak files under GAMEDATA/PCBANKS are PSARC archives. MBINCompiler
+// works on already-unpacked .MBIN files, so this covers the step before it.
+//
+// Governing: ADR-0001 (two-tier NMS data ingestion) — stage 1, "locate +
+// extract PAKs".
+//
+//	nmsextract list    <archive.pak> [substring]
+//	nmsextract extract <archive.pak> <outdir> [substring]
+//
+// The optional substring filters by path, case-insensitively — useful
+// because a PCBANKS archive holds tens of thousands of entries and the
+// recipe tables are a handful of them:
+//
+//	nmsextract list NMSARC.515F1D3.pak TABLE
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jonstump/nms-base-planner/internal/psarc"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "nmsextract: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	if len(args) < 2 {
+		usage()
+		return fmt.Errorf("expected a subcommand and an archive")
+	}
+	cmd, path := args[0], args[1]
+
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	a, err := psarc.Open(f, st.Size())
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", filepath.Base(path), err)
+	}
+
+	switch cmd {
+	case "list":
+		filter := ""
+		if len(args) > 2 {
+			filter = args[2]
+		}
+		return list(a, filter)
+	case "extract":
+		if len(args) < 3 {
+			return fmt.Errorf("extract needs an output directory")
+		}
+		filter := ""
+		if len(args) > 3 {
+			filter = args[3]
+		}
+		return extract(a, args[2], filter)
+	default:
+		usage()
+		return fmt.Errorf("unknown subcommand %q", cmd)
+	}
+}
+
+func usage() {
+	fmt.Fprint(os.Stderr, `usage:
+  nmsextract list    <archive.pak> [substring]
+  nmsextract extract <archive.pak> <outdir> [substring]
+
+The substring filters paths case-insensitively.
+`)
+}
+
+func list(a *psarc.Archive, filter string) error {
+	fmt.Printf("PSARC v%d.%d  %s  block %d  %d entries\n\n",
+		a.VersionMajor, a.VersionMinor, a.Compression, a.BlockSize, len(a.Names()))
+
+	var shown int
+	var bytes int64
+	for _, e := range a.Entries() {
+		if !matches(e.Name, filter) {
+			continue
+		}
+		fmt.Printf("%12d  %s\n", e.UncompressedSize, e.Name)
+		shown++
+		bytes += e.UncompressedSize
+	}
+	fmt.Printf("\n%d entries, %d bytes uncompressed\n", shown, bytes)
+	if filter != "" {
+		fmt.Printf("(filtered by %q)\n", filter)
+	}
+	return nil
+}
+
+func extract(a *psarc.Archive, outDir, filter string) error {
+	var n int
+	var total int64
+	for _, e := range a.Entries() {
+		if !matches(e.Name, filter) {
+			continue
+		}
+
+		// Archive paths are untrusted input. Reject anything that escapes
+		// the output directory rather than writing through it.
+		dest := filepath.Join(outDir, filepath.FromSlash(e.Name))
+		rel, err := filepath.Rel(outDir, dest)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			return fmt.Errorf("refusing path %q: escapes the output directory", e.Name)
+		}
+
+		data, err := a.ReadFile(e.Name)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(dest, data, 0o644); err != nil {
+			return err
+		}
+		n++
+		total += int64(len(data))
+	}
+	fmt.Printf("extracted %d entries, %d bytes, to %s\n", n, total, outDir)
+	if n == 0 && filter != "" {
+		fmt.Printf("(nothing matched %q — try `list` first)\n", filter)
+	}
+	return nil
+}
+
+func matches(name, filter string) bool {
+	return filter == "" || strings.Contains(strings.ToLower(name), strings.ToLower(filter))
+}

--- a/cmd/nmsextract/main.go
+++ b/cmd/nmsextract/main.go
@@ -118,7 +118,9 @@ func extract(a *psarc.Archive, outDir, filter string) error {
 		// the output directory rather than writing through it.
 		dest := filepath.Join(outDir, filepath.FromSlash(e.Name))
 		rel, err := filepath.Rel(outDir, dest)
-		if err != nil || strings.HasPrefix(rel, "..") {
+		// Compare against ".." as a whole path element: a plain prefix test
+		// also rejects legitimate names that merely start with two dots.
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			return fmt.Errorf("refusing path %q: escapes the output directory", e.Name)
 		}
 

--- a/internal/psarc/malformed_test.go
+++ b/internal/psarc/malformed_test.go
@@ -1,0 +1,174 @@
+package psarc
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+)
+
+// The reader's other tests exercise archives this package's own writer
+// produced, which are well-formed by construction. These build headers and
+// tables directly, because the inputs that matter here are the ones no
+// writer would emit: a truncated download, a half-written file, or a .pak
+// from a game version whose layout we guessed wrong.
+//
+// Every case must return an error. None may panic, and none may size an
+// allocation from an unvalidated header field.
+
+// malformedHeader assembles a 32-byte PSARC header field by field.
+func malformedHeader(tocLength, entrySize, entryCount, blockSize, flags uint32) []byte {
+	var b bytes.Buffer
+	b.WriteString(magic)
+	binary.Write(&b, binary.BigEndian, uint16(1))
+	binary.Write(&b, binary.BigEndian, uint16(4))
+	b.WriteString(compZlib)
+	binary.Write(&b, binary.BigEndian, tocLength)
+	binary.Write(&b, binary.BigEndian, entrySize)
+	binary.Write(&b, binary.BigEndian, entryCount)
+	binary.Write(&b, binary.BigEndian, blockSize)
+	binary.Write(&b, binary.BigEndian, flags)
+	return b.Bytes()
+}
+
+// tocEntry assembles one 30-byte table-of-contents entry.
+func tocEntry(blockIndex uint32, uncompressed, offset uint64) []byte {
+	var b bytes.Buffer
+	b.Write(make([]byte, 16)) // md5 of the path, unused
+	binary.Write(&b, binary.BigEndian, blockIndex)
+	b.Write(put40(uncompressed))
+	b.Write(put40(offset))
+	return b.Bytes()
+}
+
+// A block-table value wider than BlockSize must not slice past the read
+// buffer. blockWidth rounds BlockSize up to a byte boundary, so a 1-byte
+// table entry carries up to 255 against a block size of 2.
+func TestBlockLengthOverBlockSizeIsRejected(t *testing.T) {
+	var f bytes.Buffer
+	f.Write(malformedHeader(63, 30, 1, 2, 0))
+	f.Write(tocEntry(0, 2, 63))
+	f.WriteByte(255) // blocks[0], far over the 2-byte block size
+	f.Write(make([]byte, 16))
+
+	_, err := Open(bytes.NewReader(f.Bytes()), int64(f.Len()))
+	if !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("error = %v, want ErrCorrupt", err)
+	}
+}
+
+// entryCount * entrySize must be computed where it cannot wrap. In int64 the
+// product of two uint32 maxima is negative, which passes a `>` guard and
+// leaves entryCount sizing a 137 GB slice.
+func TestTOCEntryProductCannotOverflow(t *testing.T) {
+	if p := uint64(^uint32(0)) * uint64(^uint32(0)); int64(p) >= 0 {
+		t.Fatalf("premise no longer holds: int64(%d) is not negative", p)
+	}
+	var f bytes.Buffer
+	f.Write(malformedHeader(1024, ^uint32(0), ^uint32(0), 65536, 0))
+	f.Write(make([]byte, 2048))
+
+	_, err := Open(bytes.NewReader(f.Bytes()), int64(f.Len()))
+	if !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("error = %v, want ErrCorrupt", err)
+	}
+}
+
+// UncompressedSize is a 40-bit field. Unchecked it becomes a make() capacity
+// of up to 1 TiB, reached during Open via the manifest.
+func TestOversizedEntryIsRejectedBeforeAllocating(t *testing.T) {
+	var f bytes.Buffer
+	f.Write(malformedHeader(65, 30, 1, 65536, 0))
+	f.Write(tocEntry(0, 1<<40-1, 65)) // ~1 TiB declared
+	f.Write([]byte{0, 0})             // blocks[0], width 2
+	f.Write(make([]byte, 16))
+
+	_, err := Open(bytes.NewReader(f.Bytes()), int64(f.Len()))
+	if !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("error = %v, want ErrCorrupt", err)
+	}
+}
+
+// BlockSize sizes a per-entry buffer, so a corrupt header must not request
+// gigabytes.
+func TestOversizedBlockSizeIsRejected(t *testing.T) {
+	for _, bs := range []uint32{maxBlockSize + 1, 1 << 30, ^uint32(0)} {
+		var f bytes.Buffer
+		f.Write(malformedHeader(65, 30, 1, bs, 0))
+		f.Write(make([]byte, 64))
+
+		_, err := Open(bytes.NewReader(f.Bytes()), int64(f.Len()))
+		if !errors.Is(err, ErrCorrupt) {
+			t.Errorf("block size %d: error = %v, want ErrCorrupt", bs, err)
+		}
+	}
+	// The real format's 64 KiB must still open far enough to fail elsewhere.
+	var ok bytes.Buffer
+	ok.Write(malformedHeader(65, 30, 1, 65536, 0))
+	ok.Write(make([]byte, 64))
+	if _, err := Open(bytes.NewReader(ok.Bytes()), int64(ok.Len())); errors.Is(err, ErrCorrupt) && err != nil {
+		t.Logf("64 KiB block size still rejected downstream (expected, archive is otherwise empty): %v", err)
+	}
+}
+
+// A block index past the end of the table must be caught at open, not by
+// running off the slice mid-read.
+func TestBlockIndexPastTableIsRejected(t *testing.T) {
+	var f bytes.Buffer
+	f.Write(malformedHeader(65, 30, 1, 65536, 0))
+	f.Write(tocEntry(9999, 10, 65))
+	f.Write([]byte{0, 0})
+	f.Write(make([]byte, 16))
+
+	_, err := Open(bytes.NewReader(f.Bytes()), int64(f.Len()))
+	if !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("error = %v, want ErrCorrupt", err)
+	}
+}
+
+// Nothing in the corrupt-input space may panic. Truncation is the shape a
+// half-finished copy off the game drive actually takes.
+func TestTruncatedArchivesNeverPanic(t *testing.T) {
+	full := buildArchive(t, 64, []string{"A/B.MBIN", "C.MBIN"},
+		[][]byte{bytes.Repeat([]byte("xy"), 200), []byte("short")})
+
+	for n := 0; n < len(full); n++ {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panic at truncation length %d: %v", n, r)
+				}
+			}()
+			if a, err := Open(bytes.NewReader(full[:n]), int64(n)); err == nil {
+				for _, name := range a.Names() {
+					a.ReadFile(name)
+				}
+			}
+		}()
+	}
+}
+
+// Byte-level corruption of an otherwise valid archive must also stay on the
+// error path.
+func TestCorruptedBytesNeverPanic(t *testing.T) {
+	full := buildArchive(t, 64, []string{"A/B.MBIN"}, [][]byte{bytes.Repeat([]byte("z"), 300)})
+
+	for i := 4; i < len(full); i++ { // leave the magic intact so Open proceeds
+		for _, v := range []byte{0x00, 0xFF, 0x7F} {
+			mutated := append([]byte(nil), full...)
+			mutated[i] = v
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("panic with byte %d set to %#x: %v", i, v, r)
+					}
+				}()
+				if a, err := Open(bytes.NewReader(mutated), int64(len(mutated))); err == nil {
+					for _, name := range a.Names() {
+						a.ReadFile(name)
+					}
+				}
+			}()
+		}
+	}
+}

--- a/internal/psarc/psarc.go
+++ b/internal/psarc/psarc.go
@@ -1,0 +1,334 @@
+// Package psarc reads PlayStation Archive (PSARC) files.
+//
+// No Man's Sky ships its assets as .pak files under GAMEDATA/PCBANKS, which
+// are PSARC archives despite the extension. MBINCompiler operates on already
+// unpacked .MBIN files, so unpacking is our step.
+//
+// Governing: ADR-0001 (two-tier NMS data ingestion) — stage 1 of the
+// ingestion pipeline, "locate + extract PAKs".
+//
+// The format, all integers big-endian:
+//
+//	header      32 bytes: magic, version, compression, toc length, entry
+//	            size, entry count, block size, flags
+//	toc         entryCount * entrySize bytes; each entry is a 16-byte md5 of
+//	            the path, a uint32 index into the block table, and two 40-bit
+//	            values (uncompressed size, archive offset)
+//	blocks      fills the remainder of the toc; each value is the compressed
+//	            length of one block, 0 meaning a full uncompressed block
+//	data        the blocks themselves
+//
+// Entry 0 is the manifest: a newline-separated list of paths for entries
+// 1..n-1, compressed like any other entry. Paths therefore cost one
+// decompression to learn.
+package psarc
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Sentinel errors for the failure modes callers need to distinguish.
+//
+// Governing: ADR-0001; error-handling standards mirror SPEC-0001 REQ "Error
+// Handling Standards" so the ingestion CLI and the domain behave alike.
+var (
+	// ErrNotPSARC reports a file whose magic is not "PSAR".
+	ErrNotPSARC = errors.New("not a PSARC archive")
+
+	// ErrUnsupported reports a well-formed archive this reader cannot handle
+	// — an unknown compression scheme or an encrypted table of contents.
+	ErrUnsupported = errors.New("unsupported PSARC variant")
+
+	// ErrCorrupt reports internally inconsistent data: truncated reads,
+	// out-of-range offsets, or a block stream that does not produce the
+	// declared uncompressed size.
+	ErrCorrupt = errors.New("corrupt PSARC archive")
+
+	// ErrNotFound reports a path absent from the archive manifest.
+	ErrNotFound = errors.New("file not found in archive")
+)
+
+const (
+	magic            = "PSAR"
+	headerSize       = 32
+	compZlib         = "zlib"
+	flagTOCEncrypted = 1 << 0
+)
+
+// Entry is one file in the archive.
+type Entry struct {
+	// Name is the archive-relative path. Empty for entry 0, the manifest.
+	Name string
+
+	// UncompressedSize is the size Read returns on success.
+	UncompressedSize int64
+
+	blockIndex  uint32
+	startOffset int64
+}
+
+// Archive is an opened PSARC. It holds no decompressed data; entries are
+// inflated on demand, because a PCBANKS .pak is far larger than we want
+// resident.
+type Archive struct {
+	r io.ReaderAt
+
+	VersionMajor uint16
+	VersionMinor uint16
+	Compression  string
+	BlockSize    uint32
+
+	entries []Entry
+	byName  map[string]int
+	blocks  []uint32
+}
+
+// Open reads the header, table of contents, and manifest. size is the length
+// of the underlying archive, used to reject offsets that run past the end.
+func Open(r io.ReaderAt, size int64) (*Archive, error) {
+	hdr := make([]byte, headerSize)
+	if _, err := r.ReadAt(hdr, 0); err != nil {
+		return nil, fmt.Errorf("reading header: %w: %w", ErrCorrupt, err)
+	}
+	if string(hdr[0:4]) != magic {
+		return nil, fmt.Errorf("%w: magic is %q, want %q", ErrNotPSARC, hdr[0:4], magic)
+	}
+
+	a := &Archive{
+		r:            r,
+		VersionMajor: binary.BigEndian.Uint16(hdr[4:6]),
+		VersionMinor: binary.BigEndian.Uint16(hdr[6:8]),
+		Compression:  string(hdr[8:12]),
+		BlockSize:    binary.BigEndian.Uint32(hdr[24:28]),
+	}
+	tocLength := binary.BigEndian.Uint32(hdr[12:16])
+	entrySize := binary.BigEndian.Uint32(hdr[16:20])
+	entryCount := binary.BigEndian.Uint32(hdr[20:24])
+	flags := binary.BigEndian.Uint32(hdr[28:32])
+
+	if a.Compression != compZlib {
+		return nil, fmt.Errorf("%w: compression %q, only %q is supported", ErrUnsupported, a.Compression, compZlib)
+	}
+	if flags&flagTOCEncrypted != 0 {
+		return nil, fmt.Errorf("%w: table of contents is encrypted", ErrUnsupported)
+	}
+	if entrySize < 30 {
+		return nil, fmt.Errorf("%w: toc entry size %d, want at least 30", ErrCorrupt, entrySize)
+	}
+	if entryCount == 0 {
+		return nil, fmt.Errorf("%w: archive declares zero entries, but entry 0 is always the manifest", ErrCorrupt)
+	}
+	if a.BlockSize == 0 {
+		return nil, fmt.Errorf("%w: block size is zero", ErrCorrupt)
+	}
+	if int64(tocLength) > size || int64(tocLength) < headerSize {
+		return nil, fmt.Errorf("%w: toc length %d against archive size %d", ErrCorrupt, tocLength, size)
+	}
+
+	tocBytes := int64(entryCount) * int64(entrySize)
+	if headerSize+tocBytes > int64(tocLength) {
+		return nil, fmt.Errorf("%w: %d entries of %d bytes exceed toc length %d", ErrCorrupt, entryCount, entrySize, tocLength)
+	}
+
+	toc := make([]byte, tocLength-headerSize)
+	if _, err := r.ReadAt(toc, headerSize); err != nil {
+		return nil, fmt.Errorf("reading toc: %w: %w", ErrCorrupt, err)
+	}
+
+	a.entries = make([]Entry, entryCount)
+	for i := range a.entries {
+		b := toc[int64(i)*int64(entrySize):]
+		a.entries[i] = Entry{
+			// b[0:16] is the md5 of the path; we resolve names from the
+			// manifest instead, so it is read past rather than stored.
+			blockIndex:       binary.BigEndian.Uint32(b[16:20]),
+			UncompressedSize: int64(read40(b[20:25])),
+			startOffset:      int64(read40(b[25:30])),
+		}
+		if a.entries[i].startOffset > size {
+			return nil, fmt.Errorf("%w: entry %d starts at %d, past archive end %d", ErrCorrupt, i, a.entries[i].startOffset, size)
+		}
+	}
+
+	width := blockWidth(a.BlockSize)
+	blockBytes := int64(tocLength) - headerSize - tocBytes
+	if blockBytes < 0 || blockBytes%int64(width) != 0 {
+		return nil, fmt.Errorf("%w: %d block-table bytes is not a multiple of %d", ErrCorrupt, blockBytes, width)
+	}
+	a.blocks = make([]uint32, blockBytes/int64(width))
+	for i := range a.blocks {
+		off := tocBytes + int64(i)*int64(width)
+		a.blocks[i] = readN(toc[off : off+int64(width)])
+	}
+
+	if err := a.loadManifest(); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// loadManifest inflates entry 0 and assigns names to entries 1..n-1.
+func (a *Archive) loadManifest() error {
+	raw, err := a.readEntry(0)
+	if err != nil {
+		return fmt.Errorf("reading manifest: %w", err)
+	}
+	names := strings.FieldsFunc(string(raw), func(r rune) bool { return r == '\n' || r == '\r' })
+
+	a.byName = make(map[string]int, len(names))
+	for i, name := range names {
+		name = strings.TrimPrefix(strings.TrimSpace(name), "/")
+		if name == "" {
+			continue
+		}
+		// Manifest line i names entry i+1; entry 0 is the manifest itself.
+		if i+1 >= len(a.entries) {
+			return fmt.Errorf("%w: manifest lists %d names for %d entries", ErrCorrupt, len(names), len(a.entries)-1)
+		}
+		a.entries[i+1].Name = name
+		a.byName[name] = i + 1
+	}
+	return nil
+}
+
+// Names returns every path in the archive, in manifest order.
+func (a *Archive) Names() []string {
+	out := make([]string, 0, len(a.entries)-1)
+	for _, e := range a.entries[1:] {
+		if e.Name != "" {
+			out = append(out, e.Name)
+		}
+	}
+	return out
+}
+
+// Entries returns the archive's entries excluding the manifest.
+func (a *Archive) Entries() []Entry {
+	out := make([]Entry, len(a.entries)-1)
+	copy(out, a.entries[1:])
+	return out
+}
+
+// ReadFile decompresses one file by archive-relative path.
+func (a *Archive) ReadFile(name string) ([]byte, error) {
+	name = strings.TrimPrefix(name, "/")
+	i, ok := a.byName[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrNotFound, name)
+	}
+	b, err := a.readEntry(i)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", name, err)
+	}
+	return b, nil
+}
+
+// readEntry walks an entry's block list, inflating each block until the
+// declared uncompressed size is reached.
+func (a *Archive) readEntry(i int) ([]byte, error) {
+	e := a.entries[i]
+	if e.UncompressedSize == 0 {
+		return nil, nil
+	}
+
+	out := make([]byte, 0, e.UncompressedSize)
+	offset := e.startOffset
+	buf := make([]byte, a.BlockSize)
+
+	for bi := e.blockIndex; int64(len(out)) < e.UncompressedSize; bi++ {
+		if int(bi) >= len(a.blocks) {
+			return nil, fmt.Errorf("%w: entry %d ran past the block table at index %d", ErrCorrupt, i, bi)
+		}
+
+		// A zero length means the block was stored whole and uncompressed,
+		// except for a final block, which is only as long as what remains.
+		n := int64(a.blocks[bi])
+		if n == 0 {
+			n = int64(a.BlockSize)
+			if remaining := e.UncompressedSize - int64(len(out)); remaining < n {
+				n = remaining
+			}
+		}
+
+		chunk := buf[:n]
+		if _, err := a.r.ReadAt(chunk, offset); err != nil {
+			return nil, fmt.Errorf("%w: reading block %d at offset %d: %w", ErrCorrupt, bi, offset, err)
+		}
+		offset += n
+
+		// A block is compressed or stored raw, and the format gives no flag
+		// distinguishing them — only the bytes. A zlib header is the signal,
+		// but ~1 raw block in 8000 opens with a byte pair that looks like
+		// one by chance, so a failed inflate falls back to raw rather than
+		// failing the read. zlib's adler32 makes a false positive that also
+		// inflates cleanly vanishingly unlikely.
+		if inflated, ok := tryInflate(chunk); ok {
+			out = append(out, inflated...)
+		} else {
+			out = append(out, chunk...)
+		}
+	}
+
+	if int64(len(out)) != e.UncompressedSize {
+		return nil, fmt.Errorf("%w: entry %d produced %d bytes, declared %d", ErrCorrupt, i, len(out), e.UncompressedSize)
+	}
+	return out, nil
+}
+
+// tryInflate decompresses b when it is a zlib stream, reporting whether it
+// was. It screens on the zlib header first — CMF 0x78 for a 32K window with
+// the deflate method, and a FCHECK byte making the pair a multiple of 31 —
+// then confirms by actually inflating, so a chance header match on raw data
+// is rejected rather than mistaken for compressed content.
+func tryInflate(b []byte) ([]byte, bool) {
+	if len(b) < 2 || b[0] != 0x78 || (uint16(b[0])<<8|uint16(b[1]))%31 != 0 {
+		return nil, false
+	}
+	zr, err := zlib.NewReader(bytes.NewReader(b))
+	if err != nil {
+		return nil, false
+	}
+	defer zr.Close()
+	inflated, err := io.ReadAll(zr)
+	if err != nil {
+		return nil, false
+	}
+	return inflated, true
+}
+
+// read40 reads a 40-bit big-endian value. Sizes and offsets use five bytes
+// rather than four so archives can exceed 4 GiB.
+func read40(b []byte) uint64 {
+	return uint64(b[0])<<32 | uint64(b[1])<<24 | uint64(b[2])<<16 | uint64(b[3])<<8 | uint64(b[4])
+}
+
+// readN reads a 1- to 4-byte big-endian value.
+func readN(b []byte) uint32 {
+	var v uint32
+	for _, c := range b {
+		v = v<<8 | uint32(c)
+	}
+	return v
+}
+
+// blockWidth is how many bytes each block-table value occupies. A stored
+// length is always less than BlockSize, since a full block is written as 0,
+// so the width is what it takes to hold BlockSize-1.
+func blockWidth(blockSize uint32) int {
+	switch {
+	case blockSize <= 0x100:
+		return 1
+	case blockSize <= 0x10000:
+		return 2
+	case blockSize <= 0x1000000:
+		return 3
+	default:
+		return 4
+	}
+}

--- a/internal/psarc/psarc.go
+++ b/internal/psarc/psarc.go
@@ -59,6 +59,11 @@ const (
 	headerSize       = 32
 	compZlib         = "zlib"
 	flagTOCEncrypted = 1 << 0
+
+	// maxBlockSize bounds the per-entry read buffer. Real PSARC archives use
+	// 64 KiB; this is generous against that and keeps a corrupt header from
+	// asking for a 4 GiB allocation.
+	maxBlockSize = 1 << 24
 )
 
 // Entry is one file in the archive.
@@ -124,17 +129,21 @@ func Open(r io.ReaderAt, size int64) (*Archive, error) {
 	if entryCount == 0 {
 		return nil, fmt.Errorf("%w: archive declares zero entries, but entry 0 is always the manifest", ErrCorrupt)
 	}
-	if a.BlockSize == 0 {
-		return nil, fmt.Errorf("%w: block size is zero", ErrCorrupt)
+	if a.BlockSize == 0 || a.BlockSize > maxBlockSize {
+		return nil, fmt.Errorf("%w: block size %d, want 1..%d", ErrCorrupt, a.BlockSize, maxBlockSize)
 	}
 	if int64(tocLength) > size || int64(tocLength) < headerSize {
 		return nil, fmt.Errorf("%w: toc length %d against archive size %d", ErrCorrupt, tocLength, size)
 	}
 
-	tocBytes := int64(entryCount) * int64(entrySize)
-	if headerSize+tocBytes > int64(tocLength) {
+	// Computed in uint64, which cannot overflow: the product of two uint32
+	// maxima is (2^32-1)^2, below 2^64. In int64 that product wraps negative
+	// and slips past this guard, leaving entryCount to size the slice below.
+	tocBytes64 := uint64(entryCount) * uint64(entrySize)
+	if uint64(headerSize)+tocBytes64 > uint64(tocLength) {
 		return nil, fmt.Errorf("%w: %d entries of %d bytes exceed toc length %d", ErrCorrupt, entryCount, entrySize, tocLength)
 	}
+	tocBytes := int64(tocBytes64)
 
 	toc := make([]byte, tocLength-headerSize)
 	if _, err := r.ReadAt(toc, headerSize); err != nil {
@@ -165,6 +174,24 @@ func Open(r io.ReaderAt, size int64) (*Archive, error) {
 	for i := range a.blocks {
 		off := tocBytes + int64(i)*int64(width)
 		a.blocks[i] = readN(toc[off : off+int64(width)])
+	}
+
+	// Entry sizes and block indexes are only meaningful against the block
+	// table, so they are checked once it exists. Without this an entry may
+	// declare a 40-bit size — up to 1 TiB — that readEntry would preallocate
+	// before reading a single block.
+	for i, e := range a.entries {
+		if e.UncompressedSize == 0 {
+			continue
+		}
+		if int64(e.blockIndex) >= int64(len(a.blocks)) {
+			return nil, fmt.Errorf("%w: entry %d starts at block %d, past the %d-block table", ErrCorrupt, i, e.blockIndex, len(a.blocks))
+		}
+		available := int64(len(a.blocks)) - int64(e.blockIndex)
+		needed := (e.UncompressedSize + int64(a.BlockSize) - 1) / int64(a.BlockSize)
+		if needed > available {
+			return nil, fmt.Errorf("%w: entry %d declares %d bytes, needing %d blocks, but only %d remain", ErrCorrupt, i, e.UncompressedSize, needed, available)
+		}
 	}
 
 	if err := a.loadManifest(); err != nil {
@@ -254,6 +281,12 @@ func (a *Archive) readEntry(i int) ([]byte, error) {
 			if remaining := e.UncompressedSize - int64(len(out)); remaining < n {
 				n = remaining
 			}
+		} else if n > int64(a.BlockSize) {
+			// blockWidth rounds BlockSize up to a byte boundary, so a table
+			// value can hold more than BlockSize permits — a 1-byte width
+			// carries up to 255 against a block size of 2. Slicing the read
+			// buffer to it panics rather than reporting corruption.
+			return nil, fmt.Errorf("%w: entry %d block %d declares %d bytes, over the %d-byte block size", ErrCorrupt, i, bi, n, a.BlockSize)
 		}
 
 		chunk := buf[:n]

--- a/internal/psarc/psarc_test.go
+++ b/internal/psarc/psarc_test.go
@@ -1,0 +1,306 @@
+package psarc
+
+import (
+	"bytes"
+	"compress/zlib"
+	"crypto/md5"
+	"encoding/binary"
+	"errors"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// buildArchive assembles a format-correct PSARC from ordered name/content
+// pairs, so the reader can be exercised without a real .pak. It mirrors the
+// writer side of the format: entry 0 is the manifest, every entry is split
+// into blockSize chunks, and each chunk is stored compressed when that is
+// smaller and raw otherwise.
+func buildArchive(t *testing.T, blockSize uint32, names []string, contents [][]byte) []byte {
+	t.Helper()
+
+	payloads := append([][]byte{[]byte(strings.Join(names, "\n"))}, contents...)
+
+	type staged struct {
+		uncompressed int64
+		firstBlock   uint32
+		data         []byte
+	}
+	var stagedEntries []staged
+	var blockLens []uint32
+
+	for _, p := range payloads {
+		s := staged{uncompressed: int64(len(p)), firstBlock: uint32(len(blockLens))}
+		for off := 0; off < len(p); off += int(blockSize) {
+			end := off + int(blockSize)
+			if end > len(p) {
+				end = len(p)
+			}
+			chunk := p[off:end]
+
+			var zbuf bytes.Buffer
+			zw := zlib.NewWriter(&zbuf)
+			zw.Write(chunk)
+			zw.Close()
+
+			if zbuf.Len() < len(chunk) {
+				s.data = append(s.data, zbuf.Bytes()...)
+				blockLens = append(blockLens, uint32(zbuf.Len()))
+				continue
+			}
+			// Raw. A full-size block records 0; a short trailing block
+			// records its own length.
+			s.data = append(s.data, chunk...)
+			if len(chunk) == int(blockSize) {
+				blockLens = append(blockLens, 0)
+			} else {
+				blockLens = append(blockLens, uint32(len(chunk)))
+			}
+		}
+		if len(p) == 0 {
+			blockLens = append(blockLens, 0)
+		}
+		stagedEntries = append(stagedEntries, s)
+	}
+
+	const entrySize = 30
+	width := blockWidth(blockSize)
+	tocLength := headerSize + len(stagedEntries)*entrySize + len(blockLens)*width
+
+	var toc bytes.Buffer
+	offset := int64(tocLength)
+	for i, s := range stagedEntries {
+		sum := md5.Sum([]byte(nameOf(i, names)))
+		toc.Write(sum[:])
+		binary.Write(&toc, binary.BigEndian, s.firstBlock)
+		toc.Write(put40(uint64(s.uncompressed)))
+		toc.Write(put40(uint64(offset)))
+		offset += int64(len(s.data))
+	}
+	for _, bl := range blockLens {
+		b := make([]byte, 4)
+		binary.BigEndian.PutUint32(b, bl)
+		toc.Write(b[4-width:])
+	}
+
+	var out bytes.Buffer
+	out.WriteString(magic)
+	binary.Write(&out, binary.BigEndian, uint16(1))
+	binary.Write(&out, binary.BigEndian, uint16(4))
+	out.WriteString(compZlib)
+	binary.Write(&out, binary.BigEndian, uint32(tocLength))
+	binary.Write(&out, binary.BigEndian, uint32(entrySize))
+	binary.Write(&out, binary.BigEndian, uint32(len(stagedEntries)))
+	binary.Write(&out, binary.BigEndian, blockSize)
+	binary.Write(&out, binary.BigEndian, uint32(0))
+	out.Write(toc.Bytes())
+	for _, s := range stagedEntries {
+		out.Write(s.data)
+	}
+	return out.Bytes()
+}
+
+func nameOf(i int, names []string) string {
+	if i == 0 {
+		return ""
+	}
+	return names[i-1]
+}
+
+func put40(v uint64) []byte {
+	return []byte{byte(v >> 32), byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+}
+
+func open(t *testing.T, b []byte) *Archive {
+	t.Helper()
+	a, err := Open(bytes.NewReader(b), int64(len(b)))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return a
+}
+
+// Compressible, uncompressible, multi-block, and empty payloads in one
+// archive — the four block shapes the reader has to tell apart.
+func TestRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	incompressible := make([]byte, 5000)
+	rng.Read(incompressible)
+
+	multiBlock := make([]byte, 300000) // several 64 KiB blocks
+	for i := range multiBlock {
+		multiBlock[i] = byte(i % 251)
+	}
+
+	names := []string{
+		"METADATA/REALITY/TABLES/NMS_REALITY_GCPRODUCTTABLE.MBIN",
+		"random.bin",
+		"big.bin",
+		"empty.bin",
+	}
+	contents := [][]byte{
+		bytes.Repeat([]byte("compressible "), 400),
+		incompressible,
+		multiBlock,
+		{},
+	}
+
+	a := open(t, buildArchive(t, 65536, names, contents))
+
+	if got := a.Names(); len(got) != len(names) {
+		t.Fatalf("Names() = %v, want %d entries", got, len(names))
+	}
+	for i, name := range names {
+		if a.Names()[i] != name {
+			t.Errorf("Names()[%d] = %q, want %q", i, a.Names()[i], name)
+		}
+		got, err := a.ReadFile(name)
+		if err != nil {
+			t.Fatalf("ReadFile(%q): %v", name, err)
+		}
+		if !bytes.Equal(got, contents[i]) {
+			t.Errorf("%s: %d bytes read, want %d (equal=%v)", name, len(got), len(contents[i]), bytes.Equal(got, contents[i]))
+		}
+	}
+}
+
+func TestLeadingSlashIsTolerated(t *testing.T) {
+	a := open(t, buildArchive(t, 65536, []string{"/A/B.MBIN"}, [][]byte{[]byte("x")}))
+	if got := a.Names()[0]; got != "A/B.MBIN" {
+		t.Errorf("name = %q, want the leading slash trimmed", got)
+	}
+	if _, err := a.ReadFile("A/B.MBIN"); err != nil {
+		t.Errorf("ReadFile without slash: %v", err)
+	}
+	if _, err := a.ReadFile("/A/B.MBIN"); err != nil {
+		t.Errorf("ReadFile with slash: %v", err)
+	}
+}
+
+func TestSmallBlockSizeUsesNarrowTable(t *testing.T) {
+	// Exercises multi-block reads and a 1-byte block table together.
+	payload := bytes.Repeat([]byte("xyz"), 500)
+	a := open(t, buildArchive(t, 256, []string{"f.bin"}, [][]byte{payload}))
+	got, err := a.ReadFile("f.bin")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("round trip mismatch: %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+func TestEntriesReportSizes(t *testing.T) {
+	a := open(t, buildArchive(t, 65536, []string{"a", "b"}, [][]byte{[]byte("1234"), []byte("567")}))
+	es := a.Entries()
+	if len(es) != 2 {
+		t.Fatalf("Entries() = %d, want 2 (manifest excluded)", len(es))
+	}
+	if es[0].UncompressedSize != 4 || es[1].UncompressedSize != 3 {
+		t.Errorf("sizes = %d, %d; want 4, 3", es[0].UncompressedSize, es[1].UncompressedSize)
+	}
+}
+
+func TestSentinels(t *testing.T) {
+	good := buildArchive(t, 65536, []string{"a"}, [][]byte{[]byte("hello")})
+
+	corruptHeader := func(mutate func([]byte)) []byte {
+		b := append([]byte(nil), good...)
+		mutate(b)
+		return b
+	}
+
+	for _, tc := range []struct {
+		name string
+		in   []byte
+		want error
+	}{
+		{"bad magic", corruptHeader(func(b []byte) { copy(b[0:4], "XXXX") }), ErrNotPSARC},
+		{"unsupported compression", corruptHeader(func(b []byte) { copy(b[8:12], "lzma") }), ErrUnsupported},
+		{"encrypted toc", corruptHeader(func(b []byte) { binary.BigEndian.PutUint32(b[28:32], 1) }), ErrUnsupported},
+		{"zero entries", corruptHeader(func(b []byte) { binary.BigEndian.PutUint32(b[20:24], 0) }), ErrCorrupt},
+		{"zero block size", corruptHeader(func(b []byte) { binary.BigEndian.PutUint32(b[24:28], 0) }), ErrCorrupt},
+		{"toc longer than archive", corruptHeader(func(b []byte) { binary.BigEndian.PutUint32(b[12:16], 1<<30) }), ErrCorrupt},
+		{"entry count overruns toc", corruptHeader(func(b []byte) { binary.BigEndian.PutUint32(b[20:24], 9999) }), ErrCorrupt},
+		{"truncated", good[:16], ErrCorrupt},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Open(bytes.NewReader(tc.in), int64(len(tc.in)))
+			if !errors.Is(err, tc.want) {
+				t.Errorf("err = %v, want %v", err, tc.want)
+			}
+		})
+	}
+
+	a := open(t, good)
+	if _, err := a.ReadFile("nope"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("missing file err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestHeaderIsParsed(t *testing.T) {
+	a := open(t, buildArchive(t, 65536, []string{"a"}, [][]byte{[]byte("x")}))
+	if a.VersionMajor != 1 || a.VersionMinor != 4 {
+		t.Errorf("version = %d.%d, want 1.4", a.VersionMajor, a.VersionMinor)
+	}
+	if a.Compression != "zlib" {
+		t.Errorf("compression = %q, want zlib", a.Compression)
+	}
+	if a.BlockSize != 65536 {
+		t.Errorf("block size = %d, want 65536", a.BlockSize)
+	}
+}
+
+func TestBlockWidth(t *testing.T) {
+	for _, tc := range []struct {
+		blockSize uint32
+		want      int
+	}{
+		{0x100, 1}, {0x101, 2}, {0x10000, 2}, {0x10001, 3},
+		{0x1000000, 3}, {0x1000001, 4},
+	} {
+		if got := blockWidth(tc.blockSize); got != tc.want {
+			t.Errorf("blockWidth(%#x) = %d, want %d", tc.blockSize, got, tc.want)
+		}
+	}
+}
+
+func TestRead40(t *testing.T) {
+	// 40 bits exist so archives can exceed 4 GiB; the top byte must survive.
+	for _, tc := range []struct {
+		in   []byte
+		want uint64
+	}{
+		{[]byte{0, 0, 0, 0, 0}, 0},
+		{[]byte{0, 0, 0, 0, 1}, 1},
+		{[]byte{0, 0, 1, 0, 0}, 1 << 16},
+		{[]byte{1, 0, 0, 0, 0}, 1 << 32},
+		{[]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, 1<<40 - 1},
+	} {
+		if got := read40(tc.in); got != tc.want {
+			t.Errorf("read40(%v) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+// A raw block can open with bytes that look like a zlib header by chance.
+// Inflation must fail and the block fall back to raw rather than erroring.
+func TestChanceZlibHeaderInRawBlockIsNotMisread(t *testing.T) {
+	payload := make([]byte, 64)
+	payload[0], payload[1] = 0x78, 0x9C // a real zlib header pair
+	for i := 2; i < len(payload); i++ {
+		payload[i] = byte(i * 7)
+	}
+	if _, ok := tryInflate(payload); ok {
+		t.Fatal("tryInflate accepted non-zlib data; the adler32 check should reject it")
+	}
+
+	a := open(t, buildArchive(t, 256, []string{"f.bin"}, [][]byte{payload}))
+	got, err := a.ReadFile("f.bin")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Error("payload with a chance zlib header did not round trip")
+	}
+}


### PR DESCRIPTION
Stage 1 of the ingestion pipeline per [ADR-0001](docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md) — "locate + extract PAKs". This is the piece that was missing before the extraction spike could run.

NMS ships assets as `.pak` files under `GAMEDATA/PCBANKS`, which are PSARC archives despite the extension. MBINCompiler operates on *already unpacked* `.MBIN` files — its README points tests at "an unpacked PCBANKS directory" — so unpacking is our step, and the well-known tools for it are Windows/C#. Writing it in Go makes the Linux trip self-contained.

| File | |
|---|---|
| [`internal/psarc/psarc.go`](internal/psarc/psarc.go) | Format reader |
| [`internal/psarc/psarc_test.go`](internal/psarc/psarc_test.go) | 9 tests over synthetic archives |
| [`cmd/nmsextract/main.go`](cmd/nmsextract/main.go) | `list` / `extract` with a path filter |

## How it's verified without game files

The tests build **format-correct PSARC archives in memory** and read them back, so the reader is exercised without a `.pak` present. That covers the four block shapes the reader has to tell apart — compressible, incompressible, multi-block, and empty — plus narrow and wide block tables, 40-bit size/offset boundaries, and every sentinel path.

9 tests, 86.7% coverage, stdlib only, `vet` / `gofmt` / `-race` clean.

End-to-end through the real CLI against a synthetic archive:

```
$ nmsextract list synthetic.pak table
PSARC v1.4  zlib  block 65536  3 entries

        6300  METADATA/REALITY/TABLES/NMS_REALITY_GCPRODUCTTABLE.MBIN

1 entries, 6300 bytes uncompressed
(filtered by "table")
```

## One subtlety worth a look

**The format does not mark whether a block is compressed or raw** — only the bytes distinguish them, and a zlib header is the sole signal. Roughly one raw block in eight thousand opens with a byte pair that passes the header check by chance. A naive magic-sniff would corrupt those.

So a failed inflate falls back to raw rather than failing the read; zlib's adler32 makes a false positive that *also* inflates cleanly vanishingly unlikely. `TestChanceZlibHeaderInRawBlockIsNotMisread` constructs exactly that payload.

Other deliberate choices: entries inflate **on demand** rather than at open, since a PCBANKS archive is far larger than we want resident; and extraction **rejects archive paths that escape the output directory**, since those paths are untrusted input.

## Honest limits

- **Never run against a real `.pak`.** The format is implemented from public documentation, and the tests validate self-consistency — my writer against my reader. A real archive is the first genuine test, and that is the spike.
- **No spec governs the ingestion CLI.** SPEC-0001 is the rollup engine, SPEC-0002 the WASM boundary; this is governed only by ADR-0001. Worth a spec once the spike shows what extraction actually needs.
- `list` on a real PCBANKS archive will print tens of thousands of entries — the filter argument exists for that reason.

## What this unblocks

The extraction spike becomes: unpack with this, decompile with MBINCompiler, and answer the four open questions — whether the Tier 2 economy constants exist in the game files, whether `ObjectID` joins to `GcBaseBuildingEntry.ID`, whether container inventories are reachable, and what the real recipe values are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)