### PR TITLE
docs: add SPEC-0004 Tier 1 normalizer

### DIFF
--- a/docs/openspec/specs/tier1-normalizer/design.md
+++ b/docs/openspec/specs/tier1-normalizer/design.md
@@ -1,0 +1,131 @@
+# Design: Tier 1 Normalizer
+
+## Context
+
+ADR-0001 chose direct extraction from the maintainer's own install, with a Go pipeline producing a version-stamped Tier 1 artifact. Two of the three stages exist. SPEC-0003's reader unpacks HGPAK archives and its CLI extracts to disk; MBINCompiler 6.45.0.1 decompiles the result to `.MXML`. The normalizer — the stage that turns 54 sprawling tables into the artifact the app loads — has never been written.
+
+Four facts shape this design:
+
+- **The target format already exists and already has a working consumer.** `internal/domain.Tier1`, `LoadTier1`, and the rollup engine merged in #2 resolve the 34-node Stasis Device tree from hand-authored fixtures today. This is unusually good ground: the output shape is not a guess, and `testdata/stasis-device.tier1.json` is a golden file to diff against.
+- **`LoadTier1` decodes with `DisallowUnknownFields`.** Any new artifact section is a load-time error until the struct declares it. Producer, schema, and loader are one change, not three.
+- **Tier 2 nearly dissolved.** ADR-0001 planned five hand-curated constants; four turned out extractable. The normalizer's scope grew accordingly, and the schema has to grow with it.
+- **Identity is indirect.** Product IDs are opaque and carry no display name; names are localisation keys resolving in a different archive. Any readable output requires a join the reality tables alone cannot satisfy.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Produce the Tier 1 artifact ADR-0001 promised, from a real install, reproducibly
+- Emit the base-economy data confirmed extractable, so it is regenerated rather than curated
+- Fail precisely when a game update moves something, rather than emitting a quietly smaller graph
+- Make the artifact a reviewable diff, so a balance change is legible in `git diff`
+- Reach ADR-0001's acceptance criteria through generated output rather than fixtures
+
+### Non-Goals
+
+- **Decoding MBIN.** ADR-0001 rejected reimplementing libMBIN; MBINCompiler stays a subprocess.
+- **Extraction.** SPEC-0003 owns unpacking; this spec starts at `.MXML` on disk.
+- **The merged plan dataset.** Combining Tier 1 with Tier 2 into the shipped static asset is a later stage.
+- **Save parsing.** ADR-0002, separate spec. The base-parts catalogue this emits is the join target, nothing more.
+- **Biodome crop-slot count.** Not extractable as far as anything searched shows; it stays Tier 2.
+- **Running in CI.** ADR-0001 already records ingestion as developer-local.
+
+## Decisions
+
+### Game IDs, not invented short codes
+
+**Choice**: `Item.id` is the game's own identifier — `ULTRAPROD2`, `PLANT_SNOW`.
+
+**Rationale**: Game IDs are stable across builds, are what save files carry, and are what ADR-0002's stage-2 join needs. A bespoke scheme would have to be re-derived and re-verified on every regeneration, and would break the save join outright. The existing fixtures use `fc` and `sb` because they were written by hand before extraction existed; that is a property of their authorship, not a design decision to inherit.
+
+**Trade-off**: Artifacts get larger and less readable by eye. Acceptable — it is a machine artifact with a golden-file test, not a document.
+
+### Localisation join is mandatory, and unresolved keys fail
+
+**Choice**: Resolve every name through `language/nms_loc*_english.mbin`, and fail generation on any key that does not resolve.
+
+**Rationale**: The alternative — falling back to the raw key — produces an artifact full of `UI_ULTRAPROD_2_NAME_L` that loads cleanly and looks like data. That is worse than failing, because it surfaces as a confusing UI much later rather than as an error at generation. This indirection is also what made the Stasis Device hard to find by search; recording it in the spec is how the next person avoids that hour.
+
+**Alternative considered**: Emit keys and resolve in the view layer. Rejected — it pushes a game-data concern across the WASM boundary and into ADR-0004's render-only view layer.
+
+### Fail closed on structural surprise
+
+**Choice**: A missing field, unrecognized enum, or absent table fails generation. No partial artifacts, no skipped rows, no defaulted values.
+
+**Rationale**: A game update moving a field is the expected failure, and ADR-0001 already accepts that an update can invalidate the pipeline. The useful behaviour is a precise error naming what moved. A quietly smaller recipe graph surfaces as a wrong tree in the planner, long after the cause.
+
+**Contrast**: This is the same posture SPEC-0003 took for the same reason, and for the same reason it is not paranoia — the format is reverse-engineered from one build.
+
+### Determinism as a correctness property
+
+**Choice**: Stable ordering everywhere; two runs over one install produce byte-identical output.
+
+**Rationale**: The artifact is committed. Nondeterministic ordering makes every regeneration an unreviewable diff, which means nobody reviews it, which means a real balance change lands unnoticed among reordering noise. Determinism is what keeps `git diff` meaningful as the review surface.
+
+### Base-economy data as ranges, keyed by hotspot
+
+**Choice**: Preserve minimum and maximum where the source expresses a range, and attach class scaling to hotspot categories rather than to devices.
+
+**Rationale**: This is the shape the data actually has. `REGIONHOTSPOTSTABLE` gives Power hotspots `ClassStrengths` of 150/220/250/300 and Mineral and Gas 1/1.5/2/2.5; a part declares a base rate and a hotspot dependency. Per-class device variants do not exist — searching the parts table for `_C`/`_B`/`_A` finds nothing, which is exactly how an earlier pass talked itself into "classes aren't in the data." Modelling devices per class would be inventing structure the game does not have.
+
+Collapsing yield ranges to a point estimate would also discard the best/worst case the planner wants to show.
+
+### Schema extension lands with the producer
+
+**Choice**: Extend `Tier1`, bump `SchemaVersion`, migrate the fixtures, and write the normalizer as one change.
+
+**Rationale**: `DisallowUnknownFields` makes any other sequencing broken by construction — a normalizer emitting sections the struct lacks produces artifacts that fail to load. Splitting the work would mean landing a producer whose output nothing can read.
+
+**Trade-off**: A larger single change than the SPEC-0003 stories. Mitigated by the story split being along data-section lines rather than along producer/schema lines.
+
+## Architecture
+
+```mermaid
+graph TD
+    A["NMS install<br/>GAMEDATA/PCBANKS/*.pak"] -->|"internal/hgpak<br/>(SPEC-0003)"| B[".MBIN on disk"]
+    B -->|"MBINCompiler subprocess<br/>(LGPL-3.0, 6.45.0.1)"| C[".MXML on disk"]
+
+    C --> D["Reality tables<br/>products, substances,<br/>recipes, base parts"]
+    C --> E["Localisation tables<br/>language/nms_loc*_english"]
+    C --> F["Simulation tables<br/>REGIONHOTSPOTSTABLE"]
+    C --> G["Globals<br/>gcgameplayglobals"]
+
+    D --> H["Normalizer<br/>graph build · ID resolution ·<br/>name join · provenance"]
+    E --> H
+    F --> H
+    G --> H
+
+    H --> I["Tier 1 artifact<br/>items · recipes ·<br/>base economy<br/>version-stamped"]
+    I -->|"LoadTier1<br/>DisallowUnknownFields"| J["Rollup engine<br/>(SPEC-0001)"]
+    J --> K["Acceptance:<br/>ULTRAPROD2 → 34 nodes"]
+
+    L["Tier 2 YAML<br/>biodome slot count"] -.->|later stage| I
+```
+
+The four source groups are the reason the normalizer is not a single-table read. Names come from a different archive than products; class scaling comes from `METADATA/SIMULATION/SCANNING/` rather than `METADATA/REALITY/TABLES/`; refiner throughput comes from globals. Each was found only after looking somewhere the first pass had not.
+
+## Risks / Trade-offs
+
+- **A game update moves a field.** Likely eventually. Mitigated by failing closed with a named error, so the next update presents as a precise failure rather than corrupt output.
+- **MBINCompiler lags the game.** ADR-0001 already records this. The normalizer inherits it and can do nothing about it beyond failing clearly.
+- **The schema extension is a wide change.** `DisallowUnknownFields` forces producer, schema, loader, and fixtures to move together. Split the stories by data section, not by layer.
+- **Localisation coverage may be incomplete for some items.** Failing on an unresolved key is deliberate, but if the tables genuinely omit names for some obscure items it becomes a hard blocker. If that happens the right answer is an explicit allowlist of known-unnamed IDs, not a silent fallback.
+- **Everything here was verified against one build.** NMS 5.97, paks spanning 2026-05-04 to 2026-06-16. Every structural claim in the spec names the table it came from so a future reader can tell measurement from assumption.
+
+## Migration Plan
+
+1. Extend `Tier1` and bump `SchemaVersion`; migrate the committed fixtures so they still load.
+2. Build the recipe-graph half — items, recipes, IDs, localisation join — and diff generated output against `stasis-device.tier1.json`.
+3. Add the base-economy sections.
+4. Wire the acceptance test to run the rollup engine over generated output, not fixtures.
+5. Regenerate and commit the artifact; from then on it is machine-produced and never hand-edited.
+
+The hand-authored fixtures stay after step 2, as golden files rather than as the dataset.
+
+## Open Questions
+
+- Should the artifact be one file or split per section? One file is simpler and matches `LoadTier1` today; splitting would make `git diff` narrower when only economy data changes.
+- Does the cooking table need the same treatment as refining, or does `nutrient processor` output fold into the same `cook` method without a separate source?
+- Refiner throughput is difficulty-dependent (`RefinerSubsMadeInTime` 250 versus 100 on Survival). Does the artifact carry both and let the planner choose, or does the planner assume Normal?
+- Is there a stable machine-readable game version in the install, or does `game_version` have to be derived from pak timestamps and the executable's version string?
+- Biodome crop-slot count is reported as 16 by the community wiki and is not in any table searched. Is it geometric — snap points in the scene — and therefore extractable after all, or genuinely Tier 2?

--- a/docs/openspec/specs/tier1-normalizer/spec.md
+++ b/docs/openspec/specs/tier1-normalizer/spec.md
@@ -1,0 +1,235 @@
+---
+status: draft
+date: 2026-08-18
+implements: [ADR-0001]
+requires: [SPEC-0001, SPEC-0003]
+---
+
+# SPEC-0004: Tier 1 Normalizer
+
+## Overview
+
+The stage between decompiled game tables and the artifact the app consumes. SPEC-0003 unpacks `.pak` archives to `.MBIN`; MBINCompiler converts those to `.MXML`; SPEC-0001's rollup engine loads a `Tier1` artifact and resolves dependency graphs from it. Nothing currently connects the two ends — this spec covers the normalizer that does.
+
+The output format is not speculative. `internal/domain.Tier1` already exists, `LoadTier1` already validates it, and `testdata/stasis-device.tier1.json` is a hand-authored fixture in exactly that shape that the merged rollup engine resolves today. Those fixtures carry `extracted: false` precisely to mark that a real producer had not been built. This spec is that producer, and the fixtures become golden files to diff against.
+
+Scope changed materially on 2026-08-18. ADR-0001 planned a five-constant hand-curated Tier 2; confirmation against real values found four of the five extractable (per-part rates and storage, C/B/A/S hotspot class strengths, crop yields, crop growth times). The normalizer therefore emits base-economy data as well as the recipe graph, and the `Tier1` schema has to grow to hold it.
+
+## Requirements
+
+### Requirement: Source Provenance and Version Stamping
+
+Every emitted artifact MUST record what produced it. The artifact MUST set `extracted` to `true`, MUST record the game build it was derived from in `game_version`, and MUST record the source archives and MBINCompiler version in `source`.
+
+The normalizer MUST NOT emit an artifact that claims a `game_version` it did not read from the install. Where a game version string cannot be determined, the read MUST fail rather than emit a guess or a placeholder.
+
+Artifacts are regenerated per game version and MUST NOT be hand-edited. The normalizer MUST be able to reproduce any committed artifact from the same install without manual steps.
+
+#### Scenario: Provenance is recorded
+
+- **WHEN** an artifact is generated from a real install
+- **THEN** `extracted` is `true`, `game_version` names the build read, and `source` names the archives and the MBINCompiler version used
+
+#### Scenario: Unknown game version fails rather than guesses
+
+- **WHEN** the game version cannot be determined from the install
+- **THEN** generation fails naming what could not be read, and no artifact is written
+
+### Requirement: Deterministic Output
+
+Running the normalizer twice against the same install MUST produce byte-identical output. Collections MUST be emitted in a defined, stable order — not in map-iteration order, and not in the order entries happen to appear in a decompiled table.
+
+This is a correctness requirement rather than an aesthetic one: the artifact is committed to the repository, so nondeterministic output turns every regeneration into an unreviewable diff and hides real changes among spurious ones.
+
+#### Scenario: Regeneration is a no-op diff
+
+- **WHEN** the normalizer runs twice against an unchanged install
+- **THEN** the two artifacts are byte-identical and `git diff` reports no change
+
+#### Scenario: A real change is legible
+
+- **WHEN** the game updates and one recipe's quantity changes
+- **THEN** the artifact diff shows that change and no unrelated reordering
+
+### Requirement: Recipe Graph Construction
+
+The normalizer MUST build `items` and `recipes` from the reality tables — products, substances, and the refinery and cooking recipe tables.
+
+Every recipe's `method` MUST be one of `craft`, `refine`, `raw`, or `cook`. The normalizer MUST NOT emit a `buy` method; per SPEC-0001 REQ "Method Resolution" that value is deliberately absent from the vocabulary and this is a build planner, not a shopping list.
+
+Every `Input.item` and every `Recipe.output` MUST reference an `Item.id` present in the same artifact. An input referencing an unknown item MUST fail generation rather than emit a dangling edge.
+
+Items with no recipe MUST be emitted with `raw_obtainable` true and `default_method` `raw`, so the rollup engine's terminal-node handling has the leaves it expects.
+
+#### Scenario: The graph is closed
+
+- **WHEN** an artifact is generated
+- **THEN** every recipe input and output resolves to an item in the same artifact
+
+#### Scenario: A dangling reference fails generation
+
+- **WHEN** a recipe references an item ID absent from the tables
+- **THEN** generation fails naming the recipe and the missing ID, and no artifact is written
+
+#### Scenario: The method vocabulary is closed
+
+- **WHEN** a source table implies a method outside craft, refine, raw, cook
+- **THEN** generation fails naming the method found, rather than emitting it
+
+### Requirement: Identifier Policy
+
+Item identifiers in the artifact MUST be the game's own IDs (`ULTRAPROD2`, `PLANT_SNOW`, `U_EXTRACTOR_S`), not invented short codes.
+
+Game IDs are stable across builds, are what save files carry, and are what ADR-0002's save-import joins against; a bespoke ID scheme would have to be re-derived and re-verified on every regeneration. The existing fixtures use short codes (`fc`, `sb`) because they were hand-authored before extraction existed, and MUST be treated as illustrative of shape rather than of identifier policy.
+
+The normalizer MUST NOT normalize, case-fold, or otherwise rewrite game IDs.
+
+#### Scenario: Game IDs survive verbatim
+
+- **WHEN** the Stasis Device is emitted
+- **THEN** its item ID is `ULTRAPROD2`, exactly as the product table spells it
+
+### Requirement: Display Name Resolution
+
+Item names MUST be resolved to human-readable English via the localisation tables. The reality tables carry only localisation *keys* — `NameLower` on the Stasis Device is `UI_ULTRAPROD_2_NAME_L`, not "Stasis Device" — and those keys resolve in `language/nms_loc*_english.mbin`, which lives in a different archive from the product table.
+
+Where a name key does not resolve, the normalizer MUST fail generation naming the key and the item, rather than falling back to the raw key or to the ID. An artifact full of `UI_ULTRAPROD_2_NAME_L` is worse than no artifact, because it looks like data.
+
+#### Scenario: Names come from the localisation tables
+
+- **WHEN** `ULTRAPROD2` is emitted
+- **THEN** its `name` is "Stasis Device", resolved through `UI_ULTRAPROD_2_NAME_L`
+
+#### Scenario: An unresolved key fails rather than leaks
+
+- **WHEN** an item's name key is absent from the localisation tables
+- **THEN** generation fails naming the key and the item, and no artifact is written
+
+### Requirement: Base Economy Data
+
+The artifact MUST carry the base-economy values confirmed extractable on 2026-08-18, so they are version-stamped and regenerated rather than hand-curated:
+
+- Per-part production and consumption **rates** and **storage** buffers, from `GcBaseLinkGridData`, together with the network each applies to and any dependent-connection rate
+- **Hotspot class strengths and weightings** for C/B/A/S per hotspot category, from `REGIONHOTSPOTSTABLE`
+- **Crop yields**, from the reward table's `GcRewardSpecificSubstance` minimum and maximum amounts
+- **Crop growth times**, from the plant's `PlantGrowth` connection storage value
+- **Refiner throughput**, from `gcgameplayglobals`, including the difficulty variants
+
+Class scaling MUST be modelled as a property of the hotspot, not of the device. A part declares a base rate and a hotspot dependency; the class belongs to the hotspot. The normalizer MUST NOT emit per-class device variants, which do not exist in the source data.
+
+Yields and class strengths that the source expresses as a minimum and a maximum MUST be preserved as a range. Collapsing a range to a single value discards information the planner needs to show best and worst case.
+
+#### Scenario: Rates carry their network
+
+- **WHEN** `U_EXTRACTOR_S` is emitted
+- **THEN** its rate, its storage, and its dependent power draw are present, each identified by the network it applies to
+
+#### Scenario: Class scaling attaches to hotspots
+
+- **WHEN** class strengths are emitted
+- **THEN** they are keyed by hotspot category and class, and no per-class device variants appear
+
+#### Scenario: Ranges survive as ranges
+
+- **WHEN** a crop yield is expressed as a minimum and maximum in the source
+- **THEN** both bounds are emitted, rather than one derived value
+
+### Requirement: Schema Extension and Load Compatibility
+
+The `Tier1` schema MUST be extended to hold the base-economy data, and `SchemaVersion` MUST be incremented in the same change.
+
+`LoadTier1` decodes with unknown fields disallowed, so an artifact carrying sections the struct does not declare fails to load. The producer, the schema, and the loader MUST therefore change together; the normalizer MUST NOT emit a section that `internal/domain` cannot decode.
+
+Existing fixtures MUST continue to load. Where the extension makes a previously-valid artifact invalid, the fixtures MUST be migrated in the same change rather than left broken.
+
+#### Scenario: New sections load
+
+- **WHEN** an artifact carrying base-economy sections is passed to `LoadTier1`
+- **THEN** it decodes without an unknown-field error and validates
+
+#### Scenario: Existing fixtures still load
+
+- **WHEN** the committed fixtures are loaded after the schema extension
+- **THEN** they decode and validate, having been migrated if the extension required it
+
+### Requirement: Excluded Content
+
+The normalizer MUST take structure and quantities only. In-game `Description`, `Subtitle`, and `Hint` text, and icon or model asset paths, MUST NOT appear in the artifact.
+
+Per ADR-0001 this is Hello Games' creative expression, and the design bundle's own rule is that no game assets or trade dress are used. Item names are retained because they are the identifiers a user reads; descriptive prose is not.
+
+#### Scenario: Description text is excluded
+
+- **WHEN** an item whose source record carries `Description`, `Subtitle`, and `Hint` is emitted
+- **THEN** none of those fields appear anywhere in the artifact
+
+#### Scenario: Asset paths are excluded
+
+- **WHEN** an item whose source record names icon and model files is emitted
+- **THEN** no asset path appears in the artifact
+
+### Requirement: Structural Surprise Fails Loudly
+
+Where a source table's structure does not match what the normalizer expects — a missing field, an unrecognized enum value, a table absent from the archive — generation MUST fail naming the table and the expectation violated.
+
+The normalizer MUST NOT emit a partial artifact, silently skip an unparseable row, or substitute a default for a value it could not read. A game update that moves a field is the expected cause, and it MUST present as a precise error rather than as a quietly smaller recipe graph that surfaces much later as a wrong tree.
+
+#### Scenario: A moved field is named
+
+- **WHEN** an expected field is absent from a source table
+- **THEN** generation fails naming the table and the field, and no artifact is written
+
+#### Scenario: Partial output is never emitted
+
+- **WHEN** generation fails partway through
+- **THEN** no artifact file is left behind
+
+### Requirement: Search Boundaries Are Recorded
+
+Where the normalizer derives a value by searching for it rather than by reading a known field, the artifact or its generation log MUST record which sources were searched.
+
+This project has three recorded instances of a bounded search reported as a general result — the `PSARC` diagram edge, "an unknown field (1 in every archive observed)", and the Tier 2 constants declared absent while four of five were present. A derived value that does not say what was examined cannot be distinguished later from one that was read directly.
+
+#### Scenario: A derived value carries its provenance
+
+- **WHEN** a value is produced by searching several tables rather than reading one known field
+- **THEN** the sources searched are recorded alongside it
+
+### Requirement: Acceptance Against the Golden Tree
+
+The normalizer is correct when the artifact it produces reproduces ADR-0001's confirmation criteria through the merged rollup engine, rooted at `ULTRAPROD2`:
+
+- 34 distinct nodes across the Quantum Processor (`MEGAPROD2`), Cryogenic Chamber (`MEGAPROD3`), and Iridesite (`ALLOY8`) branches
+- Each gas product costing 250 gas and 50 Condensed Carbon
+- At quantity ×1: 500 each of Sulphurine, Nitrogen and Radon, and 300 Condensed Carbon
+
+This acceptance MUST run against a generated artifact, not against the hand-authored fixtures. A test that only exercises the fixtures verifies the engine, not the normalizer.
+
+#### Scenario: The generated artifact reproduces the tree
+
+- **WHEN** the rollup engine resolves `ULTRAPROD2` at quantity 1 from a generated artifact
+- **THEN** it returns 34 distinct nodes and leaf totals of 500 Sulphurine, 500 Nitrogen, 500 Radon and 300 Condensed Carbon
+
+#### Scenario: Acceptance uses generated output
+
+- **WHEN** the acceptance test runs
+- **THEN** its input was produced by the normalizer in that run, not read from a committed fixture
+
+### Requirement: Error Handling Standards
+
+All error-producing operations MUST follow structured error handling:
+
+- Errors MUST be wrapped with contextual information at each layer boundary (e.g., "normalizing nms_reality_gcproducttable: item ULTRAPROD2: name key UI_ULTRAPROD_2_NAME_L not found in localisation tables")
+- Sentinel errors MUST be defined for domain-specific failure modes that callers need to distinguish programmatically — at minimum: source table missing, structure unrecognized, reference unresolved, and localisation key unresolved
+- Silent error swallowing MUST NOT occur — every error MUST be either returned to the caller, logged with sufficient context, or explicitly handled with a documented reason for suppression
+- Structured logging MUST be used for error reporting (key-value pairs, not string interpolation)
+
+#### Scenario: A failure names its table and its row
+
+- **WHEN** normalization fails on one row of one table
+- **THEN** the error names the table, the row's identifier, and the expectation violated
+
+#### Scenario: Failure modes are distinguishable
+
+- **WHEN** a caller encounters a missing source table versus an unresolved localisation key
+- **THEN** the two failures carry different sentinels


### PR DESCRIPTION
Documents only. Adds the paired [spec.md](docs/openspec/specs/tier1-normalizer/spec.md) and [design.md](docs/openspec/specs/tier1-normalizer/design.md) for the missing middle of the ADR-0001 pipeline.

`implements: [ADR-0001]` · `requires: [SPEC-0001, SPEC-0003]` · 12 requirements · 24 scenarios

## What this covers

Two of three ingestion stages exist. SPEC-0003's reader unpacks HGPAK archives and its CLI extracts to disk; MBINCompiler 6.45.0.1 decompiles to `.MXML`. SPEC-0001's rollup engine loads a `Tier1` artifact and resolves dependency graphs. **Nothing connects the two ends** — that's this spec.

It is unusually well-grounded for greenfield work. `internal/domain.Tier1` and `LoadTier1` already exist, and `testdata/stasis-device.tier1.json` is a hand-authored fixture in exactly that shape that the merged rollup engine resolves *today*. Those fixtures carry `extracted: false` precisely to mark that no real producer had been built. This spec is that producer, and the fixtures become golden files to diff against.

## Scope reflects the finding correction

ADR-0001 planned a five-constant hand-curated Tier 2. The 2026-08-18 confirmation found four of the five extractable, so the normalizer emits base-economy data — per-part rates and storage, hotspot `ClassStrengths`, crop yields, growth times, refiner throughput — alongside the recipe graph.

That forces a schema change. `LoadTier1` decodes with `DisallowUnknownFields`, so an artifact carrying sections the struct doesn't declare fails to load. **Producer, schema, loader, and fixtures move as one change** — any other sequencing is broken by construction. The design doc says to split the stories by data section rather than by layer for that reason.

## Requirements worth reviewing

Most came from things that actually bit us, not from the template.

- **Display Name Resolution** — an unresolved localisation key **fails generation** rather than falling back to the raw key. An artifact full of `UI_ULTRAPROD_2_NAME_L` loads cleanly and *looks like data*, which is worse than failing: it surfaces as a confusing UI much later instead of an error at generation. This is the same indirection that made the Stasis Device hard to find by search, now written down.
- **Deterministic Output** — framed as correctness, not tidiness. The artifact is committed, so nondeterministic ordering makes every regeneration an unreviewable diff, which means nobody reviews it, which means a real balance change lands unnoticed in reordering noise.
- **Structural Surprise Fails Loudly** — no partial artifacts, no skipped rows, no defaulted values. Same posture SPEC-0003 took, for the same reason: the format is reverse-engineered from one build.
- **Search Boundaries Are Recorded** — a derived value must record what was searched. This exists because the project has three instances of a bounded search reported as a general result, and the requirement names all three.
- **Acceptance Against the Golden Tree** — must run against **generated** output. A test that only exercises the fixtures verifies the rollup engine, not the normalizer.
- **Identifier Policy** — game IDs verbatim (`ULTRAPROD2`, not `fc`). The spec states explicitly that the existing fixture IDs are illustrative of *shape*, not of identifier policy — left implicit, that is exactly what someone reasonably infers wrong.

## Design decisions

Class scaling attaches to **hotspots, not devices**, because that is the shape the data has: a part declares a base rate plus a hotspot dependency, and `REGIONHOTSPOTSTABLE` carries `ClassStrengths` per category. Modelling per-class device variants would be inventing structure the game does not have — and searching for `_C`/`_B`/`_A` variants finding nothing is exactly how an earlier pass talked itself into "classes aren't in the data."

The architecture diagram shows why this isn't a single-table read: names come from a different archive than products, class scaling from `METADATA/SIMULATION/SCANNING/`, refiner throughput from globals. Each was found only after looking somewhere the first pass hadn't.

## Detection outcomes

Not web-facing and not UI-facing — it's a batch normalizer — so no Security or Accessibility sections, correctly. Backend error-handling requirements injected since it parses files and shells out to a subprocess. `cgg` isn't installed and there's no implementation to graph yet, so no `## Implementation` section.

## Open questions carried, not resolved

Five in the design doc. The sharpest: refiner throughput is difficulty-dependent (`RefinerSubsMadeInTime` 250 vs 100 on Survival) — does the artifact carry both and let the planner choose, or assume Normal? Also unresolved is whether a stable machine-readable game version exists in the install, or whether `game_version` has to be derived from pak timestamps and the executable version string.

## Note for after merge

The `nms-base-planner-specs` qmd context blurb enumerates SPEC-0001 through SPEC-0003 by name and is now stale. I didn't rewrite it silently; it needs a `qmd context add` refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
