### PR TITLE
Correct ADR-0001 to HGPAK and add SPEC-0003 archive reader

### DIFF
--- a/docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md
+++ b/docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md
@@ -33,7 +33,7 @@ Where does that data come from, in what form does it reach the app, and under wh
 
 Chosen option: **C, direct extraction with a two-tier data model**, because it is the only option that gets the recipe graph under a permissive footing while keeping the refresh cycle under our control — and because the constants that extraction cannot supply turn out to be a small curated set rather than a second pipeline.
 
-**Tier 1 — extracted.** A Go CLI locates the game's `.pak` archives, extracts them, shells out to MBINCompiler to convert `.MBIN` → `.EXML`, then parses and normalizes the XML in Go into a version-stamped artifact: the recipe graph (products, substances, refinery, nutrient processor), item metadata, the biome→gas mapping from `GcGeneratorUnitComponentData.BiomeGasRewards`, the extractor taxonomy, and the base parts catalog. Regenerated per game version; never hand-edited.
+**Tier 1 — extracted.** A Go CLI locates the game's `.pak` archives, unpacks them (they are HGPAK containers — see the note below and SPEC-0003), shells out to MBINCompiler to convert `.MBIN` → `.EXML`, then parses and normalizes the XML in Go into a version-stamped artifact: the recipe graph (products, substances, refinery, nutrient processor), item metadata, the biome→gas mapping from `GcGeneratorUnitComponentData.BiomeGasRewards`, the extractor taxonomy, and the base parts catalog. Regenerated per game version; never hand-edited.
 
 **Tier 2 — curated.** A hand-maintained YAML file of base-economy constants (generator outputs, power draws, extractor rates per class, biodome capacity, crop yields), each entry carrying a `source` and a `verified` date, feeding the same `unverified` badge convention the tree canvas uses.
 
@@ -110,7 +110,7 @@ Copy the ~1.5 MB of `Products` / `RawMaterials` / `Refinery` / `NutrientProcesso
 
 ```mermaid
 graph TD
-    A["NMS install<br/>GAMEDATA/PCBANKS/*.pak"] -->|PSARC extract| B[".MBIN files"]
+    A["NMS install<br/>GAMEDATA/PCBANKS/*.pak<br/>(HGPAK container)"] -->|"Go: HGPAK reader<br/>(SPEC-0003)"| B[".MBIN files"]
     B -->|"MBINCompiler subprocess<br/>(LGPL-3.0)"| C[".EXML files"]
     C -->|"Go: encoding/xml"| D["Normalizer<br/>(graph build, ID resolution, provenance)"]
     D --> E["Tier 1 artifact<br/>recipe graph + metadata<br/>version-stamped"]
@@ -130,6 +130,20 @@ graph TD
 * **Save files** (for ADR-0002) live inside the Proton prefix, NMS being Steam app ID `275850`: `~/.steam/steam/steamapps/compatdata/275850/pfx/drive_c/users/steamuser/AppData/Roaming/HelloGames/NMS/st_<steamid>/`
 * **MBINCompiler ships first-class Linux binaries** — release `v6.45.0-pre1` publishes `MBINCompiler-linux`, `MBINCompiler-linux-dotnet6`, `libMBIN-linux.so`, and `libMBIN-linux-dotnet6.so`. It requires the .NET 8 runtime and does not need mono. Notably that release publishes **no macOS asset at all**, despite the README stating one accompanies every release — a further reason extraction belongs on Linux.
 * **Flow:** Linux PC extracts, normalizes, and commits the artifact; the Mac pulls and develops against it. The development machine never needs .NET, MBINCompiler, or the game installed.
+
+**The archive format is HGPAK, not PSARC — verified against the install.** An earlier revision of this ADR labelled the extraction edge of the diagram above `PSARC extract`. That label was never a decision, was never verified, and is wrong. All 97 archives under `GAMEDATA/PCBANKS` on the maintainer's install (game files dated 2026-06-05) carry the magic `HGPAK`; none carry `PSAR`. NMS shipped PSARC historically, which is why the assumption looked safe and why community documentation still describes it — but it does not hold for current builds.
+
+Confirmed by parsing real archives end to end:
+
+* Header is little-endian: 8-byte `HGPAK\0\0\0` magic, then u64 version (2), entry count, block count, an unknown field (1), and a data-start offset.
+* An entry table of 32-byte records — 16-byte MD5 + u64 offset + u64 size — followed by a block table of u64 compressed lengths.
+* Blocks are **zstd**, each decompressing to exactly 65,536 bytes, each starting 16-byte aligned. `NMSARC.globals.pak`: 87 blocks decompressing to 5,701,632 bytes = 87 x 64 KiB exactly.
+* Entry offsets are into a **virtual image** of the file, so stream position is `entry.offset - dataStart`.
+* **Entry 0 is a manifest** of CRLF-separated lowercase paths, and each entry's 16-byte hash is the **MD5 of its lowercase path** (verified 400/400 on sampled names). Filenames are therefore fully recoverable from the archive alone; no external hash mapping is required.
+
+**Consequence for Tier 1: the tables are in `NMSARC.Precache.pak`.** `NMSARC.MetadataEtc.pak` contains no `metadata/reality/tables/` paths at all. `NMSARC.Precache.pak` holds all 54, including `nms_reality_gcproducttable.mbin`, `nms_reality_gcsubstancetable.mbin`, `nms_reality_gcrecipetable.mbin`, and — for the base parts catalogue this ADR's Tier 1 promises — `basebuildingpartstable.mbin` and `basebuildingcoststable.mbin`. Entries extracted from it carry MBIN magic `cccccccc`, so they feed MBINCompiler directly as this decision assumes.
+
+None of this changes the decision. Option C is chosen for licensing and refresh-cycle reasons that are indifferent to the container format; only the unpacking step's implementation is affected. `internal/psarc` reads no file in the game install and is superseded by SPEC-0003.
 
 **Never commit a real save file.** The Tier 1 artifact is game data and is safe to commit. A save file is *player* data — discovered systems, base locations, platform UID — and committing one would defeat ADR-0002's privacy rationale permanently, since git history preserves it. Test fixtures MUST be either gitignored, drawn from a throwaway playthrough, or synthesized from a scrubbed `PersistentPlayerBases` subtree. The synthetic option is preferred: smaller, readable, and free of personal data.
 

--- a/docs/openspec/specs/hgpak-reader/design.md
+++ b/docs/openspec/specs/hgpak-reader/design.md
@@ -1,0 +1,100 @@
+# Design: HGPAK Archive Reader
+
+## Context
+
+ADR-0001 chose direct extraction from the maintainer's own game install, with a Go CLI unpacking `.pak` archives and MBINCompiler decompiling the `.MBIN` files that come out. The decompile half is settled — MBINCompiler ships Linux binaries and runs as a subprocess. The unpack half had no spec, and the code written for it targets the wrong format.
+
+Four facts from parsing real archives shape this design:
+
+- **The container is HGPAK, not PSARC.** Verified across all 97 archives in the install. `internal/psarc` opens none of them. The provenance of that mistake is recorded in ADR-0001 and is the reason this spec leads with a verification requirement rather than a format requirement.
+- **Blocks decompress to a fixed 65,536 bytes.** This is the single most useful property in the format: it makes stream position to block index pure arithmetic, so random access needs no index beyond the block table already present.
+- **Entry 0 is a plaintext manifest.** Names are recoverable from the archive alone. An earlier reading of the header suggested MD5-keyed lookup with no path table, which would have made extraction depend on a community-maintained hash list; that reading was wrong, and the difference is the difference between a viable pipeline and a blocked one.
+- **`NMSARC.MetadataEtc.pak` does not contain the metadata tables.** They are in `NMSARC.Precache.pak`. The obvious-sounding archive is the wrong one, which is worth stating in writing because it will otherwise be rediscovered.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Extract the ADR-0001 Tier 1 inputs from a real install, in a form MBINCompiler accepts
+- Make correctness contingent on real archives, so a green suite means the reader works
+- Keep memory bounded — read one 26 KB table without materializing 565 MB
+- Fail loudly and specifically on structural surprise, since the format is reverse-engineered and future game updates will change it
+- Stay stdlib-only apart from zstd, matching the project's current dependency posture
+
+### Non-Goals
+
+- **Writing HGPAK archives.** Nothing in the pipeline creates one. A writer exists only if fixture construction demands it, and if it does, it is a test helper and never the thing under test.
+- **Decoding MBIN.** ADR-0001 explicitly rejected reimplementing libMBIN. The reader hands bytes to MBINCompiler.
+- **Supporting historical PSARC archives.** Old installs are not a use case; the maintainer extracts from the version being played.
+- **Normalization, graph building, provenance.** Downstream, separate spec.
+- **Running in CI.** ADR-0001 already records ingestion as developer-local. The opt-in full-archive test is the concession to that.
+
+## Decisions
+
+### Verification requirement before format requirement
+
+**Choice**: The spec's first requirement is that the reader has been run against a real archive, and that a real-archive excerpt is committed as a fixture. Format structure comes second.
+
+**Rationale**: The failure this replaces was not a misread of the format — it was 996 lines of correct, well-tested PSARC code for a project that has no PSARC files. Coverage was 86.7% and every test passed, because `buildArchive()` wrote the same format the reader read. Ordering the requirements this way makes the reviewable question "what real file did this open?" rather than "do the tests pass?".
+
+**Alternatives considered**: Requiring a full archive as a fixture — rejected, since the smallest is 646 KB and it is Hello Games' data. Trusting an opt-in environment-gated test alone — rejected, because a test that skips by default is a test that is not running, which is how the original gap persisted through review.
+
+### A structurally faithful excerpt as the committed fixture
+
+**Choice**: Commit a small valid HGPAK assembled from a few real entries, preserving real header layout, block framing, alignment, and manifest formatting. Pair it with an opt-in test against the full PCBANKS directory.
+
+**Rationale**: This is the smallest artifact that still fails when an assumption is wrong. The two bugs most likely to recur — forgetting 16-byte block alignment, and treating entry offsets as stream-relative — both survive any synthetic fixture built from the same misunderstanding, and both are caught by an excerpt that carries real framing across a block boundary. The fixture must therefore span at least two blocks to be worth committing.
+
+**Trade-off**: It contains a small amount of real game data. Kept to the structural minimum, and it is game data rather than player data, which ADR-0001 already treats as committable.
+
+### On-demand block decompression, no whole-archive materialization
+
+**Choice**: Open parses the header, entry table, block table, and manifest only. Entry reads decompress just the blocks spanning the entry, computed as `pos / 65536`.
+
+**Rationale**: The fixed decompressed block size makes this trivial, and the sizes force it — MetadataEtc decompresses to ~565 MB and Precache is the archive we actually need repeatedly. Listing an archive costs only the manifest's blocks.
+
+**Trade-off**: A caller extracting every entry in path order re-decompresses shared blocks. Acceptable: extraction is a rare developer-local operation, and a small LRU over recent blocks recovers most of it if it ever matters. Not specified, because measuring first is cheaper than guessing.
+
+### Hash verification as a structural check, not a lookup mechanism
+
+**Choice**: Resolve entries by path from the manifest. Verify that MD5 of the lowercase path matches the stored hash, and fail on mismatch.
+
+**Rationale**: The hash is redundant with the manifest, which makes it a free consistency check on the two structures agreeing — and a cheap early warning that a future game update changed the convention. Using the hash *as* the lookup key would be reintroducing a dependency the manifest removes.
+
+**Trade-off**: MD5 over every path at open. Negligible against the zstd work already done, and it can move behind a flag if a 47,000-entry archive ever shows it.
+
+### Fail closed on structural surprise
+
+**Choice**: Wrong magic, unknown version, wrong decompressed block length, manifest count mismatch, hash mismatch, and out-of-range entry extent all fail the read with distinct sentinels. No best-effort parsing.
+
+**Rationale**: The format is reverse-engineered from one game version, and ADR-0001 already accepts that a game update can invalidate the pipeline. The useful behaviour on a changed format is a precise error naming what moved, not a partial extract that silently produces wrong Tier 1 data — which would surface much later as a wrong recipe tree, with no obvious cause.
+
+**Contrast with the superseded reader**: `internal/psarc` deliberately fell back to raw bytes when a block failed to inflate, because PSARC does not mark blocks as compressed. HGPAK's fixed decompressed size means a failed decompression is unambiguous evidence of a wrong assumption, so the same tolerance would be a bug here.
+
+### zstd as the one external dependency
+
+**Choice**: Take a pure-Go zstd decoder as a module dependency. The project is currently stdlib-only.
+
+**Rationale**: There is no `compress/zstd` in the standard library, and the format leaves no alternative — every block in every archive is zstd. A pure-Go decoder keeps `go test` and the WASM build free of cgo. Shelling out to the `zstd` binary is possible and is what the exploratory prototype did, but a per-block subprocess is untenable for 8,628 blocks and would put a system binary in the pipeline's dependency set.
+
+**Scope note**: The dependency belongs to the ingestion CLI, not the domain core. ADR-0003 keeps the domain package free of anything the browser cannot run, and nothing in `internal/domain` imports this reader.
+
+## Risks / Trade-offs
+
+- **A game update changes the container.** Likely eventually; version 2 is already the second. Mitigated by failing loudly on version and structure, so the next change presents as a named error rather than corrupt output.
+- **The excerpt fixture drifts from the shipping format.** A fixture built today keeps passing after the game changes. The opt-in full-archive test is the counterweight, and running it is part of re-extracting after a game update — which ADR-0001 already establishes as a manual step.
+- **The unknown header field at 0x20.** Observed as 1 in every archive examined. Parsed and ignored. If it ever differs, the version check will not catch it; worth asserting on and reporting as a curiosity rather than silently discarding.
+- **Only one game version has been examined.** Every structural claim in the spec comes from the 2026-06-05 build. The claims are stated as observations with the archives that produced them, so a future reader can tell measurement from assumption — which is exactly what the PSARC label failed to do.
+
+## Migration Plan
+
+1. Land the reader and its fixtures alongside `internal/psarc`, which stays untouched and unreferenced.
+2. Point `cmd/nmsextract` at the new reader.
+3. Run the acceptance test — extract `metadata/reality/tables/` from `NMSARC.Precache.pak` and decompile the product table with MBINCompiler.
+4. Delete `internal/psarc` in the same PR that proves the replacement works. It has no other consumer and no value as reference; keeping it invites the next reader to assume it means something.
+
+## Open Questions
+
+- Does a small block cache measurably help bulk extraction, or is the re-decompression cost noise against MBINCompiler subprocess time?
+- Is the 0x20 header field a flags word, an alignment hint, or a compression-method selector? It is 1 everywhere observed, so nothing distinguishes the hypotheses yet.
+- Do any archives in the install use a compression method other than zstd, or a block size other than 65,536? All 97 carry the HGPAK magic, but only two have been parsed in full — the opt-in test across all of them is what answers this, and it should run before the spec moves off `draft`.

--- a/docs/openspec/specs/hgpak-reader/spec.md
+++ b/docs/openspec/specs/hgpak-reader/spec.md
@@ -1,0 +1,187 @@
+---
+status: draft
+date: 2026-08-17
+implements: [ADR-0001]
+supersedes-implementation: [internal/psarc]
+---
+
+# SPEC-0003: HGPAK Archive Reader
+
+## Overview
+
+Stage 1 of the ADR-0001 ingestion pipeline: turning the game's `.pak` archives into `.MBIN` files on disk that MBINCompiler can decompile. ADR-0001 assumes this step exists and says nothing about how the container is laid out — correctly, because at decision time nobody had looked.
+
+Somebody has now looked. Every archive under `GAMEDATA/PCBANKS` is an `HGPAK` container: a zstd block stream with a fixed decompressed block size, an MD5-keyed entry table, and a path manifest stored as entry 0. This spec defines the reader for that container.
+
+It replaces `internal/psarc`, which implements PlayStation Archive and can open no file in the game install. That package was written against an unverified label on a diagram edge and its tests validated its own writer against its own reader, so a complete green suite proved only self-consistency. The verification requirements below exist specifically so that failure mode cannot recur.
+
+The reader's only consumer is the ingestion CLI. It is a developer-local tool, not shipped code, and per ADR-0001 it never runs in CI — which puts the burden of correctness on fixtures rather than on a pipeline.
+
+## Requirements
+
+### Requirement: Real-Archive Verification
+
+The reader MUST NOT be considered implemented until it has been run against an unmodified archive from a real game install and produced files that MBINCompiler accepts.
+
+The test suite MUST include at least one fixture derived from a real archive. A suite that exercises the reader only against archives constructed by the project's own test helpers does not satisfy this requirement, regardless of coverage.
+
+Because a full `.pak` is far too large to commit and is Hello Games' data, the committed fixture MUST be a **structurally faithful excerpt**: a small, valid HGPAK built from a handful of real entries, carrying the real header layout, real block framing, real alignment, and real manifest formatting. The reader MUST also be exercisable against a full archive via an opt-in path (an environment variable naming a PCBANKS directory) that skips when unset.
+
+Where a fixture is synthesized rather than excerpted, the test MUST state in a comment which real archive its structure was checked against.
+
+#### Scenario: A real excerpt is present
+
+- **WHEN** the test suite runs with no game install available
+- **THEN** it opens the committed real-archive excerpt, lists its manifest, and extracts its entries
+
+#### Scenario: Full-archive test is opt-in, not silently absent
+
+- **WHEN** the environment variable naming a PCBANKS directory is set
+- **THEN** the suite opens every archive in it and verifies each one's manifest and entry count
+- **AND WHEN** it is unset, those tests report as skipped rather than passing
+
+#### Scenario: Synthetic-only suites are rejected
+
+- **WHEN** every archive a test opens was produced by the project's own helper
+- **THEN** the requirement is not met, even at full statement coverage
+
+### Requirement: Container Identification
+
+The reader MUST verify the 8-byte magic `HGPAK\0\0\0` before interpreting any other field, and MUST reject a file whose magic does not match with an error naming the magic found.
+
+The reader MUST reject a version field it does not implement rather than attempting a best-effort parse. Version 2 is the observed version and the one this spec covers.
+
+All multi-byte integers in the header, entry table, and block table MUST be decoded as **little-endian unsigned 64-bit**, except the entry hash, which is an opaque 16-byte value.
+
+#### Scenario: A PSARC file is rejected clearly
+
+- **WHEN** a PSARC archive is opened
+- **THEN** the read fails naming the magic found, and no entry table is parsed
+
+#### Scenario: An unknown version is refused
+
+- **WHEN** the version field holds a value this reader does not implement
+- **THEN** the read fails naming the version, rather than parsing with version 2 rules
+
+### Requirement: Structural Layout
+
+The reader MUST parse the layout as: a 0x30-byte header; an entry table of `entryCount` 32-byte records beginning at 0x30, each a 16-byte hash followed by a u64 offset and a u64 size; then a block table of `blockCount` u64 compressed lengths; then the compressed blocks.
+
+Each block MUST be decompressed with zstd and MUST yield exactly 65,536 bytes, except the final block, which MAY be shorter. A block that decompresses to a different length MUST be treated as a malformed archive.
+
+Blocks MUST be located by accumulating compressed lengths from the header's data-start offset, advancing to the next **16-byte boundary** after each block. Omitting the alignment step causes the second block to fail to decompress.
+
+Entry offsets MUST be interpreted as positions in a **virtual image of the file** whose first `dataStart` bytes are the header and tables. The position of an entry within the concatenated decompressed stream is therefore `entry.offset - dataStart`.
+
+#### Scenario: Block alignment is honoured
+
+- **WHEN** an archive with more than one block is read
+- **THEN** every block decompresses successfully, and the total decompressed length equals the block count times 65,536 less any short final block
+
+#### Scenario: Virtual offsets resolve correctly
+
+- **WHEN** the first entry of an archive is read
+- **THEN** it resolves to stream position zero, not to position `dataStart`
+
+#### Scenario: A truncated archive is refused
+
+- **WHEN** an entry's extent runs past the end of the decompressed stream
+- **THEN** the read fails naming the entry, rather than returning a short buffer
+
+### Requirement: Manifest and Path Resolution
+
+The reader MUST treat entry 0 as the path manifest: a byte blob of **CRLF-separated** lowercase paths. Manifest entry *n* names archive entry *n*, so the manifest MUST hold exactly `entryCount - 1` non-empty paths.
+
+The reader MUST expose every entry by its path. It MUST NOT require the caller to supply a hash, and MUST NOT depend on any external hash-to-name mapping.
+
+The reader MUST verify that an entry's 16-byte hash equals the **MD5 of its lowercase path**, and MUST report a mismatch as a malformed archive rather than silently preferring one of the two.
+
+A manifest whose path count disagrees with `entryCount - 1` MUST be reported as malformed.
+
+#### Scenario: Paths come from the archive alone
+
+- **WHEN** an archive is opened with no external data available
+- **THEN** every entry is listed by its full path
+
+#### Scenario: Manifest count is checked
+
+- **WHEN** the manifest holds a number of paths other than `entryCount - 1`
+- **THEN** the read fails naming both counts
+
+#### Scenario: Hash and path agree
+
+- **WHEN** each entry's path is hashed with MD5
+- **THEN** the digest equals the entry's stored hash, and any mismatch fails the read
+
+### Requirement: Selective Extraction
+
+Because block size is fixed at 65,536 decompressed bytes, an entry at stream position `P` begins in block `P / 65536`. The reader MUST use this to decompress only the blocks covering a requested entry, and MUST NOT decompress the whole archive to read one file.
+
+The reader MUST expose listing without extraction, so that a caller can enumerate an archive's paths having decompressed only the blocks covering the manifest.
+
+Entry contents MUST be read on demand rather than at open. `NMSARC.MetadataEtc.pak` decompresses to roughly 565 MB, which MUST NOT be required resident to read one table.
+
+#### Scenario: Listing is cheap
+
+- **WHEN** the paths of a 47,000-entry archive are listed
+- **THEN** only the blocks covering the manifest were decompressed
+
+#### Scenario: One entry costs its own blocks
+
+- **WHEN** a single 26 KB entry is extracted from a 47 MB archive
+- **THEN** only the blocks spanning that entry were decompressed
+
+### Requirement: Safe Extraction to Disk
+
+Archive paths are untrusted input. When extracting to a directory, the reader MUST reject any entry whose resolved destination falls outside that directory — including absolute paths, paths containing `..`, and paths that traverse a symlink out of the tree.
+
+A rejected path MUST fail the extraction with an error naming the offending path. The reader MUST NOT silently skip it.
+
+The reader MUST create parent directories as needed, and MUST tolerate a leading separator on an archive path by treating it as relative.
+
+#### Scenario: Traversal is refused
+
+- **WHEN** an entry's path escapes the output directory
+- **THEN** extraction fails naming that path, and nothing is written outside the directory
+
+#### Scenario: Nested paths are created
+
+- **WHEN** an entry at `metadata/reality/tables/costtable.mbin` is extracted
+- **THEN** the intermediate directories are created and the file lands at the mirrored path
+
+### Requirement: Pipeline Fitness
+
+Extraction MUST produce byte-exact entry contents — the reader performs no transformation on entry bytes beyond decompression of the containing blocks.
+
+The CLI MUST support filtering by path substring on both listing and extraction, since a single archive holds tens of thousands of entries.
+
+Extraction of `metadata/reality/tables/` from `NMSARC.Precache.pak` MUST yield files beginning with MBIN magic `cccccccc` that MBINCompiler decompiles without error. This is the acceptance test for the whole stage.
+
+#### Scenario: The tables extract and decompile
+
+- **WHEN** `metadata/reality/tables/` is extracted from `NMSARC.Precache.pak`
+- **THEN** all 54 tables are written, each begins with `cccccccc`, and MBINCompiler decompiles `nms_reality_gcproducttable.mbin` to EXML without error
+
+#### Scenario: Filtering narrows a large archive
+
+- **WHEN** a 47,000-entry archive is listed with a path filter
+- **THEN** only matching paths are printed, and the count of matches is reported
+
+### Requirement: Error Handling Standards
+
+All error-producing operations MUST follow structured error handling:
+
+- Errors MUST be wrapped with contextual information at each layer boundary (e.g., "reading entry metadata/reality/tables/costtable.mbin: block 42 decompressed to 32768 bytes, want 65536")
+- Sentinel errors MUST be defined for domain-specific failure modes that callers need to distinguish programmatically — at minimum: not an HGPAK archive, unsupported version, malformed archive, entry not found, and unsafe extraction path
+- Silent error swallowing MUST NOT occur — every error MUST be either returned to the caller, logged with sufficient context, or explicitly handled with a documented reason for suppression
+- Structured logging MUST be used for error reporting (key-value pairs, not string interpolation)
+
+#### Scenario: A wrong-format file is distinguishable from a corrupt one
+
+- **WHEN** a caller opens a PSARC file, versus an HGPAK whose blocks will not decompress
+- **THEN** the two failures carry different sentinels
+
+#### Scenario: Failures name the entry
+
+- **WHEN** extraction fails on one entry of many
+- **THEN** the error names that entry's path and the structural expectation that was violated


### PR DESCRIPTION
Part of [ADR-0001](docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md) — stage 1 of the ingestion pipeline. Documents only; no code changes.

## The problem

`internal/psarc`, merged in #5, cannot open a single file in the game install. Every one of the 97 archives under `GAMEDATA/PCBANKS` carries the magic `HGPAK`; none carries `PSAR`. NMS shipped PSARC historically — which is why the assumption looked safe and why community docs still describe it — but it does not hold for current builds.

**PSARC entered the project exactly once, as a label on a mermaid edge.** ADR-0001's prose only ever said `.pak`; the Decision Outcome, Decision Drivers, Considered Options, and References never named a format. The only occurrence was `-->|PSARC extract|` in the diagram. From there it was promoted without recheck:

| Stage | How the claim was stated |
|---|---|
| ADR-0001 prose | `.pak` archives — no format named |
| ADR-0001 diagram | `PSARC extract` — unsourced edge label |
| #5 body | "which are PSARC archives despite the extension" — stated as fact |
| `psarc.go` package doc | same sentence, now a documented invariant |
| Implementation | 367 lines + 480 lines of tests |

The #5 body flagged the risk accurately in its own "Honest limits" section — *"Never run against a real `.pak` … my writer against my reader"* — and it merged anyway. The caveat was recorded but never made a gate. Verification was `head -c 4` on a file that was on the extraction machine the whole time.

## What changed

**[ADR-0001](docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md)** — diagram edge corrected, format named in the Tier 1 prose, and a More Information note recording the finding with the evidence behind each claim. **The decision itself is unaffected**: option C was chosen on licensing and refresh-cycle grounds indifferent to the container format, so only the unpacking step's implementation changes. Status stays `proposed`.

**[SPEC-0003](docs/openspec/specs/hgpak-reader/spec.md)** — 7 requirements with scenarios, plus [design.md](docs/openspec/specs/hgpak-reader/design.md).

## The requirement worth reviewing

The spec's **first** requirement is not about the format. It is Real-Archive Verification: the reader is not implemented until it has opened an unmodified archive from a real install, a structurally faithful excerpt is committed as a fixture, and the full-archive test is env-gated so it *skips* rather than silently passes when unset. One scenario states explicitly that a suite where every archive came from the project's own helper fails the requirement **at any coverage level**.

That ordering is deliberate. The failure being replaced was not a misread of a format — it was correct, well-tested code for a format this project does not have, at 86.7% coverage with every test green, because `buildArchive()` wrote the same format the reader read. Putting verification first makes the reviewable question "what real file did this open?" rather than "do the tests pass?".

The design doc argues the fixture must span at least two blocks: the two bugs most likely to recur — forgetting 16-byte block alignment, and treating entry offsets as stream-relative — both survive any synthetic fixture built from the same misunderstanding.

## Format, verified end to end

Parsed against real archives, not documentation:

- Little-endian u64 header after `HGPAK\0\0\0`: version (2), entry count, block count, unknown (1), data start
- Entry table at 0x30 — 32-byte records: 16-byte MD5 + u64 offset + u64 size; then a u64 block-length table
- Blocks are **zstd**, each decompressing to exactly 65,536 bytes, each **16-byte aligned**. `globals.pak`: 87 blocks → 5,701,632 bytes = 87 × 64 KiB exactly
- Entry offsets are **virtual** — stream position is `offset - dataStart`
- **Entry 0 is a manifest** of CRLF-separated lowercase paths: 47,234 paths for MetadataEtc's 47,235 entries
- Entry hash is **MD5 of the lowercase path** — 400/400 on sampled names, 0/400 for the uppercase variant

## Two findings recorded so they are not rediscovered

1. **Filenames are recoverable from the archive alone.** I initially read the header as MD5-keyed with no path table, which would have made extraction depend on a community-maintained hash list. That reading was wrong — entry 0 is the manifest. The difference is a viable pipeline versus a blocked one, so it is stated explicitly in both documents.
2. **`NMSARC.MetadataEtc.pak` contains zero `metadata/reality/tables/` paths.** All 54 are in `NMSARC.Precache.pak`, including `nms_reality_gcproducttable.mbin` and — for the base parts catalogue Tier 1 promises — `basebuildingpartstable.mbin` and `basebuildingcoststable.mbin`.

## Honest limits

- **Every structural claim comes from the 2026-06-05 build**, and only 2 of the 97 archives have been parsed in full. All 97 carry the HGPAK magic, but the opt-in test across all of them is what confirms block size and compression method are uniform — it should run before this moves off `draft`.
- **The acceptance test is not fully executed.** I confirmed extraction from Precache yields MBIN magic `cccccccc`; the MBINCompiler decompile leg is unverified, since it is not installed on this machine.
- **The 0x20 header field is parsed and ignored.** Observed as 1 everywhere. Flagged as an open question rather than assumed meaningless.
- **No code here.** The reader and the deletion of `internal/psarc` follow; the migration plan deliberately puts that deletion in the same PR that proves the replacement works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
