### PR TITLE
Artifact schema, provenance envelope, and fail-closed errors

### DIFF
--- a/internal/domain/economy.go
+++ b/internal/domain/economy.go
@@ -1,0 +1,186 @@
+package domain
+
+import "fmt"
+
+// Base-economy data carried alongside the recipe graph.
+//
+// Governing: ADR-0001 (two-tier NMS data ingestion), SPEC-0004 REQ "Schema
+// Extension and Load Compatibility"
+//
+// ADR-0001 originally planned these as hand-curated Tier 2 constants. The
+// 2026-08-18 confirmation found four of the five extractable, so they belong
+// to the machine-generated tier and live here. Only biodome crop-slot count
+// remains curated.
+//
+// The shapes below mirror the source data rather than a convenient
+// abstraction of it: rates are per-network because a part participates in
+// several, class scaling hangs off hotspots because that is where the game
+// puts it, and yields keep both bounds because collapsing a range to a point
+// discards the best/worst case the planner exists to show.
+
+// Network is a link-grid network a rate applies to.
+type Network string
+
+const (
+	NetworkPower       Network = "power"
+	NetworkResources   Network = "resources"
+	NetworkPlantGrowth Network = "plant_growth"
+	NetworkByteBeat    Network = "byte_beat"
+)
+
+var validNetworks = map[Network]bool{
+	NetworkPower: true, NetworkResources: true,
+	NetworkPlantGrowth: true, NetworkByteBeat: true,
+}
+
+// Valid reports whether n is a known network.
+func (n Network) Valid() bool { return validNetworks[n] }
+
+// Flow is a rate on one network, with the buffer that accumulates it.
+// A positive Rate produces, a negative Rate consumes.
+type Flow struct {
+	Network Network `json:"network"`
+	Rate    int64   `json:"rate"`
+	Storage int64   `json:"storage,omitempty"`
+}
+
+// Dependency is a part's requirement on another network — typically a power
+// draw that gates the part's primary rate.
+type Dependency struct {
+	Network Network `json:"network"`
+	Rate    int64   `json:"rate"`
+	// Effect is the source's DependentEffect, e.g. "EnablesRate". Carried
+	// verbatim rather than interpreted, because the planner needs to know
+	// whether an unpowered part produces nothing or merely produces less.
+	Effect string `json:"effect,omitempty"`
+}
+
+// Part is one buildable's economic behaviour.
+type Part struct {
+	ID           string       `json:"id"`
+	Name         string       `json:"name,omitempty"`
+	Primary      Flow         `json:"primary"`
+	Dependencies []Dependency `json:"dependencies,omitempty"`
+	// Hotspot names the hotspot category this part's rate scales with, if
+	// any. The class lives on the hotspot, never on the part.
+	Hotspot string `json:"hotspot,omitempty"`
+}
+
+// ClassValues holds one value per C/B/A/S class.
+type ClassValues struct {
+	C float64 `json:"c"`
+	B float64 `json:"b"`
+	A float64 `json:"a"`
+	S float64 `json:"s"`
+}
+
+// Hotspot carries the class scaling for one hotspot category.
+//
+// Classes are ranges a hotspot falls into, not multipliers attached to a
+// device. Searching the parts table for per-class variants finds nothing
+// precisely because the game models it this way.
+type Hotspot struct {
+	Category   string      `json:"category"`
+	Strengths  ClassValues `json:"strengths"`
+	Weightings ClassValues `json:"weightings"`
+}
+
+// Range is an inclusive minimum and maximum. Both bounds are kept even when
+// equal, so a later widening in the game data is a visible change rather
+// than a silent one.
+type Range struct {
+	Min int64 `json:"min"`
+	Max int64 `json:"max"`
+}
+
+// Crop is one farmable plant's yield and growth time.
+type Crop struct {
+	// ID is the buildable plant's ID, e.g. SNOWPLANT.
+	ID string `json:"id"`
+	// Substance is the item ID the plant yields, e.g. PLANT_SNOW.
+	Substance string `json:"substance"`
+	Yield     Range  `json:"yield"`
+	// GrowthSeconds is time to maturity.
+	GrowthSeconds int64 `json:"growth_seconds"`
+}
+
+// Refining is refiner throughput, which is difficulty-dependent.
+type Refining struct {
+	ProductsPerCycle   int64 `json:"products_per_cycle"`
+	SubstancesPerCycle int64 `json:"substances_per_cycle"`
+	// Survival variants. The design's open question of whether the planner
+	// should choose is settled by carrying both and letting it.
+	ProductsPerCycleSurvival   int64 `json:"products_per_cycle_survival"`
+	SubstancesPerCycleSurvival int64 `json:"substances_per_cycle_survival"`
+}
+
+// Economy is the base-economy half of the artifact.
+type Economy struct {
+	Parts    []Part    `json:"parts,omitempty"`
+	Hotspots []Hotspot `json:"hotspots,omitempty"`
+	Crops    []Crop    `json:"crops,omitempty"`
+	Refining *Refining `json:"refining,omitempty"`
+}
+
+// validate checks the economy section's internal consistency. Item
+// references are checked by the caller, which owns the item index.
+func (e *Economy) validate(knownItem func(string) bool) error {
+	seenPart := make(map[string]bool, len(e.Parts))
+	for _, p := range e.Parts {
+		if p.ID == "" {
+			return fmt.Errorf("%w: part with empty id", ErrInvalidArtifact)
+		}
+		if seenPart[p.ID] {
+			return fmt.Errorf("%w: duplicate part id %q", ErrInvalidArtifact, p.ID)
+		}
+		seenPart[p.ID] = true
+		if !p.Primary.Network.Valid() {
+			return fmt.Errorf("%w: part %q primary network %q is not a known network", ErrInvalidArtifact, p.ID, p.Primary.Network)
+		}
+		for _, d := range p.Dependencies {
+			if !d.Network.Valid() {
+				return fmt.Errorf("%w: part %q dependency network %q is not a known network", ErrInvalidArtifact, p.ID, d.Network)
+			}
+		}
+	}
+
+	seenCat := make(map[string]bool, len(e.Hotspots))
+	for _, h := range e.Hotspots {
+		if h.Category == "" {
+			return fmt.Errorf("%w: hotspot with empty category", ErrInvalidArtifact)
+		}
+		if seenCat[h.Category] {
+			return fmt.Errorf("%w: duplicate hotspot category %q", ErrInvalidArtifact, h.Category)
+		}
+		seenCat[h.Category] = true
+	}
+
+	// A part naming a hotspot must name one the artifact carries, or the
+	// planner cannot scale its rate.
+	for _, p := range e.Parts {
+		if p.Hotspot != "" && !seenCat[p.Hotspot] {
+			return fmt.Errorf("%w: part %q references hotspot %q, which is not in this artifact", ErrInvalidArtifact, p.ID, p.Hotspot)
+		}
+	}
+
+	seenCrop := make(map[string]bool, len(e.Crops))
+	for _, c := range e.Crops {
+		if c.ID == "" {
+			return fmt.Errorf("%w: crop with empty id", ErrInvalidArtifact)
+		}
+		if seenCrop[c.ID] {
+			return fmt.Errorf("%w: duplicate crop id %q", ErrInvalidArtifact, c.ID)
+		}
+		seenCrop[c.ID] = true
+		if !knownItem(c.Substance) {
+			return fmt.Errorf("%w: crop %q yields %q: %w", ErrInvalidArtifact, c.ID, c.Substance, ErrUnknownItem)
+		}
+		if c.Yield.Min < 0 || c.Yield.Max < c.Yield.Min {
+			return fmt.Errorf("%w: crop %q yield range [%d, %d] is not ordered and non-negative", ErrInvalidArtifact, c.ID, c.Yield.Min, c.Yield.Max)
+		}
+		if c.GrowthSeconds < 0 {
+			return fmt.Errorf("%w: crop %q growth time is negative: %d", ErrInvalidArtifact, c.ID, c.GrowthSeconds)
+		}
+	}
+	return nil
+}

--- a/internal/domain/resolve_test.go
+++ b/internal/domain/resolve_test.go
@@ -329,7 +329,7 @@ func TestCycleDetection(t *testing.T) {
 	// A deliberately cyclic artifact: refining A yields B and refining B
 	// yields A, which is a shape the real refining data is capable of.
 	const cyclic = `{
-	  "schema_version": 1, "game_version": "test-cycle",
+	  "schema_version": 2, "game_version": "test-cycle",
 	  "items": [
 	    {"id":"a","name":"Alpha","default_method":"refine"},
 	    {"id":"b","name":"Beta","default_method":"refine"}
@@ -459,7 +459,7 @@ func TestSentinelsAreDistinct(t *testing.T) {
 
 func TestTier1ValidationRejectsMissingGameVersion(t *testing.T) {
 	const noVersion = `{
-	  "schema_version": 1,
+	  "schema_version": 2,
 	  "items": [{"id":"a","name":"Alpha","raw_obtainable":true,"default_method":"raw"}],
 	  "recipes": []
 	}`

--- a/internal/domain/testdata/hexaberry-cake.tier1.json
+++ b/internal/domain/testdata/hexaberry-cake.tier1.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "game_version": "community-2026-08",
   "extracted": false,
   "source": "docs/design/base-planner/handoff.md (v2 CAKE target: RANCH rows + KITCHEN Nutrient Processor steps)",

--- a/internal/domain/testdata/stasis-device.tier1.json
+++ b/internal/domain/testdata/stasis-device.tier1.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "game_version": "community-2026-08",
   "extracted": false,
   "source": "docs/design/tree-canvas/handoff.md + Tree Canvas.dc.html",

--- a/internal/domain/tier1.go
+++ b/internal/domain/tier1.go
@@ -74,6 +74,31 @@ type Recipe struct {
 // IsVerified reports the recipe's provenance, defaulting to verified.
 func (r Recipe) IsVerified() bool { return r.Verified == nil || *r.Verified }
 
+// CurrentSchemaVersion is the schema every artifact this package writes or
+// accepts must declare.
+//
+// Governing: SPEC-0004 REQ "Schema Extension and Load Compatibility" — the
+// schema, the producer and the loader move together, so a version bump is
+// how an artifact from the wrong side of a change is rejected rather than
+// silently half-read.
+//
+// 1: items and recipes only.
+// 2: adds provenance and the base-economy section.
+const CurrentSchemaVersion = 2
+
+// Provenance records the inputs a generated artifact was derived from.
+//
+// Deliberately carries no generation timestamp: SPEC-0004 REQ "Deterministic
+// Output" requires two runs over one install to be byte-identical, and a
+// clock reading would defeat that for no benefit the game version does not
+// already provide.
+type Provenance struct {
+	// Archives names the .pak files read, in sorted order.
+	Archives []string `json:"archives"`
+	// MBINCompiler is the decompiler version that produced the .MXML input.
+	MBINCompiler string `json:"mbincompiler"`
+}
+
 // Tier1 is the extracted recipe graph.
 //
 // Governing: ADR-0001 (two-tier ingestion) — Tier 1 is machine-extracted and
@@ -85,8 +110,20 @@ type Tier1 struct {
 	Source        string `json:"source"`
 	Note          string `json:"note"`
 
+	// Provenance records what produced a generated artifact. Absent on
+	// hand-authored fixtures, which carry Extracted false instead.
+	//
+	// Governing: SPEC-0004 REQ "Source Provenance and Version Stamping"
+	Provenance *Provenance `json:"provenance,omitempty"`
+
 	Items   []Item   `json:"items"`
 	Recipes []Recipe `json:"recipes"`
+
+	// Economy is the base-economy half of the artifact. Optional so that
+	// recipe-only fixtures remain valid.
+	//
+	// Governing: SPEC-0004 REQ "Base Economy Data"
+	Economy *Economy `json:"economy,omitempty"`
 
 	// Derived indexes, built by Validate.
 	itemsByID    map[string]Item
@@ -110,6 +147,13 @@ func LoadTier1(r io.Reader) (*Tier1, error) {
 
 // Validate checks structural integrity and builds the lookup indexes.
 func (t *Tier1) Validate() error {
+	if t.SchemaVersion != CurrentSchemaVersion {
+		// Governing: SPEC-0004 REQ "Schema Extension and Load Compatibility"
+		// — an artifact from the other side of a schema change is refused
+		// outright rather than half-read, since the fields it is missing (or
+		// carrying) are exactly the ones a partial read would get wrong.
+		return fmt.Errorf("%w: schema_version %d, want %d", ErrInvalidArtifact, t.SchemaVersion, CurrentSchemaVersion)
+	}
 	if t.GameVersion == "" {
 		// Governing: SPEC-0001 REQ "Dependency Graph Resolution" — fixtures
 		// asserting exact node counts or leaf totals must name the game
@@ -169,6 +213,17 @@ func (t *Tier1) Validate() error {
 	for _, it := range t.Items {
 		if !t.methodAvailable(it, it.DefaultMethod) {
 			return fmt.Errorf("%w: item %q default method %q: %w", ErrInvalidArtifact, it.ID, it.DefaultMethod, ErrIllegalMethod)
+		}
+	}
+
+	if t.Economy != nil {
+		// Governing: SPEC-0004 REQ "Base Economy Data" — validated after the
+		// item index is built, since crop yields reference item IDs.
+		if err := t.Economy.validate(func(id string) bool {
+			_, ok := t.itemsByID[id]
+			return ok
+		}); err != nil {
+			return err
 		}
 	}
 

--- a/internal/normalize/artifact.go
+++ b/internal/normalize/artifact.go
@@ -95,8 +95,9 @@ func (b *Builder) Artifact() (*domain.Tier1, error) {
 // Governing: SPEC-0004 REQ "Deterministic Output" — the artifact is
 // committed, so unstable ordering turns each regeneration into an
 // unreviewable diff and buries real balance changes in reordering noise.
-// Sort keys are chosen to be total: where one field can repeat, a second
-// breaks the tie.
+// Sort keys are chosen to be total: where one field can repeat, the
+// remaining fields break the tie, so two records that sort equal are also
+// byte-identical and their order cannot show in the output.
 func sortArtifact(t *domain.Tier1) {
 	sort.Slice(t.Items, func(i, j int) bool { return t.Items[i].ID < t.Items[j].ID })
 	sort.Slice(t.Recipes, func(i, j int) bool {
@@ -106,15 +107,39 @@ func sortArtifact(t *domain.Tier1) {
 		return t.Recipes[i].Method < t.Recipes[j].Method
 	})
 	for _, r := range t.Recipes {
-		sort.Slice(r.Inputs, func(i, j int) bool { return r.Inputs[i].Item < r.Inputs[j].Item })
+		// Item alone is not total: Validate does not reject a recipe naming
+		// the same input twice, and an unstable sort would then leave the
+		// caller's insertion order showing through.
+		sort.Slice(r.Inputs, func(i, j int) bool {
+			a, b := r.Inputs[i], r.Inputs[j]
+			if a.Item != b.Item {
+				return a.Item < b.Item
+			}
+			return a.Quantity < b.Quantity
+		})
 	}
 	if t.Economy == nil {
 		return
 	}
 	sort.Slice(t.Economy.Parts, func(i, j int) bool { return t.Economy.Parts[i].ID < t.Economy.Parts[j].ID })
 	for _, p := range t.Economy.Parts {
+		// Network alone is not total. Every other collection here sorts on a
+		// key Validate guarantees unique — item IDs, part IDs, hotspot
+		// categories, (output, method) pairs — but nothing rejects a part
+		// carrying two dependencies on one network, so the remaining fields
+		// have to break the tie. Tiebreaking rather than rejecting, because
+		// whether the game data ever does this has not been established, and
+		// refusing to generate over an unverified assumption is the failure
+		// mode this pipeline already learned once.
 		sort.Slice(p.Dependencies, func(i, j int) bool {
-			return p.Dependencies[i].Network < p.Dependencies[j].Network
+			a, b := p.Dependencies[i], p.Dependencies[j]
+			if a.Network != b.Network {
+				return a.Network < b.Network
+			}
+			if a.Rate != b.Rate {
+				return a.Rate < b.Rate
+			}
+			return a.Effect < b.Effect
 		})
 	}
 	sort.Slice(t.Economy.Hotspots, func(i, j int) bool {

--- a/internal/normalize/artifact.go
+++ b/internal/normalize/artifact.go
@@ -1,0 +1,190 @@
+package normalize
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/jonstump/nms-base-planner/internal/domain"
+)
+
+// Governing: ADR-0001 (two-tier NMS data ingestion), SPEC-0004 REQ "Source
+// Provenance and Version Stamping", REQ "Deterministic Output"
+
+// Builder accumulates the pieces of a Tier 1 artifact and emits it.
+//
+// Later stories fill it: the recipe graph populates Items and Recipes, the
+// base-economy pass populates Economy. This story owns the envelope — what
+// every artifact must carry regardless of which pass produced its contents.
+type Builder struct {
+	gameVersion  string
+	archives     []string
+	mbinCompiler string
+	note         string
+
+	items   []domain.Item
+	recipes []domain.Recipe
+	economy *domain.Economy
+}
+
+// NewBuilder starts an artifact for the named game build.
+//
+// gameVersion MUST have been read from the install. SPEC-0004 REQ "Source
+// Provenance and Version Stamping" forbids emitting a guess or a
+// placeholder, so an empty value is refused here rather than written and
+// discovered later.
+func NewBuilder(gameVersion, mbinCompiler string, archives []string) (*Builder, error) {
+	if gameVersion == "" {
+		return nil, fmt.Errorf("game version was not determined from the install: %w", ErrSourceMissing)
+	}
+	if mbinCompiler == "" {
+		return nil, fmt.Errorf("MBINCompiler version was not determined: %w", ErrSourceMissing)
+	}
+	if len(archives) == 0 {
+		return nil, fmt.Errorf("no source archives recorded: %w", ErrSourceMissing)
+	}
+	cp := append([]string(nil), archives...)
+	return &Builder{gameVersion: gameVersion, mbinCompiler: mbinCompiler, archives: cp}, nil
+}
+
+// SetNote attaches a human-readable note to the artifact.
+func (b *Builder) SetNote(note string) { b.note = note }
+
+// AddItems appends items. Ordering is imposed at emit time, so callers need
+// not sort.
+func (b *Builder) AddItems(items ...domain.Item) { b.items = append(b.items, items...) }
+
+// AddRecipes appends recipes.
+func (b *Builder) AddRecipes(recipes ...domain.Recipe) { b.recipes = append(b.recipes, recipes...) }
+
+// SetEconomy attaches the base-economy section.
+func (b *Builder) SetEconomy(e *domain.Economy) { b.economy = e }
+
+// Artifact assembles and validates the artifact.
+//
+// Every collection is sorted into a defined order here rather than at the
+// call sites, so determinism is a property of the emitter and cannot be lost
+// by a caller that happened to range over a map.
+func (b *Builder) Artifact() (*domain.Tier1, error) {
+	t := &domain.Tier1{
+		SchemaVersion: domain.CurrentSchemaVersion,
+		GameVersion:   b.gameVersion,
+		Extracted:     true,
+		Source:        fmt.Sprintf("%s via MBINCompiler %s", joinArchives(b.archives), b.mbinCompiler),
+		Note:          b.note,
+		Provenance: &domain.Provenance{
+			Archives:     sortedCopy(b.archives),
+			MBINCompiler: b.mbinCompiler,
+		},
+		Items:   append([]domain.Item(nil), b.items...),
+		Recipes: append([]domain.Recipe(nil), b.recipes...),
+		Economy: b.economy,
+	}
+	sortArtifact(t)
+	if err := t.Validate(); err != nil {
+		return nil, fmt.Errorf("assembling artifact: %w", err)
+	}
+	return t, nil
+}
+
+// sortArtifact imposes a total order on every collection.
+//
+// Governing: SPEC-0004 REQ "Deterministic Output" — the artifact is
+// committed, so unstable ordering turns each regeneration into an
+// unreviewable diff and buries real balance changes in reordering noise.
+// Sort keys are chosen to be total: where one field can repeat, a second
+// breaks the tie.
+func sortArtifact(t *domain.Tier1) {
+	sort.Slice(t.Items, func(i, j int) bool { return t.Items[i].ID < t.Items[j].ID })
+	sort.Slice(t.Recipes, func(i, j int) bool {
+		if t.Recipes[i].Output != t.Recipes[j].Output {
+			return t.Recipes[i].Output < t.Recipes[j].Output
+		}
+		return t.Recipes[i].Method < t.Recipes[j].Method
+	})
+	for _, r := range t.Recipes {
+		sort.Slice(r.Inputs, func(i, j int) bool { return r.Inputs[i].Item < r.Inputs[j].Item })
+	}
+	if t.Economy == nil {
+		return
+	}
+	sort.Slice(t.Economy.Parts, func(i, j int) bool { return t.Economy.Parts[i].ID < t.Economy.Parts[j].ID })
+	for _, p := range t.Economy.Parts {
+		sort.Slice(p.Dependencies, func(i, j int) bool {
+			return p.Dependencies[i].Network < p.Dependencies[j].Network
+		})
+	}
+	sort.Slice(t.Economy.Hotspots, func(i, j int) bool {
+		return t.Economy.Hotspots[i].Category < t.Economy.Hotspots[j].Category
+	})
+	sort.Slice(t.Economy.Crops, func(i, j int) bool { return t.Economy.Crops[i].ID < t.Economy.Crops[j].ID })
+}
+
+// Encode marshals the artifact deterministically.
+func Encode(t *domain.Tier1) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	// Struct field order is fixed by the type, and every slice was sorted by
+	// sortArtifact, so this encoding is stable across runs.
+	if err := enc.Encode(t); err != nil {
+		return nil, fmt.Errorf("encoding artifact: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// WriteFile writes the artifact to path atomically.
+//
+// Governing: SPEC-0004 REQ "Structural Surprise Fails Loudly" — "no artifact
+// file is left behind" when generation fails. Writing to a temporary file in
+// the destination directory and renaming means a reader never observes a
+// half-written artifact, and a failure partway through leaves the previous
+// artifact intact rather than a truncated one.
+func WriteFile(path string, t *domain.Tier1) error {
+	blob, err := Encode(t)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".tier1-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file in %s: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op once the rename succeeds
+
+	if _, err := tmp.Write(blob); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing %s: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing %s: %w", tmpName, err)
+	}
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		return fmt.Errorf("setting mode on %s: %w", tmpName, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("renaming %s to %s: %w", tmpName, path, err)
+	}
+	return nil
+}
+
+func sortedCopy(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}
+
+func joinArchives(a []string) string {
+	s := sortedCopy(a)
+	if len(s) == 1 {
+		return s[0]
+	}
+	return fmt.Sprintf("%d archives (%s …)", len(s), s[0])
+}

--- a/internal/normalize/artifact_test.go
+++ b/internal/normalize/artifact_test.go
@@ -1,0 +1,420 @@
+package normalize_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jonstump/nms-base-planner/internal/domain"
+	"github.com/jonstump/nms-base-planner/internal/normalize"
+)
+
+// Governing: SPEC-0004 REQ "Source Provenance and Version Stamping", REQ
+// "Deterministic Output", REQ "Structural Surprise Fails Loudly", REQ "Error
+// Handling Standards".
+
+func builder(t *testing.T) *normalize.Builder {
+	t.Helper()
+	b, err := normalize.NewBuilder("NMS 5.97", "6.45.0.1", []string{"NMSARC.Precache.pak", "NMSARC.globals.pak"})
+	if err != nil {
+		t.Fatalf("NewBuilder: %v", err)
+	}
+	return b
+}
+
+// A minimal but valid graph: one raw leaf and one craftable that consumes it.
+func seed(b *normalize.Builder) {
+	b.AddItems(
+		domain.Item{ID: "PLANT_SNOW", Name: "Frost Crystal", RawObtainable: true, DefaultMethod: domain.MethodRaw},
+		domain.Item{ID: "FUEL2", Name: "Condensed Carbon", RawObtainable: true, DefaultMethod: domain.MethodRaw},
+		domain.Item{ID: "REACTION1", Name: "Thermic Condensate", DefaultMethod: domain.MethodRefine},
+	)
+	b.AddRecipes(domain.Recipe{
+		Output: "REACTION1", Method: domain.MethodRefine,
+		Inputs: []domain.Input{{Item: "PLANT_SNOW", Quantity: 250}, {Item: "FUEL2", Quantity: 50}},
+	})
+}
+
+// SPEC-0004 REQ "Source Provenance and Version Stamping":
+// WHEN an artifact is generated from a real install
+// THEN extracted is true, game_version names the build read, and source
+// names the archives and the MBINCompiler version used.
+func TestProvenanceIsRecorded(t *testing.T) {
+	b := builder(t)
+	seed(b)
+	art, err := b.Artifact()
+	if err != nil {
+		t.Fatalf("Artifact: %v", err)
+	}
+	if !art.Extracted {
+		t.Error("extracted is false on a generated artifact")
+	}
+	if art.GameVersion != "NMS 5.97" {
+		t.Errorf("game_version = %q, want the build read", art.GameVersion)
+	}
+	if art.Provenance == nil {
+		t.Fatal("provenance is absent")
+	}
+	if art.Provenance.MBINCompiler != "6.45.0.1" {
+		t.Errorf("mbincompiler = %q", art.Provenance.MBINCompiler)
+	}
+	if len(art.Provenance.Archives) != 2 {
+		t.Errorf("archives = %v, want both recorded", art.Provenance.Archives)
+	}
+	if !strings.Contains(art.Source, "6.45.0.1") {
+		t.Errorf("source %q does not name the MBINCompiler version", art.Source)
+	}
+	if art.SchemaVersion != domain.CurrentSchemaVersion {
+		t.Errorf("schema_version = %d, want %d", art.SchemaVersion, domain.CurrentSchemaVersion)
+	}
+}
+
+// SPEC-0004 REQ "Source Provenance and Version Stamping":
+// WHEN the game version cannot be determined from the install
+// THEN generation fails naming what could not be read, and no artifact is
+// written.
+func TestUnknownGameVersionFailsRatherThanGuesses(t *testing.T) {
+	for _, tc := range []struct {
+		name, game, mbin string
+		archives         []string
+	}{
+		{"no game version", "", "6.45.0.1", []string{"a.pak"}},
+		{"no compiler version", "NMS 5.97", "", []string{"a.pak"}},
+		{"no archives", "NMS 5.97", "6.45.0.1", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := normalize.NewBuilder(tc.game, tc.mbin, tc.archives)
+			if err == nil {
+				t.Fatal("NewBuilder accepted missing provenance")
+			}
+			if !errors.Is(err, normalize.ErrSourceMissing) {
+				t.Errorf("error is %v, want ErrSourceMissing", err)
+			}
+		})
+	}
+}
+
+// SPEC-0004 REQ "Deterministic Output":
+// WHEN the normalizer runs twice against an unchanged install
+// THEN the two artifacts are byte-identical.
+//
+// The two builders add the same records in *opposite* order, which is what
+// makes this a test of the emitter rather than of the caller: unstable
+// output would differ here even though the inputs are the same set.
+func TestOutputIsByteIdenticalRegardlessOfInsertionOrder(t *testing.T) {
+	forward := builder(t)
+	forward.AddItems(
+		domain.Item{ID: "AAA", Name: "A", RawObtainable: true, DefaultMethod: domain.MethodRaw},
+		domain.Item{ID: "BBB", Name: "B", RawObtainable: true, DefaultMethod: domain.MethodRaw},
+		domain.Item{ID: "CCC", Name: "C", DefaultMethod: domain.MethodCraft},
+	)
+	forward.AddRecipes(domain.Recipe{
+		Output: "CCC", Method: domain.MethodCraft,
+		Inputs: []domain.Input{{Item: "AAA", Quantity: 1}, {Item: "BBB", Quantity: 2}},
+	})
+
+	reverse := builder(t)
+	reverse.AddItems(
+		domain.Item{ID: "CCC", Name: "C", DefaultMethod: domain.MethodCraft},
+		domain.Item{ID: "BBB", Name: "B", RawObtainable: true, DefaultMethod: domain.MethodRaw},
+		domain.Item{ID: "AAA", Name: "A", RawObtainable: true, DefaultMethod: domain.MethodRaw},
+	)
+	reverse.AddRecipes(domain.Recipe{
+		Output: "CCC", Method: domain.MethodCraft,
+		Inputs: []domain.Input{{Item: "BBB", Quantity: 2}, {Item: "AAA", Quantity: 1}},
+	})
+
+	a1, err := forward.Artifact()
+	if err != nil {
+		t.Fatal(err)
+	}
+	a2, err := reverse.Artifact()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b1, err := normalize.Encode(a1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b2, err := normalize.Encode(a2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(b1, b2) {
+		t.Errorf("encodings differ by insertion order:\n--- forward\n%s\n--- reverse\n%s", b1, b2)
+	}
+}
+
+// Encoding the same artifact twice must not drift either — this is the plain
+// reading of "two runs produce byte-identical output".
+func TestRepeatedEncodingIsStable(t *testing.T) {
+	b := builder(t)
+	seed(b)
+	art, err := b.Artifact()
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := normalize.Encode(art)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range 5 {
+		again, err := normalize.Encode(art)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(first, again) {
+			t.Fatalf("encoding %d differs from the first", i+2)
+		}
+	}
+}
+
+// The artifact carries no clock reading, because one would defeat
+// determinism for no benefit game_version does not already provide.
+func TestArtifactCarriesNoTimestamp(t *testing.T) {
+	b := builder(t)
+	seed(b)
+	art, err := b.Artifact()
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, err := normalize.Encode(art)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, banned := range []string{"generated_at", "timestamp", "2026-", "2026-"} {
+		if bytes.Contains(blob, []byte(banned)) {
+			t.Errorf("artifact contains %q, which would break byte-identical regeneration", banned)
+		}
+	}
+}
+
+// SPEC-0004 REQ "Structural Surprise Fails Loudly":
+// WHEN generation fails partway through THEN no artifact file is left behind.
+//
+// Two halves, because "no artifact left behind" has two failure points. A
+// generation that fails never reaches the writer at all; a write that fails
+// mid-stream must not leave a truncated file at the destination, which is
+// what the temp-file-and-rename buys.
+func TestFailedGenerationNeverReachesTheWriter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tier1.json")
+
+	b := builder(t)
+	seed(b)
+	// A recipe input naming an item no table defines: the graph is not
+	// closed, so assembly must fail before anything is written.
+	b.AddRecipes(domain.Recipe{
+		Output: "REACTION1", Method: domain.MethodCraft,
+		Inputs: []domain.Input{{Item: "NOT_AN_ITEM", Quantity: 1}},
+	})
+
+	art, err := b.Artifact()
+	if err == nil {
+		t.Fatal("Artifact accepted a recipe with a dangling input")
+	}
+	if art != nil {
+		t.Error("Artifact returned a value alongside an error")
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("an artifact exists at %s after a failed generation", path)
+	}
+	assertNoTempFiles(t, dir)
+}
+
+// A write that cannot complete leaves the previous artifact intact and no
+// partial file at the destination.
+func TestFailedWriteLeavesThePreviousArtifactIntact(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tier1.json")
+
+	b := builder(t)
+	seed(b)
+	good, err := b.Artifact()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := normalize.WriteFile(path, good); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the directory read-only so the temp-file creation fails. The
+	// destination must be untouched, not truncated.
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Skipf("cannot make directory read-only here: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0o755) })
+
+	if err := normalize.WriteFile(path, good); err == nil {
+		t.Skip("directory is still writable (running as root?); cannot exercise the failure path")
+	}
+
+	os.Chmod(dir, 0o755)
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the previous artifact is gone after a failed write: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Error("a failed write modified the previously written artifact")
+	}
+	assertNoTempFiles(t, dir)
+}
+
+func assertNoTempFiles(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file %s was left behind", e.Name())
+		}
+	}
+}
+
+// SPEC-0004 REQ "Error Handling Standards":
+// WHEN a caller encounters a missing source table versus an unresolved
+// localisation key THEN the two failures carry different sentinels.
+func TestSentinelsAreDistinguishable(t *testing.T) {
+	all := []error{
+		normalize.ErrSourceMissing,
+		normalize.ErrStructureUnrecognized,
+		normalize.ErrReferenceUnresolved,
+		normalize.ErrLocalisationUnresolved,
+	}
+	for i, a := range all {
+		for j, b := range all {
+			if i != j && errors.Is(a, b) {
+				t.Errorf("sentinels %d and %d are not distinct: %v / %v", i, j, a, b)
+			}
+		}
+	}
+
+	missing := normalize.Missing("nms_reality_gcproducttable")
+	name := normalize.UnresolvedName("nms_reality_gcproducttable", "ULTRAPROD2", "UI_ULTRAPROD_2_NAME_L")
+	if !errors.Is(missing, normalize.ErrSourceMissing) || errors.Is(missing, normalize.ErrLocalisationUnresolved) {
+		t.Error("a missing table is not cleanly distinguishable from an unresolved name")
+	}
+	if !errors.Is(name, normalize.ErrLocalisationUnresolved) || errors.Is(name, normalize.ErrSourceMissing) {
+		t.Error("an unresolved name is not cleanly distinguishable from a missing table")
+	}
+}
+
+// SPEC-0004 REQ "Error Handling Standards":
+// WHEN normalization fails on one row of one table
+// THEN the error names the table, the row's identifier, and the expectation
+// violated.
+func TestErrorNamesTableRowAndExpectation(t *testing.T) {
+	err := normalize.Unrecognized("basebuildingobjectstable", "U_EXTRACTOR_S", "Rate", "an integer", "\"fast\"")
+	msg := err.Error()
+	for _, want := range []string{"basebuildingobjectstable", "U_EXTRACTOR_S", "Rate", "an integer"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q does not name %q", msg, want)
+		}
+	}
+	var se *normalize.SourceError
+	if !errors.As(err, &se) {
+		t.Fatalf("error %v is not a *SourceError", err)
+	}
+	attrs := se.LogAttrs()
+	if len(attrs)%2 != 0 {
+		t.Errorf("LogAttrs returned %d values; key-value pairs must be even", len(attrs))
+	}
+	if se.Table == "" || se.Row == "" {
+		t.Error("SourceError lost its table or row")
+	}
+}
+
+// The economy section round-trips through LoadTier1 with unknown fields
+// disallowed — the constraint that forces schema and producer to move
+// together.
+//
+// SPEC-0004 REQ "Schema Extension and Load Compatibility":
+// WHEN an artifact carrying base-economy sections is passed to LoadTier1
+// THEN it decodes without an unknown-field error and validates.
+func TestEconomySectionLoads(t *testing.T) {
+	b := builder(t)
+	seed(b)
+	b.SetEconomy(&domain.Economy{
+		Parts: []domain.Part{{
+			ID:      "U_EXTRACTOR_S",
+			Primary: domain.Flow{Network: domain.NetworkResources, Rate: 100, Storage: 360000},
+			Dependencies: []domain.Dependency{
+				{Network: domain.NetworkPower, Rate: -50, Effect: "EnablesRate"},
+			},
+			Hotspot: "Mineral1",
+		}},
+		Hotspots: []domain.Hotspot{{
+			Category:   "Mineral1",
+			Strengths:  domain.ClassValues{C: 1, B: 1.5, A: 2, S: 2.5},
+			Weightings: domain.ClassValues{C: 6, B: 4, A: 2, S: 1},
+		}},
+		Crops: []domain.Crop{{
+			ID: "SNOWPLANT", Substance: "PLANT_SNOW",
+			Yield: domain.Range{Min: 50, Max: 50}, GrowthSeconds: 3600,
+		}},
+		Refining: &domain.Refining{
+			ProductsPerCycle: 2, SubstancesPerCycle: 250,
+			ProductsPerCycleSurvival: 1, SubstancesPerCycleSurvival: 100,
+		},
+	})
+	art, err := b.Artifact()
+	if err != nil {
+		t.Fatalf("Artifact: %v", err)
+	}
+	blob, err := normalize.Encode(art)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := domain.LoadTier1(bytes.NewReader(blob))
+	if err != nil {
+		t.Fatalf("LoadTier1 rejected an artifact carrying the economy section: %v", err)
+	}
+	if loaded.Economy == nil {
+		t.Fatal("economy section did not survive the round trip")
+	}
+	if got := loaded.Economy.Crops[0].Yield.Max; got != 50 {
+		t.Errorf("crop yield max = %d, want 50", got)
+	}
+	if got := loaded.Economy.Refining.SubstancesPerCycleSurvival; got != 100 {
+		t.Errorf("survival throughput = %d, want 100", got)
+	}
+}
+
+// A crop yielding an item the artifact does not carry is a dangling
+// reference and must be refused.
+func TestEconomyReferencesAreChecked(t *testing.T) {
+	b := builder(t)
+	seed(b)
+	b.SetEconomy(&domain.Economy{
+		Crops: []domain.Crop{{ID: "SNOWPLANT", Substance: "NOT_AN_ITEM", Yield: domain.Range{Min: 1, Max: 1}}},
+	})
+	if _, err := b.Artifact(); err == nil {
+		t.Fatal("Artifact accepted a crop yielding an unknown item")
+	}
+}
+
+// A part naming a hotspot category the artifact does not carry is likewise
+// dangling — the planner could not scale its rate.
+func TestPartHotspotReferenceIsChecked(t *testing.T) {
+	b := builder(t)
+	seed(b)
+	b.SetEconomy(&domain.Economy{
+		Parts: []domain.Part{{
+			ID:      "U_EXTRACTOR_S",
+			Primary: domain.Flow{Network: domain.NetworkResources, Rate: 100},
+			Hotspot: "NoSuchCategory",
+		}},
+	})
+	if _, err := b.Artifact(); err == nil {
+		t.Fatal("Artifact accepted a part referencing an absent hotspot category")
+	}
+}

--- a/internal/normalize/artifact_test.go
+++ b/internal/normalize/artifact_test.go
@@ -418,3 +418,75 @@ func TestPartHotspotReferenceIsChecked(t *testing.T) {
 		t.Fatal("Artifact accepted a part referencing an absent hotspot category")
 	}
 }
+
+// SPEC-0004 REQ "Deterministic Output": collections are emitted in a
+// defined, stable order — "not map-iteration order".
+//
+// TestOutputIsByteIdenticalRegardlessOfInsertionOrder covers items and
+// recipes, but attaches no Economy and uses distinct input items, so it only
+// ever exercises sort keys that were already total. This covers the nested
+// slices, where a partial key let the caller's order show through: a part
+// with two dependencies on one network sorted only by network, and Validate
+// does not reject the duplicate.
+//
+// It matters for the story that fills Economy — if it builds dependencies by
+// ranging a map, unstable order here turns every regeneration into a
+// spurious diff, which is the failure this requirement exists to prevent.
+func TestEconomyOrderingIsTotalAcrossNestedSlices(t *testing.T) {
+	// Two dependencies on the SAME network, distinguishable only by the
+	// fields the sort has to fall through to.
+	d1 := domain.Dependency{Network: domain.NetworkPower, Rate: -50, Effect: "EnablesRate"}
+	d2 := domain.Dependency{Network: domain.NetworkPower, Rate: -20, Effect: "ReducesRate"}
+	d3 := domain.Dependency{Network: domain.NetworkResources, Rate: -5}
+
+	// Same rate, differing only by effect — the last tiebreaker.
+	e1 := domain.Dependency{Network: domain.NetworkPlantGrowth, Rate: 1, Effect: "Alpha"}
+	e2 := domain.Dependency{Network: domain.NetworkPlantGrowth, Rate: 1, Effect: "Beta"}
+
+	build := func(deps, more []domain.Dependency, ins []domain.Input) []byte {
+		t.Helper()
+		b := builder(t)
+		b.AddItems(
+			domain.Item{ID: "AAA", Name: "A", RawObtainable: true, DefaultMethod: domain.MethodRaw},
+			domain.Item{ID: "CCC", Name: "C", DefaultMethod: domain.MethodCraft},
+		)
+		b.AddRecipes(domain.Recipe{Output: "CCC", Method: domain.MethodCraft, Inputs: ins})
+		b.SetEconomy(&domain.Economy{
+			Parts: []domain.Part{
+				{ID: "PART1", Primary: domain.Flow{Network: domain.NetworkResources, Rate: 10}, Dependencies: deps},
+				{ID: "PART2", Primary: domain.Flow{Network: domain.NetworkPower, Rate: 100}, Dependencies: more},
+			},
+			Crops: []domain.Crop{{ID: "PLANT1", Substance: "AAA", Yield: domain.Range{Min: 1, Max: 3}, GrowthSeconds: 60}},
+		})
+		a, err := b.Artifact()
+		if err != nil {
+			t.Fatalf("Artifact: %v", err)
+		}
+		out, err := normalize.Encode(a)
+		if err != nil {
+			t.Fatalf("Encode: %v", err)
+		}
+		return out
+	}
+
+	// A recipe naming the same input twice is malformed source data, but
+	// Validate accepts it today, so the emitter still has to order it
+	// reproducibly rather than leave it to insertion order.
+	dupIn1 := domain.Input{Item: "AAA", Quantity: 1}
+	dupIn2 := domain.Input{Item: "AAA", Quantity: 7}
+
+	forward := build(
+		[]domain.Dependency{d1, d2, d3},
+		[]domain.Dependency{e1, e2},
+		[]domain.Input{dupIn1, dupIn2},
+	)
+	reverse := build(
+		[]domain.Dependency{d3, d2, d1},
+		[]domain.Dependency{e2, e1},
+		[]domain.Input{dupIn2, dupIn1},
+	)
+
+	if !bytes.Equal(forward, reverse) {
+		t.Errorf("encodings differ by insertion order:\n--- forward\n%s\n--- reverse\n%s", forward, reverse)
+	}
+}

--- a/internal/normalize/errors.go
+++ b/internal/normalize/errors.go
@@ -1,0 +1,119 @@
+// Package normalize turns decompiled No Man's Sky tables into the Tier 1
+// artifact the planner loads.
+//
+// Governing: ADR-0001 (two-tier NMS data ingestion) — the Tier 1 producer.
+// SPEC-0004 REQ "Structural Surprise Fails Loudly", REQ "Error Handling
+// Standards".
+//
+// The posture throughout is fail-closed. The source tables are decompiled
+// from a reverse-engineered format that one game update can move, and a
+// normalizer that skips an unparseable row emits a quietly smaller recipe
+// graph — which surfaces much later as a wrong tree in the planner, with no
+// obvious cause. A named error at generation is the cheap failure; a
+// plausible-looking artifact is the expensive one.
+package normalize
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinels for the failure modes a caller needs to tell apart.
+//
+// Governing: SPEC-0004 REQ "Error Handling Standards"
+var (
+	// ErrSourceMissing means an expected source table or archive is absent.
+	// Usually a wrong path or an incomplete extraction, not corrupt data.
+	ErrSourceMissing = errors.New("source table missing")
+
+	// ErrStructureUnrecognized means a table is present but does not match
+	// the structure this normalizer expects — a missing field, an
+	// unrecognized enum. The expected shape of a game update breaking us.
+	ErrStructureUnrecognized = errors.New("source structure unrecognized")
+
+	// ErrReferenceUnresolved means one record points at another that is not
+	// there — a recipe input naming an item no table defines.
+	ErrReferenceUnresolved = errors.New("reference unresolved")
+
+	// ErrLocalisationUnresolved means a name key did not resolve in the
+	// localisation tables. Distinct from ErrReferenceUnresolved because the
+	// remedy differs: this one usually means the wrong language tables were
+	// read, not that the data is inconsistent.
+	ErrLocalisationUnresolved = errors.New("localisation key unresolved")
+)
+
+// SourceError reports a problem with a specific place in a specific source
+// table. Fields are exposed rather than pre-formatted so a structured logger
+// can emit them as key-value pairs instead of scraping a message string.
+//
+// Mirrors the shape of hgpak.StructureError deliberately: the two packages
+// sit next to each other in one pipeline, and a caller that has learned to
+// read one should not have to learn a second vocabulary.
+type SourceError struct {
+	// Table names the source table, e.g. "nms_reality_gcproducttable".
+	Table string
+	// Row identifies the record within it, e.g. "ULTRAPROD2". Empty when
+	// the fault is with the table as a whole.
+	Row string
+	// Field names the specific field at fault, when there is one.
+	Field string
+	// Want and Got carry the expectation that was violated.
+	Want, Got any
+	// Err is the sentinel this wraps.
+	Err error
+}
+
+func (e *SourceError) Error() string {
+	loc := e.Table
+	if e.Row != "" {
+		loc += ": " + e.Row
+	}
+	if e.Field != "" {
+		loc += ": " + e.Field
+	}
+	if e.Want == nil && e.Got == nil {
+		return fmt.Sprintf("%s: %v", loc, e.Err)
+	}
+	return fmt.Sprintf("%s: got %v, want %v: %v", loc, e.Got, e.Want, e.Err)
+}
+
+func (e *SourceError) Unwrap() error { return e.Err }
+
+// LogAttrs returns the error's fields as alternating key-value pairs, ready
+// to splat into a structured logger.
+func (e *SourceError) LogAttrs() []any {
+	attrs := []any{"table", e.Table}
+	if e.Row != "" {
+		attrs = append(attrs, "row", e.Row)
+	}
+	if e.Field != "" {
+		attrs = append(attrs, "field", e.Field)
+	}
+	if e.Want != nil {
+		attrs = append(attrs, "want", e.Want)
+	}
+	if e.Got != nil {
+		attrs = append(attrs, "got", e.Got)
+	}
+	return append(attrs, "cause", e.Err.Error())
+}
+
+// Missing reports an absent source table.
+func Missing(table string) error {
+	return &SourceError{Table: table, Err: ErrSourceMissing}
+}
+
+// Unrecognized reports a table whose structure does not match expectation.
+func Unrecognized(table, row, field string, want, got any) error {
+	return &SourceError{Table: table, Row: row, Field: field, Want: want, Got: got, Err: ErrStructureUnrecognized}
+}
+
+// Unresolved reports a record referencing something no table defines.
+func Unresolved(table, row, field string, got any) error {
+	return &SourceError{Table: table, Row: row, Field: field, Got: got, Err: ErrReferenceUnresolved}
+}
+
+// UnresolvedName reports a name key absent from the localisation tables.
+func UnresolvedName(table, row string, key string) error {
+	return &SourceError{Table: table, Row: row, Field: "name", Got: key, Err: ErrLocalisationUnresolved}
+}


### PR DESCRIPTION
Closes #22
Part of #21

Implements SPEC-0004 REQ "Schema Extension and Load Compatibility", REQ "Source Provenance and Version Stamping", REQ "Deterministic Output", REQ "Structural Surprise Fails Loudly", REQ "Error Handling Standards".

The foundation for the Tier 1 normalizer: the schema it emits into, the provenance envelope, the sentinel vocabulary, and a deterministic atomic writer. #23 and #24 fill it; this PR is the shape they fill.

## The schema and its fixtures move together

`LoadTier1` decodes with `DisallowUnknownFields`, so a producer emitting sections the struct does not declare yields artifacts that fail to load. `SchemaVersion` goes **1 → 2**, `Validate` now refuses an artifact from the other side of that change rather than half-reading it, and both committed fixtures plus two inline test artifacts are migrated in the same commit.

Verified: `hexaberry-cake.tier1.json` and `stasis-device.tier1.json` both load and validate at schema 2, with 7/4 and 35/25 items/recipes respectively.

## Economy section mirrors the source, not a tidier abstraction

`internal/domain/economy.go` carries what the 2026-08-18 finding correction made extractable:

- **Flows** keyed by network (`power`, `resources`, `plant_growth`, `byte_beat`) with rate and storage — because a part participates in several networks and a single "rate" field would lose which one
- **`ClassValues`** hanging off **hotspot categories**, not devices — class is a property of the hotspot, which is why searching parts for `_C`/`_B`/`_A` finds nothing
- **`Range`** for crop yields, keeping both bounds even when equal, so a later widening in the game data is a visible change rather than a silent one
- **`Refining`** carrying both standard and Survival throughput — settling the design's open question by letting the planner choose rather than assuming Normal

Cross-references are validated: a crop yielding an unknown item, or a part naming an absent hotspot category, is refused.

## Determinism belongs to the emitter, not the callers

`sortArtifact` imposes a total order at assembly, so a caller that ranged over a map still produces stable output. The test builds the same artifact from **opposite insertion orders** and asserts the encodings are byte-identical — which is what makes it a test of the emitter rather than of the caller.

The artifact deliberately carries **no generation timestamp**. One would defeat byte-identical regeneration for no benefit `game_version` does not already provide, and a test asserts its absence so nobody adds one later thinking it is free.

## Fail-closed, in two places

"No artifact file is left behind" has two failure points, so there are two tests:

- **Generation fails** → never reaches the writer. A recipe with a dangling input fails assembly; no file appears.
- **Write fails** → previous artifact intact. `WriteFile` is temp-file-and-rename, so a mid-stream failure leaves the prior artifact rather than a truncated one, and a reader never observes a half-written file. Exercised by making the directory read-only.

Both tests **pass** rather than skip on this machine — worth noting since the second one skips if run as root.

## Sentinels mirror hgpak deliberately

Four sentinels — source missing, structure unrecognized, reference unresolved, localisation key unresolved — plus a `SourceError` carrying `Table`/`Row`/`Field`/`Want`/`Got` and a `LogAttrs()` helper.

The shape intentionally mirrors `hgpak.StructureError`, which I found via the qmd code pre-search rather than by memory. The two packages sit in one pipeline; a caller who has learned to read one error vocabulary should not have to learn a second.

Localisation gets its own sentinel rather than folding into "reference unresolved" because the remedy differs: it usually means the wrong language tables were read, not that the data is inconsistent.

## Verification

| Check | Result |
|---|---|
| `go test ./...` | all packages ok |
| `go test -race ./...` | all packages ok |
| `gofmt -l .` | no output |
| `go vet ./...` | clean |
| `staticcheck` (v0.8.0-rc.1) | exit 0 |
| Fixtures load at schema 2 | both, verified explicitly |

## Note on scope

This story owns the envelope, not the parsing. There is no table reader here — `Builder` accumulates items, recipes and economy from whatever fills it, and #23/#24 are what fill it. The sentinels and `SourceError` exist now so those stories inherit a vocabulary rather than inventing two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
