### PR TITLE
docs: amend SPEC-0001, SPEC-0002 and SPEC-0004 for ADR-0005

### DIFF
--- a/docs/openspec/specs/rollup-engine/design.md
+++ b/docs/openspec/specs/rollup-engine/design.md
@@ -63,6 +63,28 @@ Rounding up is not an arithmetic preference but a physical fact: you cannot buil
 - *Floating point with epsilon comparison*: pushes tolerance decisions into every test and every comparison, and the epsilon is a lie that eventually bites.
 - *Fixed-point decimal*: workable, but rationals express the class multipliers more directly and Go's `math/big.Rat` is available without a dependency.
 
+### Recipe selection is the engine's job, not the artifact's
+
+**Choice**: The Tier 1 artifact carries every recipe the game defines for an output and method. The engine picks one — smallest raw-input total, ties broken by a stable recipe id — and the view may override it per node.
+
+**Rationale**: ADR-0005 records the discovery that forced this: 261 of 403 refiner output/method pairs have more than one recipe, up to 61 for a single item. Sodium Nitrate has 26. An artifact that carried only one would be discarding most of the refining graph, and a planner whose answer to "how do I make this?" is one arbitrary route is not doing the job the tree canvas exists to do.
+
+Selection belongs in the engine rather than in the normalizer because it depends on the *expansion* — the raw-input total of a candidate is only knowable by resolving it — and because it is a user-facing choice. ADR-0004 keeps the view rendering rather than computing, so the view surfaces alternatives and reports a selection; it does not evaluate them.
+
+**Trade-off**: The default rule costs more work per node than picking the only option, since candidates must be resolved before they can be compared. Acceptable — the comparison is over already-memoized subtrees, and correctness here is worth more than the saved traversal.
+
+**Alternative considered**: Let the normalizer pick and emit one recipe. Rejected in ADR-0005 — it discards the alternatives invisibly, and the planner cannot offer what the artifact does not carry.
+
+### Yield is part of exactness, not separate from it
+
+**Choice**: A recipe's output quantity is a first-class field, and demand-to-batch arithmetic is exact.
+
+**Rationale**: 156 of 1,681 refiner recipes produce a quantity other than one, up to 250. `1x Crystal Sulphide -> 50x Sodium Nitrate` is representative. The engine's exactness commitment was written for input quantities and non-integer multipliers; a yield of 50 handled as floating-point division reintroduces exactly the error that commitment exists to prevent, at the last step before the total the user reads.
+
+Rounding a batch count up follows the same reasoning as the physical-unit boundaries: you cannot run 0.4 of a refining cycle.
+
+**Trade-off**: One more place quantities can be wrong, and one more field the normalizer must read correctly. Mitigated by SPEC-0004's requirement that yields come from the source rather than defaulting silently.
+
 ### Tier 2 constants injected, never hardcoded
 
 **Choice**: All economy constants — crop yields, dome capacity, extractor rates per class, generator outputs, class multipliers, draws, depot thresholds and capacities, battery ratios, fauna yield per collection cycle, cycle durations, and steps per nutrient processor — arrive as a parameter.

--- a/docs/openspec/specs/rollup-engine/spec.md
+++ b/docs/openspec/specs/rollup-engine/spec.md
@@ -62,6 +62,41 @@ The engine MUST report which methods are legal for a given node so the view can 
 - **WHEN** a method is requested for a node that has no recipe of that kind in the Tier 1 artifact
 - **THEN** the engine returns an error naming the node and the illegal method, and the plan is left unchanged
 
+### Requirement: Recipe Selection
+
+A method does not identify a recipe. The Tier 1 artifact carries a *list* of recipes per output and method, because the game's refining and cooking data provides many routes to the same item — 261 of 403 output/method pairs, per ADR-0005. Each node MUST therefore resolve to exactly one **recipe**, not merely one method.
+
+The engine MUST select a default recipe deterministically: the candidate whose expansion resolves to the smallest total of raw inputs, with ties broken by a stable recipe identifier. The same artifact and the same target MUST select the same default on every run, on every machine.
+
+The engine MUST report which recipes are legal for a node's chosen method, alongside the legal methods, so the view can offer the alternatives rather than presenting one route as though it were the only one. Changing a node's recipe MUST change that node's expansion and MUST trigger recomputation of all totals derived from it, exactly as changing its method does.
+
+A node using its default recipe MUST be representable without recording a selection, so that plan state carries only deliberate overrides.
+
+#### Scenario: A node with alternatives selects deterministically
+
+- **WHEN** a node's item has more than one recipe for its chosen method
+- **THEN** the engine expands the candidate with the smallest raw-input total, and repeated runs over the same artifact select the same one
+
+#### Scenario: Alternatives are reported, not hidden
+
+- **WHEN** the view asks for a node's options
+- **THEN** it receives every legal recipe for the chosen method, not only the selected one
+
+#### Scenario: Recipe change alters expansion
+
+- **WHEN** a node's recipe changes to another legal recipe for the same method
+- **THEN** the node's child edges change to that recipe's inputs, and all ancestor quantities are recomputed
+
+#### Scenario: An illegal recipe is rejected
+
+- **WHEN** a recipe is requested for a node that has no such recipe in the Tier 1 artifact
+- **THEN** the engine returns an error naming the node and the recipe, and the plan is left unchanged
+
+#### Scenario: Defaults cost no plan state
+
+- **WHEN** every node in a plan uses its default recipe
+- **THEN** the serialized plan records no recipe selections
+
 #### Scenario: No buy method exists
 
 - **WHEN** any input requests the method `buy`
@@ -104,7 +139,9 @@ The engine MUST detect cycles during graph resolution and MUST return an error n
 
 ### Requirement: Exact Arithmetic and Rounding Discipline
 
-All item quantities MUST be represented as exact integers. Multipliers that are not integers (such as extractor and generator class multipliers) MUST be applied as exact rational arithmetic. The engine MUST NOT accumulate binary floating-point error across the graph.
+All item quantities MUST be represented as exact integers. This includes a recipe's **yield** — the quantity it produces, which is not always one: 156 of 1,681 refiner recipes produce more, up to 250 (ADR-0005). A recipe producing *y* units to satisfy a demand of *n* MUST be applied as exact arithmetic over *n* and *y*, never as a floating-point division.
+
+Multipliers that are not integers (such as extractor and generator class multipliers) MUST be applied as exact rational arithmetic. The engine MUST NOT accumulate binary floating-point error across the graph.
 
 Rounding MUST occur only at stated physical boundaries, and MUST round up, because partial physical units cannot be built. The boundaries are: plants per crop, biodomes per crop, extractors per resource, supply depots per resource, fauna per fauna product, nutrient processors per base, generators per base, and batteries per base.
 

--- a/docs/openspec/specs/tier1-normalizer/design.md
+++ b/docs/openspec/specs/tier1-normalizer/design.md
@@ -104,6 +104,20 @@ graph TD
 
 The four source groups are the reason the normalizer is not a single-table read. Names come from a different archive than products; class scaling comes from `METADATA/SIMULATION/SCANNING/` rather than `METADATA/REALITY/TABLES/`; refiner throughput comes from globals. Each was found only after looking somewhere the first pass had not.
 
+### The normalizer emits every recipe and selects none
+
+**Choice**: All recipes for an output and method are emitted; selection is left to the engine.
+
+**Rationale**: ADR-0005. Choosing requires knowing each candidate's raw-material total, which requires expanding it — work the normalizer does not do and should not start doing, since it would duplicate the engine's traversal and drift from it. Emitting everything also keeps the artifact a faithful record of the source rather than a record of one interpretation of it.
+
+**Trade-off**: A larger artifact. 2,159 recipes rather than roughly 400 if deduplicated. Acceptable: it is a static asset, and the alternative discards most of refining.
+
+### Cooking is a flag, not a table
+
+**Choice**: Read `Cooking` from each refiner recipe rather than treating cooking as a separate source.
+
+**Rationale**: This resolves what was an open question in this design. The refiner table carries both refining and cooking, with a per-recipe boolean distinguishing them — verified against the real table, where `RECIPE_1` (yeast) carries `Cooking` true. There is no separate nutrient-processor source to read.
+
 ## Risks / Trade-offs
 
 - **A game update moves a field.** Likely eventually. Mitigated by failing closed with a named error, so the next update presents as a precise failure rather than corrupt output.
@@ -125,7 +139,6 @@ The hand-authored fixtures stay after step 2, as golden files rather than as the
 ## Open Questions
 
 - Should the artifact be one file or split per section? One file is simpler and matches `LoadTier1` today; splitting would make `git diff` narrower when only economy data changes.
-- Does the cooking table need the same treatment as refining, or does `nutrient processor` output fold into the same `cook` method without a separate source?
 - Refiner throughput is difficulty-dependent (`RefinerSubsMadeInTime` 250 versus 100 on Survival). Does the artifact carry both and let the planner choose, or does the planner assume Normal?
 - Is there a stable machine-readable game version in the install, or does `game_version` have to be derived from pak timestamps and the executable's version string?
 - Biodome crop-slot count is reported as 16 by the community wiki and is not in any table searched. Is it geometric — snap points in the scene — and therefore extractable after all, or genuinely Tier 2?

--- a/docs/openspec/specs/tier1-normalizer/spec.md
+++ b/docs/openspec/specs/tier1-normalizer/spec.md
@@ -61,6 +61,39 @@ Every `Input.item` and every `Recipe.output` MUST reference an `Item.id` present
 
 Items with no recipe MUST be emitted with `raw_obtainable` true and `default_method` `raw`, so the rollup engine's terminal-node handling has the leaves it expects.
 
+**Every recipe the source defines MUST be emitted.** Per ADR-0005 the artifact carries a list of recipes per output and method, not one: 261 of 403 refiner output/method pairs have more than one route, up to 61 for a single item. The normalizer MUST NOT select, deduplicate, or otherwise discard alternatives — selection is the engine's job and depends on expansion the normalizer does not perform.
+
+**Each recipe's yield MUST be read from the source.** 156 of 1,681 refiner recipes produce a quantity other than one, up to 250. A yield MUST NOT default silently to one; where the source does not state it, generation MUST fail rather than assume.
+
+**Refining and cooking come from one table.** The refiner table carries both, distinguished by a per-recipe `Cooking` flag: true yields method `cook`, false yields `refine`. The normalizer MUST read that flag rather than inferring the method from the recipe's contents.
+
+**Self-referential recipes MUST be excluded, and the count recorded.** A recipe naming its own output among its ingredients — `1x Phosphorus + 1x Solanium -> 2x Solanium` — is a doubling strategy rather than a production path, and expanding it is a cycle. There are 27. The normalizer MUST omit them and MUST record how many it omitted in the artifact's provenance, so a change in that number is visible rather than silent.
+
+#### Scenario: Alternatives are all emitted
+
+- **WHEN** the source defines 26 refine recipes producing `CATALYST2`
+- **THEN** the artifact carries all 26, and the normalizer selects none of them
+
+#### Scenario: Yields survive
+
+- **WHEN** a recipe producing 50 units from one input is read
+- **THEN** its yield is 50 in the artifact, not 1
+
+#### Scenario: An absent yield fails rather than defaults
+
+- **WHEN** a recipe's output quantity cannot be read from the source
+- **THEN** generation fails naming the recipe, rather than assuming a yield of one
+
+#### Scenario: Cooking is distinguished by its flag
+
+- **WHEN** a refiner recipe carries `Cooking` true
+- **THEN** its method is `cook`, and a recipe carrying `Cooking` false is `refine`
+
+#### Scenario: Self-referential recipes are excluded and counted
+
+- **WHEN** a recipe names its own output among its ingredients
+- **THEN** it is omitted from the artifact, and the provenance records the omitted count
+
 #### Scenario: The graph is closed
 
 - **WHEN** an artifact is generated

--- a/docs/openspec/specs/wasm-boundary/design.md
+++ b/docs/openspec/specs/wasm-boundary/design.md
@@ -115,6 +115,14 @@ sequenceDiagram
     V->>V: render — no recomputation (ADR-0004)
 ```
 
+### Recipe selection joins method in the plan payload
+
+**Choice**: The per-node recipe choice crosses the boundary as plan state, and defaults encode nothing.
+
+**Rationale**: ADR-0005 makes recipe a user-facing choice, and ADR-0002 puts plan state in the URL hash. Both facts together mean the encoding has to be sparse or the hash grows with graph size rather than with user intent. Making the default deterministic in the engine — rather than "whatever the artifact listed first" — is what allows an unrecorded selection to mean something precise on decode.
+
+**Trade-off**: The decoder must know the engine's default rule to interpret an absent selection, which couples the two more tightly than a fully explicit encoding would. Accepted because the alternative is a hash that grows with every node in a 34-node tree whether or not the user touched it.
+
 ## Risks / Trade-offs
 
 - **Serialize/parse cost on every crossing** → Irrelevant at 34 nodes and one crossing per interaction. Revisit only if a combined tree pushes payloads far beyond current scale, and measure before optimizing.

--- a/docs/openspec/specs/wasm-boundary/spec.md
+++ b/docs/openspec/specs/wasm-boundary/spec.md
@@ -42,7 +42,7 @@ The adapter MUST NOT expose any function that mutates domain state. Every entry 
 
 ### Requirement: Exact Quantity Encoding
 
-Every quantity crossing the boundary MUST be encoded as a decimal string, never as a JavaScript number. This applies to node totals, edge per-unit quantities, target quantity, and every derived count added by later stages.
+Every quantity crossing the boundary MUST be encoded as a decimal string, never as a JavaScript number. This applies to node totals, edge per-unit quantities, target quantity, recipe **yields**, and every derived count added by later stages.
 
 The adapter MUST NOT convert a quantity to `float64` at any point in the encoding path. Where a total is not an exact integer, it MUST be encoded as an exact decimal or rational string that round-trips without loss.
 
@@ -67,6 +67,29 @@ Where the domain reports a value as inexact — `TotalInt` returning `false` per
 
 - **WHEN** the adapter encodes any quantity
 - **THEN** no conversion through `float64` occurs, verified by the absence of such conversions in the encoding code
+
+### Requirement: Recipe Selection Crossing
+
+A node's recipe selection is plan state, exactly as its method is, and MUST cross the boundary in both directions: inbound as part of the plan input, outbound as part of each node's reported options.
+
+Per SPEC-0001 REQ "Recipe Selection" a node using its default recipe is representable without recording a selection. The encoding MUST preserve that: a plan in which every node uses its default MUST encode no recipe selections, so the boundary payload and the URL hash carry only deliberate overrides.
+
+The adapter MUST report each node's legal recipes alongside its legal methods. The view MUST NOT be required to consult the artifact directly to discover alternatives, since that would put domain knowledge in the render layer that ADR-0004 keeps out of it.
+
+#### Scenario: A selection round-trips
+
+- **WHEN** a plan specifying a non-default recipe for one node crosses the boundary and is returned
+- **THEN** that node reports the specified recipe, and its expansion reflects it
+
+#### Scenario: Defaults encode nothing
+
+- **WHEN** a plan in which every node uses its default recipe is encoded
+- **THEN** the payload contains no recipe selections
+
+#### Scenario: Alternatives reach the view
+
+- **WHEN** the view receives a resolved graph
+- **THEN** each node carries its legal recipes for the chosen method, without the view reading the artifact
 
 ### Requirement: Result Envelope
 


### PR DESCRIPTION
Documents only. Applies every amendment [ADR-0005](docs/adrs/ADR-0005-multiple-recipes-per-output.md) named, across all three specs at once.

Amending them separately would leave the producer and the consumer disagreeing about the same artifact — SPEC-0004 emitting recipe lists that SPEC-0001 still says are singular — so they move together.

## SPEC-0001 (rollup engine)

**New REQ "Recipe Selection".** The hinge is that its existing REQ "Method Resolution" says *"each node MUST resolve to exactly one method"* — and with 26 refine recipes for Sodium Nitrate, resolving the method no longer resolves the recipe. The new requirement adds:

- A node resolves to exactly one **recipe**, not merely one method
- The default is deterministic — smallest raw-input total, ties broken by a stable recipe id — and identical across runs and machines
- Legal recipes are reported alongside legal methods, so the view can offer alternatives rather than presenting one route as the only one
- **A node on its default records no selection**, which keeps plan state proportional to user intent rather than to graph size

**REQ "Exact Arithmetic" extends to yield.** 156 of 1,681 refiner recipes produce more than one unit, up to 250. Handling `1x Crystal Sulphide -> 50x Sodium Nitrate` as floating-point division would reintroduce precisely the error that requirement exists to prevent, at the last step before the number the user reads.

## SPEC-0002 (WASM boundary)

**New REQ "Recipe Selection Crossing".** The per-node choice is plan state, so it crosses in both directions; defaults encode nothing; and the adapter reports legal recipes so the view never reads the artifact directly — which would put domain knowledge in the render layer ADR-0004 keeps it out of.

Yield joins the quantities that must cross as decimal strings rather than JS numbers.

## SPEC-0004 (Tier 1 normalizer)

REQ "Recipe Graph Construction" now requires the normalizer to **emit every recipe and select none** — selection depends on expansion the normalizer doesn't perform — to **read yields from the source** rather than defaulting to one, to distinguish cook from refine by the per-recipe `Cooking` flag, and to **exclude self-referential recipes while recording the count** in provenance.

**One open question resolved and removed.** The design doc asked whether cooking needs a separate source. It doesn't — it's a boolean on the refiner recipe, verified against the real table where `RECIPE_1` (yeast) carries `Cooking` true.

## Design docs updated alongside

Each spec's companion explains the *why*, not just the *what*: why selection belongs to the engine rather than the normalizer (it needs the expansion, and it's a user-facing choice), why yield is part of exactness rather than adjacent to it, and why the sparse plan encoding couples the decoder to the engine's default rule — a real trade accepted because the alternative is a URL hash that grows with every node whether the user touched it or not.

## One thing I caught in self-review

Inserting "Recipe Selection" between "Method Resolution" and its scenarios **orphaned them** — the two original scenarios ended up under the new requirement, leaving Method Resolution with none. Caught by a coverage check rather than by reading, and fixed by reattaching them. All three specs now pass: every requirement has at least one scenario, every scenario is at `####`, no `RFC-XXXX` numbering.

| Spec | Requirements | Scenarios |
|---|---|---|
| SPEC-0001 | 12 | 44 |
| SPEC-0002 | 11 | 27 |
| SPEC-0004 | 12 | 29 |

## No code

`internal/domain` still rejects duplicate recipes per output and method. That change — `recipesByOut` becoming `map[string]map[Method][]Recipe`, `Recipe` gaining a yield, `Validate` inverting from reject-duplicates to index-them — lands with the #23 implementation, now that there's a settled contract to write it against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
