### PR TITLE
docs: mark ADR-0002 accepted

### DIFF
--- a/docs/adrs/ADR-0002-client-side-save-import.md
+++ b/docs/adrs/ADR-0002-client-side-save-import.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-08-17
 decision-makers: [Jon Stump]
 extends: [ADR-0001]


### PR DESCRIPTION
Status field only — `proposed` → `accepted`. No other frontmatter key, no body content.

Format was `yaml-frontmatter`; edited in place. The file carries no inline `- **Status:**` bullet, so there is no dual-source-of-truth risk here.

## Why this one needed no gate

**ADR-0002 sets no acceptance condition of its own.** That is the substantive difference from ADR-0001, which explicitly said it *"should not be marked `accepted` until the finding is confirmed by decompiling actual MBIN files"* — a gate that had to be cleared first (#18).

ADR-0002's core decision is already verified. Its More Information section records every dependent field resolved against the live mapping table — 1,424 entries at `libMBIN_version 6.45.0.1`: `PersistentPlayerBases` → `F?0`, `Name` → `NKm`, `GalacticAddress` → `oZw`, `BaseType` → `peI`, `Objects` → `@ZJ`, `ObjectID` → `r<7`, `Position` → `wMC`, plus `Owner`, `RegionSeed`, `LastUpdateTimestamp`, `BaseVersion`.

## Three things stay unverified, and this change does not pretend otherwise

From the ADR's own "Unverified, to settle during the spike" list:

1. **The macOS save file location** — presumed under `~/Library/Application Support/HelloGames/`, unconfirmed.
2. **Whether container inventories are reachable**, which decides whether stage 3 is feasible at all. The ADR already marks stage 3 *Speculative* in its Decision Outcome.
3. **Whether `ObjectID` joins cleanly to `GcBaseBuildingEntry.ID` without normalization** — the premise of stage 2.

These are spike questions, not gates. They stay open, and accepting the decision does not close them.

Worth noting on item 3: the join's other half now exists. `basebuildingobjectstable` decompiles to 1,997 `GcBaseBuildingEntry` rows with IDs like `U_BIOGENERATOR`, `U_SOLAR_S`, `U_EXTRACTOR_S`. So the moment there is a real save to read, that premise is checkable rather than assumed — which is the shape of check this project has learned to want.

## Precedent

Consistent with ADR-0003 and ADR-0004, both `accepted` with no implementation behind them. In this repo `accepted` marks a decision as adopted, not delivered.

---

Note: ADR-0001 reads `proposed` on this branch because its acceptance lives on the unmerged #18. Once both land, the ingestion line is ADR-0001 through ADR-0004 all accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
