### PR TITLE
docs: record the HGPAK storage flag and raw-block rule

### DIFF
--- a/docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md
+++ b/docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md
@@ -135,9 +135,10 @@ graph TD
 
 Confirmed by parsing real archives end to end:
 
-* Header is little-endian: 8-byte `HGPAK\0\0\0` magic, then u64 version (2), entry count, block count, an unknown field (1), and a data-start offset.
+* Header is little-endian: 8-byte `HGPAK\0\0\0` magic, then u64 version (2), entry count, block count, a **storage flag**, and a data-start offset.
 * An entry table of 32-byte records — 16-byte MD5 + u64 offset + u64 size — followed by a block table of u64 compressed lengths.
-* Blocks are **zstd**, each decompressing to exactly 65,536 bytes, each starting 16-byte aligned. `NMSARC.globals.pak`: 87 blocks decompressing to 5,701,632 bytes = 87 x 64 KiB exactly.
+* The storage flag selects the layout. `1` is a zstd block stream (95 archives); `0` is **stored** — no block table, entry offsets are direct file offsets, and entry bytes including the manifest sit uncompressed (`NMSARC.audio.pak`, `NMSARC.audioBNK.pak`, whose WEM/BNK payloads are already compressed). An earlier revision of this ADR called this an unknown field, "1 in every archive observed" — true of the two archives parsed at the time, and false in general. Parsing all 97 is what corrected it.
+* Blocks are **zstd**, each decompressing to exactly 65,536 bytes, each starting 16-byte aligned. `NMSARC.globals.pak`: 87 blocks decompressing to 5,701,632 bytes = 87 x 64 KiB exactly. A block whose *compressed* length is exactly 65,536 is stored verbatim instead (`NMSARC.UI.pak` and the `TexBiomes*` family) — a length rule, not a magic sniff.
 * Entry offsets are into a **virtual image** of the file, so stream position is `entry.offset - dataStart`.
 * **Entry 0 is a manifest** of CRLF-separated lowercase paths, and each entry's 16-byte hash is the **MD5 of its lowercase path** (verified 400/400 on sampled names). Filenames are therefore fully recoverable from the archive alone; no external hash mapping is required.
 

--- a/docs/openspec/specs/hgpak-reader/design.md
+++ b/docs/openspec/specs/hgpak-reader/design.md
@@ -71,6 +71,8 @@ Four facts from parsing real archives shape this design:
 
 **Contrast with the superseded reader**: `internal/psarc` deliberately fell back to raw bytes when a block failed to inflate, because PSARC does not mark blocks as compressed. HGPAK's fixed decompressed size means a failed decompression is unambiguous evidence of a wrong assumption, so the same tolerance would be a bug here.
 
+HGPAK does store some blocks verbatim, but it identifies them by **length, not by sniffing**: a compressed length of exactly 65,536 means stored, because the packer skips compression when it would not pay and the stored length then equals the decompressed length by definition. That rule is decided before any decompression is attempted, so it does not reintroduce inflate-and-fall-back. A block of any other length that fails to decompress remains a hard `ErrMalformed`.
+
 ### zstd as the one external dependency
 
 **Choice**: Take a pure-Go zstd decoder as a module dependency. The project is currently stdlib-only.
@@ -83,7 +85,7 @@ Four facts from parsing real archives shape this design:
 
 - **A game update changes the container.** Likely eventually; version 2 is already the second. Mitigated by failing loudly on version and structure, so the next change presents as a named error rather than corrupt output.
 - **The excerpt fixture drifts from the shipping format.** A fixture built today keeps passing after the game changes. The opt-in full-archive test is the counterweight, and running it is part of re-extracting after a game update — which ADR-0001 already establishes as a manual step.
-- **The unknown header field at 0x20.** Observed as 1 in every archive examined. Parsed and ignored. If it ever differs, the version check will not catch it; worth asserting on and reporting as a curiosity rather than silently discarding.
+- **The header field at 0x20 — resolved; it is a storage flag.** This entry previously read "observed as 1 in every archive examined, parsed and ignored". That held for the two archives parsed when it was written and broke on the first run across all 97: it is `1` for a zstd block stream and `0` for stored archives (`NMSARC.audio.pak`, `NMSARC.audioBNK.pak`). The reader now validates it and rejects any third value. Kept in this list rather than deleted, because the mitigation this risk asked for — assert on the field instead of silently discarding it — is exactly what surfaced the answer.
 - **Only one game version has been examined.** Every structural claim in the spec comes from the 2026-06-05 build. The claims are stated as observations with the archives that produced them, so a future reader can tell measurement from assumption — which is exactly what the PSARC label failed to do.
 
 ## Migration Plan
@@ -96,5 +98,10 @@ Four facts from parsing real archives shape this design:
 ## Open Questions
 
 - Does a small block cache measurably help bulk extraction, or is the re-decompression cost noise against MBINCompiler subprocess time?
-- Is the 0x20 header field a flags word, an alignment hint, or a compression-method selector? It is 1 everywhere observed, so nothing distinguishes the hypotheses yet.
-- Do any archives in the install use a compression method other than zstd, or a block size other than 65,536? All 97 carry the HGPAK magic, but only two have been parsed in full — the opt-in test across all of them is what answers this, and it should run before the spec moves off `draft`.
+- Where does `blockCount` point for a stored archive? It is non-zero (1017 for `NMSARC.audioBNK.pak`) but no block table exists between the entry table and the data. Unchased: nothing in the ADR-0001 pipeline needs it.
+- Is a stored *final* block distinguishable from a compressed one? For the last block the compressed length equals the decompressed length either way, so the `== 65,536` rule cannot separate them. No archive in the install exhibits it, so it is unhandled rather than speculatively coded.
+
+**Answered by the full-archive run** (all 97 archives, story #9):
+
+- ~~Is the 0x20 header field a flags word, an alignment hint, or a compression-method selector?~~ A storage selector — see the resolved risk above.
+- ~~Do any archives use a compression method other than zstd, or a block size other than 65,536?~~ No. Block size is 65,536 everywhere and zstd is the only compression used. Two storage variants exist that the spec did not describe — stored archives and verbatim blocks — and both are identified structurally rather than by sniffing.

--- a/docs/openspec/specs/hgpak-reader/spec.md
+++ b/docs/openspec/specs/hgpak-reader/spec.md
@@ -65,13 +65,41 @@ All multi-byte integers in the header, entry table, and block table MUST be deco
 
 ### Requirement: Structural Layout
 
-The reader MUST parse the layout as: a 0x30-byte header; an entry table of `entryCount` 32-byte records beginning at 0x30, each a 16-byte hash followed by a u64 offset and a u64 size; then a block table of `blockCount` u64 compressed lengths; then the compressed blocks.
+The reader MUST parse a 0x30-byte header: the 8-byte magic, then u64 version, entry count, block count, a **storage flag** at `0x20`, and a data-start offset. In both layouts below, an entry table of `entryCount` 32-byte records begins at 0x30, each a 16-byte hash followed by a u64 offset and a u64 size.
 
-Each block MUST be decompressed with zstd and MUST yield exactly 65,536 bytes, except the final block, which MAY be shorter. A block that decompresses to a different length MUST be treated as a malformed archive.
+The storage flag selects the layout. The reader MUST reject any value other than the two below rather than guessing:
+
+| Flag | Layout |
+|---|---|
+| `1` | **Block stream.** The entry table is followed by a block table of `blockCount` u64 compressed lengths, then the blocks. 95 of the install's 97 archives. |
+| `0` | **Stored.** The entry table is followed directly by the data — no block table. `dataStart` is exactly `0x30 + entryCount * 32`, entry offsets are direct file offsets, and entry bytes including the manifest sit uncompressed. Observed in `NMSARC.audio.pak` and `NMSARC.audioBNK.pak`, whose WEM/BNK payloads are already compressed, so a second pass would buy nothing. |
+
+For a block-stream archive, each block MUST be decompressed with zstd and MUST yield exactly 65,536 bytes, except the final block, which MAY be shorter. A block that decompresses to a different length MUST be treated as a malformed archive.
+
+A block whose **compressed length is exactly 65,536** MUST be treated as stored verbatim and MUST NOT be passed to the decompressor. This is a length rule decided before any decompression is attempted, not a magic sniff and not a fallback: the packer stores a block when compressing it would not pay, and the stored length then equals the decompressed length by definition. A block of any other length that fails to decompress MUST remain a malformed archive — the reader MUST NOT fall back to raw bytes on decompression failure, which is the PSARC behaviour this format makes unnecessary. Observed in `NMSARC.UI.pak` and the `TexBiomes*` family.
 
 Blocks MUST be located by accumulating compressed lengths from the header's data-start offset, advancing to the next **16-byte boundary** after each block. Omitting the alignment step causes the second block to fail to decompress.
 
 Entry offsets MUST be interpreted as positions in a **virtual image of the file** whose first `dataStart` bytes are the header and tables. The position of an entry within the concatenated decompressed stream is therefore `entry.offset - dataStart`.
+
+Entry sizes, block lengths, and the table counts are all read from the file and are otherwise unbounded. The reader MUST bound each against the bytes actually remaining **before** allocating for it, and MUST NOT perform that check by computing a sum or a signed conversion that can overflow. A malformed archive MUST surface as a malformed-archive error naming the structure at fault; it MUST NOT panic.
+
+#### Scenario: Both storage layouts are read
+
+- **WHEN** an archive with storage flag `0` is opened
+- **THEN** its entries resolve by direct file offset with no block table parsed
+- **AND WHEN** the flag holds any value other than `0` or `1`
+- **THEN** the read fails naming the value found
+
+#### Scenario: A verbatim block is not decompressed
+
+- **WHEN** a block's compressed length is exactly 65,536
+- **THEN** its bytes are taken as-is, and no decompression is attempted on it
+
+#### Scenario: An oversized extent is refused, not fatal
+
+- **WHEN** an entry size or block length is large enough that adding it to a position would overflow
+- **THEN** the read fails as a malformed archive naming the entry or block, rather than panicking on an oversized allocation
 
 #### Scenario: Block alignment is honoured
 


### PR DESCRIPTION
Part of #7

Closes the design-doc drift deferred by #13. The reader on `main` parses two container layouts and a verbatim-block rule that ADR-0001 and SPEC-0003 never described — until this PR that knowledge lived only in a PR description, while the governing artifacts asserted something the merged code disproves.

That gap matters more than usual here. `internal/psarc` exists because a reader was written against an unverified label on a diagram edge, and SPEC-0003 leads with a real-archive verification requirement so it can't recur. Stories #10 and #11 will be built by agents reading these documents.

## What changed

| Artifact | Was | Now |
|---|---|---|
| `ADR-0001` | header `0x20` is "an unknown field (1)" | a storage flag, with both observed values and the archives exhibiting each |
| `spec.md` REQ "Structural Layout" | block-stream layout only | both layouts, third-value rejection, the raw-block rule, and an overflow bound |
| `design.md` Risks | "the unknown header field at 0x20 … parsed and ignored" | resolved, with the reason the mitigation worked |
| `design.md` Open Questions | two questions about `0x20` and compression uniformity | marked answered by the 97-archive run; two genuinely-open ones added |

## Notes for review

**The raw-block rule is stated as a length comparison, deliberately.** `design.md` already argues against PSARC's inflate-and-fall-back, and a careless reading of "some blocks are stored" would reintroduce exactly that. The requirement says the rule is decided *before* decompression is attempted, and that a wrong-length block failing to decompress remains a hard error.

**One addition goes beyond correcting drift.** REQ "Structural Layout" now requires file-controlled sizes to be bounded against the bytes remaining, with no overflowing sums or signed conversions, and requires a malformed archive to error rather than panic. That reflects shipped behaviour (80ee4c1) rather than new intent, and #10 adds more file-controlled values, so the constraint is worth stating before it's needed. Easy to drop if you'd rather keep this PR purely corrective.

**Every scenario added is backed by a test already on `main`** — `TestStoredArchiveLayout`, `TestUnknownStorageFlagIsRefused`, `TestRawBlockIsStoredNotCompressed`, `TestOversizedEntryIsRefusedNotPanicked`, `TestHugeBlockLengthIsRefusedWithSentinel`. Nothing here is aspirational.

**`design.md` keeps the `0x20` risk instead of deleting it.** The mitigation it asked for — assert on the field rather than silently discard it — is what surfaced the answer, and that's worth leaving legible.

## Still open

- SPEC-0003 is still `status: draft` with half its stories shipped. Not changed here since I don't know your convention for an in-progress state.
- Finding 3 from the #13 review is unfixed: `printableMagic` returns `""` for a magic starting with a non-printable byte, so REQ "Container Identification"'s "name the magic found" is unmet for non-ASCII-leading files. Code fix, not a docs fix.

Docs-only — no code touched.
