### PR TITLE
CI: static analysis, race detection, and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+# Governing: ADR-0001 (two-tier NMS data ingestion) — ingestion is a
+# developer-local step and cannot run in CI, so every job here must pass on a
+# machine with no No Man's Sky install. Tests that need game files gate on an
+# environment variable and skip when it is unset; CI never sets it.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: "1.26.6"
+
+# Each job is independent so a formatting failure and a test failure surface
+# separately rather than one masking the other.
+jobs:
+  format:
+    name: Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            echo
+            echo "Run: gofmt -w ."
+            exit 1
+          fi
+
+  vet:
+    name: Static analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: go vet
+        run: go vet ./...
+      - name: staticcheck
+        # Pinned to the 0.8.0 release candidate deliberately: it is the only
+        # published staticcheck built against go1.26, which go.mod requires.
+        # The 0.6.x line (built with go1.24) and 0.7.x (go1.25) both refuse to
+        # analyze this module. Move to v0.8.0 final once it ships.
+        run: go run honnef.co/go/tools/cmd/staticcheck@v0.8.0-rc.1 ./...
+
+  test:
+    name: Tests (race)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: go test -race
+        # NMS_PCBANKS is deliberately unset: tests requiring a real game
+        # install must skip, not fail. See SPEC-0003 REQ "Real-Archive
+        # Verification".
+        run: go test -race ./...

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ mf_save*.hg
 *.save.json
 *-decoded.json
 testdata/saves/
+
+# Agent worktrees created by /sdd:work — local scratch, never committed.
+.claude/worktrees/


### PR DESCRIPTION
Closes #8
Part of #7

The repository had no CI at all. PRs #2 and #5 each reported "vet / gofmt / -race clean" from a local run — accurate at the time, but nothing enforced it, and nothing would have caught a regression.

## Three independent jobs

Split so a formatting failure and a test failure surface separately rather than one masking the other.

| Job | Check |
|---|---|
| Formatting | `gofmt -l .` — fails with the offending file list and the fix command |
| Static analysis | `go vet ./...` then `staticcheck ./...` |
| Tests (race) | `go test -race ./...` |

Runs on every pull request and on pushes to `main`. `permissions: contents: read` — the workflow needs nothing else.

## The staticcheck version pin is deliberate

`go.mod` requires go 1.26.6, and staticcheck refuses to analyze a module built for a newer Go than the analyzer itself:

| Version | Built with | Result |
|---|---|---|
| `2025.1.1` (v0.6.1) | go1.24.13 | ❌ `module requires at least go1.26.6` |
| `v0.7.0` | go1.25.13 | ❌ `package requires newer Go version go1.26` |
| `v0.8.0-rc.1` | go1.26 | ✅ exits 0, no findings |

So the pin is to a release candidate. That is a real trade — I'd rather pin an RC that works than ship a job that fails on every run, and the alternative was dropping static analysis beyond `go vet` entirely. The workflow carries a comment saying to move to `v0.8.0` final once it ships.

## Verified locally

All three checks were run in the worktree before opening this PR:

- `gofmt -l .` — no output
- `go vet ./...` — clean
- `staticcheck ./...` (v0.8.0-rc.1) — exit 0, no findings
- `go test -race ./...` — `internal/domain` ok, `internal/psarc` ok

## Note on the game-files constraint

Per [ADR-0001](docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md), ingestion is developer-local and cannot run in CI. The test job deliberately does not set `NMS_PCBANKS`, so the opt-in full-archive tests that [SPEC-0003](docs/openspec/specs/hgpak-reader/spec.md) REQ "Real-Archive Verification" specifies must **skip** rather than fail. That requirement is implemented in #9; this workflow is the environment it has to skip cleanly in.

## Also here

`.gitignore` gains `.claude/worktrees/` — the scratch directory `/sdd:work` creates for agent worktrees, which otherwise shows up as untracked in the main tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
