### PR TITLE
feat(domain): recipe lists, explicit yields, deterministic selection

### DIFF
--- a/internal/domain/resolve.go
+++ b/internal/domain/resolve.go
@@ -23,6 +23,17 @@ type PlanInput struct {
 	// Methods overrides the per-item default method. Items absent from the
 	// map use their Tier 1 default.
 	Methods map[string]Method
+
+	// Recipes overrides the per-item recipe, keyed by item ID and holding a
+	// recipe ID. Items absent from the map use the engine's default choice.
+	//
+	// Absence is meaningful: SPEC-0001 REQ "Recipe Selection" requires that a
+	// node using its default be representable without recording a selection,
+	// so that plan state — and the URL hash it serializes into — carries only
+	// deliberate overrides.
+	//
+	// Governing: SPEC-0001 REQ "Recipe Selection"
+	Recipes map[string]string
 }
 
 // Edge is one resolved dependency, carrying the per-unit-of-parent quantity.
@@ -31,8 +42,20 @@ type Edge struct {
 	From string
 	// To is the consumed (child) item ID.
 	To string
-	// PerUnit is how many To are needed per single unit of From.
+	// PerUnit is how many To the recipe consumes per application.
 	PerUnit int64
+
+	// Yield is how many From one application produces. Per unit of From the
+	// requirement is therefore PerUnit/Yield, which is rational — 1 Crystal
+	// Sulphide yields 50 Sodium Nitrate, so a unit of Sodium Nitrate costs
+	// one fiftieth of a Crystal Sulphide.
+	//
+	// Kept as a separate integer rather than folded into PerUnit so the edge
+	// still reports what the recipe literally says, and so the division
+	// happens once, exactly, in propagate.
+	//
+	// Governing: SPEC-0001 REQ "Exact Arithmetic and Rounding Discipline"
+	Yield int64
 }
 
 // Node is one item in the resolved graph, with its aggregated total.
@@ -46,6 +69,23 @@ type Node struct {
 	// LegalMethods lists every method available to this item, sorted, so the
 	// view can render unavailable options as inert rather than hiding them.
 	LegalMethods []Method
+
+	// Recipe is the id of the single recipe this node resolved to. Empty for
+	// terminal nodes, which expand through no recipe.
+	//
+	// Governing: SPEC-0001 REQ "Recipe Selection"
+	Recipe string
+
+	// LegalRecipes lists every recipe id available for this node's chosen
+	// method, sorted, so the view can offer the alternatives rather than
+	// presenting one route as though it were the only one.
+	LegalRecipes []string
+
+	// Yield is how many units one application of the resolved recipe
+	// produces. Zero for terminal nodes, which apply no recipe.
+	//
+	// Governing: ADR-0005 (explicit yields)
+	Yield int64
 
 	// Terminal reports that expansion stopped here (method raw).
 	Terminal bool
@@ -84,6 +124,20 @@ func (n *Node) TotalInt() (int64, bool) {
 		return 0, false
 	}
 	return n.total.Num().Int64(), true
+}
+
+// Applications returns how many times this node's recipe must be applied to
+// meet its total, as an exact rational. Nil for a terminal node.
+//
+// Deliberately unrounded: SPEC-0001 REQ "Exact Arithmetic and Rounding
+// Discipline" enumerates the boundaries at which rounding up is allowed, and
+// a recipe application is not one of them. A caller wanting whole batches
+// rounds this value itself, once, at the point it reports them.
+func (n *Node) Applications() *big.Rat {
+	if n.Terminal || n.Yield == 0 {
+		return nil
+	}
+	return new(big.Rat).Quo(n.total, new(big.Rat).SetInt64(n.Yield))
 }
 
 // ResolvedGraph is stage 1's output.
@@ -149,7 +203,7 @@ func Resolve(t *Tier1, in PlanInput) (*ResolvedGraph, error) {
 		return nil, fmt.Errorf("resolving %s: %w: %q", in.Target, ErrUnknownItem, in.Target)
 	}
 
-	r := &resolver{t: t, in: in, state: map[string]dfsState{}, nodes: map[string]*Node{}}
+	r := &resolver{t: t, in: in, state: map[string]dfsState{}, nodes: map[string]*Node{}, costs: map[string]*big.Rat{}}
 	if err := r.walk(in.Target, nil); err != nil {
 		return nil, fmt.Errorf("resolving %s: %w", targetItem.Name, err)
 	}
@@ -172,6 +226,9 @@ func Resolve(t *Tier1, in PlanInput) (*ResolvedGraph, error) {
 }
 
 type resolver struct {
+	// costs memoizes rawCost per item: nil means known-unresolvable.
+	costs map[string]*big.Rat
+
 	t     *Tier1
 	in    PlanInput
 	state map[string]dfsState
@@ -229,11 +286,13 @@ func (r *resolver) walk(id string, path []string) error {
 	}
 
 	if !n.Terminal {
-		rc, ok := r.t.Recipe(id, m)
-		if !ok {
-			// Unreachable via method(), which already validated availability.
-			return fmt.Errorf("expanding %s: %w: no %s recipe", it.Name, ErrIllegalMethod, m)
+		rc, err := r.selectRecipe(it, m)
+		if err != nil {
+			return err
 		}
+		n.Recipe = rc.ID
+		n.Yield = rc.Producing()
+		n.LegalRecipes = r.t.LegalRecipes(id, m)
 		if !rc.IsVerified() {
 			n.Verified = false
 		}
@@ -247,7 +306,7 @@ func (r *resolver) walk(id string, path []string) error {
 
 		child := append(append([]string{}, path...), id)
 		for _, input := range inputs {
-			n.Children = append(n.Children, Edge{From: id, To: input.Item, PerUnit: input.Quantity})
+			n.Children = append(n.Children, Edge{From: id, To: input.Item, PerUnit: input.Quantity, Yield: rc.Producing()})
 			if err := r.walk(input.Item, child); err != nil {
 				if len(path) == 0 {
 					// The target's own frame; Resolve supplies the
@@ -297,7 +356,13 @@ func (r *resolver) propagate(g *ResolvedGraph) {
 		for _, e := range parent.Children {
 			child := g.byID[e.To]
 
-			contribution := new(big.Rat).Mul(parent.total, new(big.Rat).SetInt64(e.PerUnit))
+			// PerUnit is per application of the parent's recipe; Yield is how
+			// many parents one application makes. Dividing here rather than
+			// pre-folding keeps the whole chain exact — 1/50 of a Crystal
+			// Sulphide stays 1/50, not 0.02.
+			// Governing: SPEC-0001 REQ "Exact Arithmetic and Rounding
+			// Discipline".
+			contribution := new(big.Rat).Mul(parent.total, big.NewRat(e.PerUnit, e.Yield))
 			child.total.Add(child.total, contribution)
 
 			// Over-flagging is the honest direction: any unverified

--- a/internal/domain/resolve_test.go
+++ b/internal/domain/resolve_test.go
@@ -188,7 +188,7 @@ func TestTerminalNodesAreNotExpanded(t *testing.T) {
 	if !cc.Terminal || len(cc.Children) != 0 {
 		t.Errorf("cc terminal = %v with %d children, want terminal with none", cc.Terminal, len(cc.Children))
 	}
-	if _, hasRecipe := loadFixture(t).Recipe("cc", MethodRefine); !hasRecipe {
+	if len(loadFixture(t).RecipesFor("cc", MethodRefine)) == 0 {
 		t.Fatal("fixture no longer holds a cc refine recipe, so this scenario is not being exercised")
 	}
 	if got, want := cc.LegalMethods, []Method{MethodRaw, MethodRefine}; !equalMethods(got, want) {
@@ -335,8 +335,8 @@ func TestCycleDetection(t *testing.T) {
 	    {"id":"b","name":"Beta","default_method":"refine"}
 	  ],
 	  "recipes": [
-	    {"output":"a","method":"refine","inputs":[{"item":"b","quantity":1}]},
-	    {"output":"b","method":"refine","inputs":[{"item":"a","quantity":1}]}
+	    {"id":"a_refine","output":"a","method":"refine","inputs":[{"item":"b","quantity":1}]},
+	    {"id":"b_refine","output":"b","method":"refine","inputs":[{"item":"a","quantity":1}]}
 	  ]
 	}`
 	a1, err := LoadTier1(strings.NewReader(cyclic))
@@ -422,10 +422,10 @@ func TestErrorCarriesResolutionPath(t *testing.T) {
 	// not exist. Structural validation catches it at load, so build the
 	// artifact past validation and confirm the walk reports the path.
 	a1 := loadFixture(t)
-	a1.recipesByOut["cp"][MethodCraft] = Recipe{
-		Output: "cp", Method: MethodCraft,
+	a1.recipesByOut["cp"][MethodCraft] = []Recipe{{
+		ID: "cp_craft", Output: "cp", Method: MethodCraft,
 		Inputs: []Input{{Item: "prod999", Quantity: 1}},
-	}
+	}}
 
 	g, err := Resolve(a1, PlanInput{Target: "sd", Quantity: 1})
 	if err == nil {

--- a/internal/domain/select.go
+++ b/internal/domain/select.go
@@ -1,0 +1,142 @@
+package domain
+
+import (
+	"fmt"
+	"math/big"
+)
+
+// Recipe selection.
+//
+// Governing: ADR-0005 (multiple recipes per output), SPEC-0001 REQ "Recipe
+// Selection"
+//
+// A method no longer identifies a recipe: the artifact carries a list,
+// because the game defines many routes to the same item. The engine picks
+// one, deterministically, and the plan may override it per item.
+
+// selectRecipe resolves the single recipe a node expands through.
+//
+// An explicit override wins and is validated. Otherwise the default rule
+// applies: the candidate whose expansion resolves to the smallest total of
+// raw inputs, ties broken by recipe id so the choice is stable across runs
+// and machines.
+func (r *resolver) selectRecipe(it Item, m Method) (Recipe, error) {
+	candidates := r.t.RecipesFor(it.ID, m)
+	if len(candidates) == 0 {
+		return Recipe{}, fmt.Errorf("%w: %s has no %s recipe", ErrIllegalMethod, it.Name, m)
+	}
+
+	if want, overridden := r.in.Recipes[it.ID]; overridden {
+		for _, rc := range candidates {
+			if rc.ID == want {
+				return rc, nil
+			}
+		}
+		return Recipe{}, fmt.Errorf("%w: %s has no %s recipe %q", ErrIllegalMethod, it.Name, m, want)
+	}
+
+	best := candidates[0]
+	bestCost, bestOK := r.recipeCost(best, map[string]bool{it.ID: true})
+	for _, rc := range candidates[1:] {
+		cost, ok := r.recipeCost(rc, map[string]bool{it.ID: true})
+		switch {
+		case ok && !bestOK:
+			// A resolvable candidate always beats an unresolvable one.
+			best, bestCost, bestOK = rc, cost, true
+		case ok == bestOK && better(cost, bestCost, rc.ID, best.ID):
+			best, bestCost = rc, cost
+		}
+	}
+	return best, nil
+}
+
+// better reports whether candidate (cost, id) beats incumbent (bestCost,
+// bestID). Both costs may be nil, meaning unresolvable; ties fall to the
+// lexicographically smaller id so the result never depends on artifact order.
+func better(cost, bestCost *big.Rat, id, bestID string) bool {
+	if cost == nil || bestCost == nil {
+		return id < bestID
+	}
+	if c := cost.Cmp(bestCost); c != 0 {
+		return c < 0
+	}
+	return id < bestID
+}
+
+// recipeCost is the total raw-input quantity needed to apply this recipe once
+// and obtain one unit of its output, as an exact rational.
+//
+// Returns ok=false when the expansion cannot be resolved — an unknown item,
+// or a cycle. An unresolvable candidate is never preferred over a resolvable
+// one, which is what keeps a self-referential recipe from being chosen while
+// still leaving it selectable if it is somehow the only option.
+func (r *resolver) recipeCost(rc Recipe, inProgress map[string]bool) (*big.Rat, bool) {
+	total := new(big.Rat)
+	for _, in := range rc.Inputs {
+		c, ok := r.rawCost(in.Item, inProgress)
+		if !ok {
+			return nil, false
+		}
+		total.Add(total, new(big.Rat).Mul(c, new(big.Rat).SetInt64(in.Quantity)))
+	}
+	// One application yields Producing() units, so the cost of a single unit
+	// is the batch cost divided by the yield — exact, never floating point.
+	return total.Quo(total, new(big.Rat).SetInt64(rc.Producing())), true
+}
+
+// rawCost is the raw-input quantity needed for one unit of an item, memoized.
+//
+// A raw node costs one of itself. Anything else costs the minimum over its
+// available recipes, which is what makes the default rule a genuine
+// smallest-raw-total rather than a first-listed heuristic.
+func (r *resolver) rawCost(id string, inProgress map[string]bool) (*big.Rat, bool) {
+	if c, done := r.costs[id]; done {
+		if c == nil {
+			return nil, false
+		}
+		return c, true
+	}
+	if inProgress[id] {
+		// Revisiting an item still being costed is a cycle. Not memoized:
+		// the same item may cost fine on a path that does not loop.
+		return nil, false
+	}
+
+	it, ok := r.t.Item(id)
+	if !ok {
+		return nil, false
+	}
+	m, err := r.method(it)
+	if err != nil {
+		return nil, false
+	}
+	if m == MethodRaw {
+		one := new(big.Rat).SetInt64(1)
+		r.costs[id] = one
+		return one, true
+	}
+
+	inProgress[id] = true
+	defer delete(inProgress, id)
+
+	var best *big.Rat
+	for _, rc := range r.t.RecipesFor(id, m) {
+		c, ok := r.recipeCost(rc, inProgress)
+		if !ok {
+			continue
+		}
+		if best == nil || c.Cmp(best) < 0 {
+			best = c
+		}
+	}
+	if best == nil {
+		// Memoize the failure only when nothing is in progress beneath it,
+		// so a cycle-induced miss on one path does not poison another.
+		if len(inProgress) == 1 {
+			r.costs[id] = nil
+		}
+		return nil, false
+	}
+	r.costs[id] = best
+	return best, true
+}

--- a/internal/domain/select_test.go
+++ b/internal/domain/select_test.go
@@ -1,0 +1,390 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// load builds a Tier1 from a JSON literal, failing the test if it will not
+// validate. Selection scenarios need artifacts the Stasis fixture cannot
+// express — several recipes for one output and method — so they are written
+// inline rather than added to a fixture other tests assert node counts over.
+func load(t *testing.T, artifact string) *Tier1 {
+	t.Helper()
+	a1, err := LoadTier1(strings.NewReader(artifact))
+	if err != nil {
+		t.Fatalf("loading artifact: %v", err)
+	}
+	return a1
+}
+
+// nitrate is the readable real example from ADR-0005: Sodium Nitrate carries
+// 26 refine recipes, among them 2x Sodium -> 1x and 1x Crystal Sulphide ->
+// 50x. The 24 filler recipes stand in for the rest of the real list; they
+// exist so the list is genuinely long rather than nominally plural.
+func nitrate(t *testing.T) *Tier1 {
+	t.Helper()
+	var recipes []string
+	recipes = append(recipes,
+		`{"id":"CAT2_SODIUM","output":"CATALYST2","method":"refine","inputs":[{"item":"SODIUM","quantity":2}]}`,
+		`{"id":"CAT2_SULPHIDE","output":"CATALYST2","method":"refine","inputs":[{"item":"SULPHIDE","quantity":1}],"yield":50}`,
+	)
+	var items []string
+	items = append(items,
+		`{"id":"SODIUM","name":"Sodium","raw_obtainable":true,"default_method":"raw"}`,
+		`{"id":"SULPHIDE","name":"Crystal Sulphide","raw_obtainable":true,"default_method":"raw"}`,
+		`{"id":"CATALYST2","name":"Sodium Nitrate","default_method":"refine"}`,
+	)
+	for i := 0; i < 24; i++ {
+		items = append(items, fmt.Sprintf(`{"id":"FILL%02d","name":"Filler %d","raw_obtainable":true,"default_method":"raw"}`, i, i))
+		// Costlier than both real routes, so their presence cannot change
+		// which recipe the default rule picks.
+		recipes = append(recipes, fmt.Sprintf(`{"id":"CAT2_FILL%02d","output":"CATALYST2","method":"refine","inputs":[{"item":"FILL%02d","quantity":100}]}`, i, i))
+	}
+	return load(t, fmt.Sprintf(`{
+	  "schema_version": 2, "game_version": "adr-0005",
+	  "items": [%s],
+	  "recipes": [%s]
+	}`, strings.Join(items, ",\n"), strings.Join(recipes, ",\n")))
+}
+
+// Governing: SPEC-0001 REQ "Recipe Selection" —
+// Scenario "Alternatives are reported, not hidden".
+// ADR-0005: CATALYST2 carries 26 refine recipes.
+func TestManyRecipesForOneOutputLoad(t *testing.T) {
+	a1 := nitrate(t)
+
+	if got := len(a1.RecipesFor("CATALYST2", MethodRefine)); got != 26 {
+		t.Fatalf("refine recipes for CATALYST2 = %d, want 26", got)
+	}
+
+	legal := a1.LegalRecipes("CATALYST2", MethodRefine)
+	if len(legal) != 26 {
+		t.Fatalf("legal recipes = %d, want 26", len(legal))
+	}
+	for i := 1; i < len(legal); i++ {
+		if legal[i-1] >= legal[i] {
+			t.Fatalf("legal recipes are not sorted: %q before %q", legal[i-1], legal[i])
+		}
+	}
+
+	// The node reports the whole list, not just the one it took.
+	g, err := Resolve(a1, PlanInput{Target: "CATALYST2", Quantity: 1})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	n, _ := g.Node("CATALYST2")
+	if len(n.LegalRecipes) != 26 {
+		t.Errorf("node legal recipes = %d, want 26", len(n.LegalRecipes))
+	}
+	if n.Recipe == "" {
+		t.Error("node resolved to no recipe")
+	}
+}
+
+// Governing: SPEC-0001 REQ "Exact Arithmetic and Rounding Discipline" —
+// "A recipe producing y units to satisfy a demand of n MUST be applied as
+// exact arithmetic over n and y, never as a floating-point division."
+func TestYieldAppliesExactly(t *testing.T) {
+	a1 := nitrate(t)
+	g, err := Resolve(a1, PlanInput{
+		Target:   "CATALYST2",
+		Quantity: 125,
+		Recipes:  map[string]string{"CATALYST2": "CAT2_SULPHIDE"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// 125 Sodium Nitrate at 50 per application: 2.5 applications, each
+	// consuming one Crystal Sulphide.
+	sul, _ := g.Node("SULPHIDE")
+	if got, want := sul.Total().RatString(), "5/2"; got != want {
+		t.Errorf("Crystal Sulphide total = %s, want %s", got, want)
+	}
+	if _, exact := sul.TotalInt(); exact {
+		t.Error("a fractional total reported itself as an exact integer")
+	}
+
+	nit, _ := g.Node("CATALYST2")
+	if got, want := nit.Applications().RatString(), "5/2"; got != want {
+		t.Errorf("applications = %s, want %s", got, want)
+	}
+	if got := ceil(nit.Applications()); got != 3 {
+		t.Errorf("whole batches = %d, want 3", got)
+	}
+
+	// The demand is met by whole applications, never by 2.5 of them.
+	if got := ceil(nit.Applications()) * nit.Yield; got < 125 {
+		t.Errorf("3 applications yield %d, which does not meet 125", got)
+	}
+}
+
+// ceil rounds a rational up using integer division on its numerator and
+// denominator — the operation the spec permits at a rounding boundary, and
+// the one no float is involved in.
+func ceil(r *big.Rat) int64 {
+	q, m := new(big.Int).QuoRem(r.Num(), r.Denom(), new(big.Int))
+	if m.Sign() > 0 {
+		q.Add(q, big.NewInt(1))
+	}
+	return q.Int64()
+}
+
+// Governing: SPEC-0001 REQ "Recipe Selection" —
+// Scenario "A node with alternatives selects deterministically".
+func TestDefaultRecipeIsTheCheapestInRawTerms(t *testing.T) {
+	g, err := Resolve(nitrate(t), PlanInput{Target: "CATALYST2", Quantity: 1})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	n, _ := g.Node("CATALYST2")
+
+	// 1/50 of a Crystal Sulphide beats 2 Sodium and beats all 24 fillers.
+	if n.Recipe != "CAT2_SULPHIDE" {
+		t.Errorf("default recipe = %q, want CAT2_SULPHIDE", n.Recipe)
+	}
+	if _, reached := g.Node("SODIUM"); reached {
+		t.Error("Sodium was expanded; the Sodium route was not the one selected")
+	}
+	sul, _ := g.Node("SULPHIDE")
+	if got, want := sul.Total().RatString(), "1/50"; got != want {
+		t.Errorf("Crystal Sulphide total = %s, want %s", got, want)
+	}
+}
+
+// Governing: SPEC-0001 REQ "Recipe Selection" — ties broken by a stable
+// recipe identifier, so the choice cannot depend on artifact ordering.
+func TestTiesBreakOnRecipeID(t *testing.T) {
+	// Two routes of identical raw cost. Listed worst-id-first so a
+	// first-wins implementation would pick the other one.
+	const artifact = `{
+	  "schema_version": 2, "game_version": "test-tie",
+	  "items": [
+	    {"id":"x","name":"X","raw_obtainable":true,"default_method":"raw"},
+	    {"id":"y","name":"Y","raw_obtainable":true,"default_method":"raw"},
+	    {"id":"z","name":"Z","default_method":"refine"}
+	  ],
+	  "recipes": [
+	    {"id":"z_via_y","output":"z","method":"refine","inputs":[{"item":"y","quantity":3}]},
+	    {"id":"z_via_x","output":"z","method":"refine","inputs":[{"item":"x","quantity":3}]}
+	  ]
+	}`
+	g, err := Resolve(load(t, artifact), PlanInput{Target: "z", Quantity: 1})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	n, _ := g.Node("z")
+	if n.Recipe != "z_via_x" {
+		t.Errorf("tie-broken recipe = %q, want z_via_x (lexicographically smaller id)", n.Recipe)
+	}
+}
+
+// Governing: SPEC-0001 REQ "Determinism", REQ "Recipe Selection" — "The same
+// artifact and the same target MUST select the same default on every run."
+func TestDefaultSelectionIsStableAcrossRuns(t *testing.T) {
+	a1 := nitrate(t)
+	first := map[string]string{}
+	for run := 0; run < 25; run++ {
+		g, err := Resolve(a1, PlanInput{Target: "CATALYST2", Quantity: 3})
+		if err != nil {
+			t.Fatalf("run %d: %v", run, err)
+		}
+		for _, n := range g.Nodes {
+			if run == 0 {
+				first[n.ItemID] = n.Recipe
+				continue
+			}
+			if n.Recipe != first[n.ItemID] {
+				t.Fatalf("run %d selected %q for %s, run 1 selected %q", run+1, n.Recipe, n.ItemID, first[n.ItemID])
+			}
+		}
+	}
+
+	// The same must hold of the fixture, whose every node has exactly one
+	// candidate — a stability check that passes vacuously there is not one.
+	stasisFirst := map[string]string{}
+	for run := 0; run < 5; run++ {
+		g := resolveStasis(t, 4, nil)
+		for _, n := range g.Nodes {
+			if run == 0 {
+				stasisFirst[n.ItemID] = n.Recipe
+				continue
+			}
+			if n.Recipe != stasisFirst[n.ItemID] {
+				t.Fatalf("stasis run %d selected %q for %s, want %q", run+1, n.Recipe, n.ItemID, stasisFirst[n.ItemID])
+			}
+		}
+	}
+}
+
+// Governing: SPEC-0001 REQ "Recipe Selection" —
+// Scenario "Recipe change alters expansion".
+func TestRecipeOverrideChangesExpansion(t *testing.T) {
+	a1 := nitrate(t)
+	g, err := Resolve(a1, PlanInput{
+		Target:   "CATALYST2",
+		Quantity: 100,
+		Recipes:  map[string]string{"CATALYST2": "CAT2_SODIUM"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	n, _ := g.Node("CATALYST2")
+	if n.Recipe != "CAT2_SODIUM" {
+		t.Fatalf("recipe = %q, want CAT2_SODIUM", n.Recipe)
+	}
+	sod, ok := g.Node("SODIUM")
+	if !ok {
+		t.Fatal("Sodium missing after overriding onto the Sodium route")
+	}
+	if got, _ := sod.TotalInt(); got != 200 {
+		t.Errorf("Sodium total = %d, want 200", got)
+	}
+	if _, reached := g.Node("SULPHIDE"); reached {
+		t.Error("Crystal Sulphide still expanded after the override")
+	}
+}
+
+// Governing: SPEC-0001 REQ "Recipe Selection" —
+// Scenario "An illegal recipe is rejected".
+func TestIllegalRecipeIsRejected(t *testing.T) {
+	g, err := Resolve(nitrate(t), PlanInput{
+		Target:   "CATALYST2",
+		Quantity: 1,
+		Recipes:  map[string]string{"CATALYST2": "CAT2_NOT_A_RECIPE"},
+	})
+	if !errors.Is(err, ErrIllegalMethod) {
+		t.Fatalf("error = %v, want ErrIllegalMethod", err)
+	}
+	if g != nil {
+		t.Error("a graph was returned alongside an error; must be nil")
+	}
+	for _, want := range []string{"Sodium Nitrate", "CAT2_NOT_A_RECIPE"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name %q", err, want)
+		}
+	}
+}
+
+// Governing: SPEC-0001 REQ "Recipe Selection" —
+// Scenario "Defaults cost no plan state".
+func TestDefaultsCostNoPlanState(t *testing.T) {
+	in := PlanInput{Target: "sd", Quantity: 1}
+	g, err := Resolve(loadFixture(t), in)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if in.Recipes != nil {
+		t.Fatal("resolving mutated the plan input")
+	}
+	// Every non-terminal node still resolved to a named recipe, so "no
+	// selections recorded" is about plan state, not about missing data.
+	for _, n := range g.Nodes {
+		switch {
+		case n.Terminal && n.Recipe != "":
+			t.Errorf("terminal node %s carries recipe %q", n.ItemID, n.Recipe)
+		case !n.Terminal && n.Recipe == "":
+			t.Errorf("node %s resolved to no recipe", n.ItemID)
+		}
+	}
+}
+
+// A self-referential recipe must not be chosen while another route exists.
+// The refiner data contains them (ADR-0005), so this is a live condition
+// rather than a hypothetical one.
+func TestSelfReferentialRecipeIsNotPreferred(t *testing.T) {
+	const artifact = `{
+	  "schema_version": 2, "game_version": "test-self",
+	  "items": [
+	    {"id":"raw","name":"Raw","raw_obtainable":true,"default_method":"raw"},
+	    {"id":"a","name":"Alpha","default_method":"refine"}
+	  ],
+	  "recipes": [
+	    {"id":"a_self","output":"a","method":"refine","inputs":[{"item":"a","quantity":1}],"yield":2},
+	    {"id":"a_raw","output":"a","method":"refine","inputs":[{"item":"raw","quantity":9999}]}
+	  ]
+	}`
+	g, err := Resolve(load(t, artifact), PlanInput{Target: "a", Quantity: 1})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	n, _ := g.Node("a")
+	// a_self sorts first by id and is far cheaper on its face, so both the
+	// cost rule and the tie-break point at it. Only the cycle guard in
+	// rawCost rules it out — without one, costing it does not terminate.
+	if n.Recipe != "a_raw" {
+		t.Errorf("recipe = %q, want a_raw; the self-referential recipe was preferred", n.Recipe)
+	}
+}
+
+// Governing: SPEC-0001 REQ "Recipe Selection" — the recipe id is what a plan
+// records, so an artifact that leaves it absent or ambiguous is unusable.
+func TestRecipeIdentityIsValidated(t *testing.T) {
+	const head = `{"schema_version":2,"game_version":"test-ids",
+	  "items":[{"id":"x","name":"X","raw_obtainable":true,"default_method":"raw"},
+	           {"id":"z","name":"Z","default_method":"refine"}],
+	  "recipes":[`
+	cases := []struct {
+		name    string
+		recipes string
+		want    string
+	}{
+		{
+			name:    "no id",
+			recipes: `{"output":"z","method":"refine","inputs":[{"item":"x","quantity":1}]}`,
+			want:    "has no id",
+		},
+		{
+			name: "duplicate id",
+			recipes: `{"id":"dup","output":"z","method":"refine","inputs":[{"item":"x","quantity":1}]},
+			          {"id":"dup","output":"z","method":"refine","inputs":[{"item":"x","quantity":2}]}`,
+			want: `duplicate recipe id "dup"`,
+		},
+		{
+			name:    "negative yield",
+			recipes: `{"id":"z_x","output":"z","method":"refine","inputs":[{"item":"x","quantity":1}],"yield":-5}`,
+			want:    "yield must be positive",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := LoadTier1(strings.NewReader(head + tc.recipes + "]}"))
+			if !errors.Is(err, ErrInvalidArtifact) {
+				t.Fatalf("error = %v, want ErrInvalidArtifact", err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// Two recipes for one output and method must load — the condition the old
+// schema rejected outright, and the whole reason for ADR-0005.
+func TestTwoRecipesForOneOutputAndMethodLoad(t *testing.T) {
+	const artifact = `{
+	  "schema_version": 2, "game_version": "test-plural",
+	  "items": [
+	    {"id":"x","name":"X","raw_obtainable":true,"default_method":"raw"},
+	    {"id":"z","name":"Z","default_method":"refine"}
+	  ],
+	  "recipes": [
+	    {"id":"z_a","output":"z","method":"refine","inputs":[{"item":"x","quantity":1}]},
+	    {"id":"z_b","output":"z","method":"refine","inputs":[{"item":"x","quantity":2}]}
+	  ]
+	}`
+	a1 := load(t, artifact)
+	if got := len(a1.RecipesFor("z", MethodRefine)); got != 2 {
+		t.Fatalf("recipes = %d, want 2", got)
+	}
+	if _, ok := a1.Recipe("z", MethodRefine, "z_b"); !ok {
+		t.Error("Recipe could not retrieve z_b by id")
+	}
+	if _, ok := a1.Recipe("z", MethodRefine, "z_missing"); ok {
+		t.Error("Recipe returned a value for an id the artifact does not carry")
+	}
+}

--- a/internal/domain/testdata/hexaberry-cake.tier1.json
+++ b/internal/domain/testdata/hexaberry-cake.tier1.json
@@ -17,9 +17,9 @@
   ],
 
   "recipes": [
-    { "output": "flour",  "method": "cook", "inputs": [{ "item": "wheat", "quantity": 5 }] },
-    { "output": "butter", "method": "cook", "inputs": [{ "item": "milk",  "quantity": 4 }] },
-    { "output": "batter", "method": "cook", "inputs": [{ "item": "flour", "quantity": 2 }, { "item": "egg", "quantity": 3 }] },
-    { "output": "cake",   "method": "cook", "inputs": [{ "item": "batter", "quantity": 1 }, { "item": "butter", "quantity": 1 }] }
+    { "id": "flour_cook", "output": "flour", "method": "cook", "inputs": [{ "item": "wheat", "quantity": 5 }] },
+    { "id": "butter_cook", "output": "butter", "method": "cook", "inputs": [{ "item": "milk",  "quantity": 4 }] },
+    { "id": "batter_cook", "output": "batter", "method": "cook", "inputs": [{ "item": "flour", "quantity": 2 }, { "item": "egg", "quantity": 3 }] },
+    { "id": "cake_cook", "output": "cake", "method": "cook", "inputs": [{ "item": "batter", "quantity": 1 }, { "item": "butter", "quantity": 1 }] }
   ]
 }

--- a/internal/domain/testdata/stasis-device.tier1.json
+++ b/internal/domain/testdata/stasis-device.tier1.json
@@ -45,41 +45,41 @@
   ],
 
   "recipes": [
-    { "output": "hc",  "method": "craft",  "inputs": [{ "item": "fc", "quantity": 100 }, { "item": "sol", "quantity": 200 }] },
+    { "id": "hc_craft", "output": "hc", "method": "craft",  "inputs": [{ "item": "fc", "quantity": 100 }, { "item": "sol", "quantity": 200 }] },
 
-    { "output": "cc",  "method": "refine", "inputs": [{ "item": "car", "quantity": 2 }] },
+    { "id": "cc_refine", "output": "cc", "method": "refine", "inputs": [{ "item": "car", "quantity": 2 }] },
 
-    { "output": "gla", "method": "craft",  "inputs": [{ "item": "fc", "quantity": 40 }] },
-    { "output": "gla", "method": "refine", "inputs": [{ "item": "fc", "quantity": 250 }] },
+    { "id": "gla_craft", "output": "gla", "method": "craft",  "inputs": [{ "item": "fc", "quantity": 40 }] },
+    { "id": "gla_refine", "output": "gla", "method": "refine", "inputs": [{ "item": "fc", "quantity": 250 }] },
 
-    { "output": "pf",  "method": "craft",  "inputs": [{ "item": "cf", "quantity": 100 }, { "item": "sb", "quantity": 200 }] },
-    { "output": "lub", "method": "craft",  "inputs": [{ "item": "fae", "quantity": 50 }, { "item": "gr", "quantity": 400 }] },
+    { "id": "pf_craft", "output": "pf", "method": "craft",  "inputs": [{ "item": "cf", "quantity": 100 }, { "item": "sb", "quantity": 200 }] },
+    { "id": "lub_craft", "output": "lub", "method": "craft",  "inputs": [{ "item": "fae", "quantity": 50 }, { "item": "gr", "quantity": 400 }] },
 
-    { "output": "ec",  "method": "craft",  "inputs": [{ "item": "sul", "quantity": 250 }, { "item": "cc", "quantity": 50 }] },
-    { "output": "ec",  "method": "refine", "inputs": [{ "item": "sul", "quantity": 300 }] },
+    { "id": "ec_craft", "output": "ec", "method": "craft",  "inputs": [{ "item": "sul", "quantity": 250 }, { "item": "cc", "quantity": 50 }] },
+    { "id": "ec_refine", "output": "ec", "method": "refine", "inputs": [{ "item": "sul", "quantity": 300 }] },
 
-    { "output": "ns",  "method": "craft",  "inputs": [{ "item": "nit", "quantity": 250 }, { "item": "cc", "quantity": 50 }] },
-    { "output": "ns",  "method": "refine", "inputs": [{ "item": "nit", "quantity": 300 }] },
+    { "id": "ns_craft", "output": "ns", "method": "craft",  "inputs": [{ "item": "nit", "quantity": 250 }, { "item": "cc", "quantity": 50 }] },
+    { "id": "ns_refine", "output": "ns", "method": "refine", "inputs": [{ "item": "nit", "quantity": 300 }] },
 
-    { "output": "tc",  "method": "craft",  "inputs": [{ "item": "rad", "quantity": 250 }, { "item": "cc", "quantity": 50 }] },
-    { "output": "tc",  "method": "refine", "inputs": [{ "item": "rad", "quantity": 300 }] },
+    { "id": "tc_craft", "output": "tc", "method": "craft",  "inputs": [{ "item": "rad", "quantity": 250 }, { "item": "cc", "quantity": 50 }] },
+    { "id": "tc_refine", "output": "tc", "method": "refine", "inputs": [{ "item": "rad", "quantity": 300 }] },
 
-    { "output": "aro", "method": "craft",  "inputs": [{ "item": "par", "quantity": 50 }, { "item": "ion", "quantity": 50 }] },
-    { "output": "mg",  "method": "craft",  "inputs": [{ "item": "pho", "quantity": 50 }, { "item": "ion", "quantity": 50 }] },
-    { "output": "gra", "method": "craft",  "inputs": [{ "item": "dio", "quantity": 50 }, { "item": "ion", "quantity": 50 }] },
+    { "id": "aro_craft", "output": "aro", "method": "craft",  "inputs": [{ "item": "par", "quantity": 50 }, { "item": "ion", "quantity": 50 }] },
+    { "id": "mg_craft", "output": "mg", "method": "craft",  "inputs": [{ "item": "pho", "quantity": 50 }, { "item": "ion", "quantity": 50 }] },
+    { "id": "gra_craft", "output": "gra", "method": "craft",  "inputs": [{ "item": "dio", "quantity": 50 }, { "item": "ion", "quantity": 50 }] },
 
-    { "output": "cb",  "method": "craft",  "inputs": [{ "item": "hc", "quantity": 1 }, { "item": "pf", "quantity": 1 }] },
-    { "output": "lg",  "method": "craft",  "inputs": [{ "item": "gla", "quantity": 5 }, { "item": "lub", "quantity": 1 }] },
-    { "output": "hi",  "method": "craft",  "inputs": [{ "item": "ns", "quantity": 1 }, { "item": "ec", "quantity": 1 }] },
-    { "output": "sem", "method": "craft",  "inputs": [{ "item": "tc", "quantity": 1 }, { "item": "ns", "quantity": 1 }] },
+    { "id": "cb_craft", "output": "cb", "method": "craft",  "inputs": [{ "item": "hc", "quantity": 1 }, { "item": "pf", "quantity": 1 }] },
+    { "id": "lg_craft", "output": "lg", "method": "craft",  "inputs": [{ "item": "gla", "quantity": 5 }, { "item": "lub", "quantity": 1 }] },
+    { "id": "hi_craft", "output": "hi", "method": "craft",  "inputs": [{ "item": "ns", "quantity": 1 }, { "item": "ec", "quantity": 1 }] },
+    { "id": "sem_craft", "output": "sem", "method": "craft",  "inputs": [{ "item": "tc", "quantity": 1 }, { "item": "ns", "quantity": 1 }] },
 
-    { "output": "sup", "method": "craft",  "inputs": [{ "item": "sem", "quantity": 1 }, { "item": "ec", "quantity": 1 }] },
-    { "output": "cp",  "method": "craft",  "inputs": [{ "item": "hi", "quantity": 1 }, { "item": "tc", "quantity": 1 }] },
+    { "id": "sup_craft", "output": "sup", "method": "craft",  "inputs": [{ "item": "sem", "quantity": 1 }, { "item": "ec", "quantity": 1 }] },
+    { "id": "cp_craft", "output": "cp", "method": "craft",  "inputs": [{ "item": "hi", "quantity": 1 }, { "item": "tc", "quantity": 1 }] },
 
-    { "output": "qp",  "method": "craft",  "inputs": [{ "item": "cb", "quantity": 1 }, { "item": "sup", "quantity": 1 }] },
-    { "output": "cry", "method": "craft",  "inputs": [{ "item": "lg", "quantity": 1 }, { "item": "cp", "quantity": 1 }] },
-    { "output": "iri", "method": "craft",  "inputs": [{ "item": "aro", "quantity": 1 }, { "item": "mg", "quantity": 1 }, { "item": "gra", "quantity": 1 }] },
+    { "id": "qp_craft", "output": "qp", "method": "craft",  "inputs": [{ "item": "cb", "quantity": 1 }, { "item": "sup", "quantity": 1 }] },
+    { "id": "cry_craft", "output": "cry", "method": "craft",  "inputs": [{ "item": "lg", "quantity": 1 }, { "item": "cp", "quantity": 1 }] },
+    { "id": "iri_craft", "output": "iri", "method": "craft",  "inputs": [{ "item": "aro", "quantity": 1 }, { "item": "mg", "quantity": 1 }, { "item": "gra", "quantity": 1 }] },
 
-    { "output": "sd",  "method": "craft",  "inputs": [{ "item": "qp", "quantity": 1 }, { "item": "cry", "quantity": 1 }, { "item": "iri", "quantity": 1 }] }
+    { "id": "sd_craft", "output": "sd", "method": "craft",  "inputs": [{ "item": "qp", "quantity": 1 }, { "item": "cry", "quantity": 1 }, { "item": "iri", "quantity": 1 }] }
   ]
 }

--- a/internal/domain/tier1.go
+++ b/internal/domain/tier1.go
@@ -65,10 +65,34 @@ type Input struct {
 
 // Recipe produces one unit of Output by Method from Inputs.
 type Recipe struct {
-	Output   string  `json:"output"`
-	Method   Method  `json:"method"`
-	Inputs   []Input `json:"inputs"`
-	Verified *bool   `json:"verified,omitempty"`
+	// ID is the recipe's stable identifier — the source's own where it has
+	// one (RECIPE_1), synthesized otherwise. It is what a plan records when
+	// overriding the default, and what breaks ties in the default rule, so
+	// it MUST be stable across regenerations.
+	//
+	// Governing: SPEC-0001 REQ "Recipe Selection"
+	ID string `json:"id"`
+
+	Output string  `json:"output"`
+	Method Method  `json:"method"`
+	Inputs []Input `json:"inputs"`
+
+	// Yield is how many units of Output one application produces. Absent
+	// means one, which is what crafting always is; refining is not — 156 of
+	// 1,681 refiner recipes produce more, up to 250 (ADR-0005).
+	//
+	// Governing: SPEC-0001 REQ "Exact Arithmetic and Rounding Discipline"
+	Yield int64 `json:"yield,omitempty"`
+
+	Verified *bool `json:"verified,omitempty"`
+}
+
+// Producing returns the recipe's yield, treating absent as one.
+func (r Recipe) Producing() int64 {
+	if r.Yield == 0 {
+		return 1
+	}
+	return r.Yield
 }
 
 // IsVerified reports the recipe's provenance, defaulting to verified.
@@ -127,7 +151,7 @@ type Tier1 struct {
 
 	// Derived indexes, built by Validate.
 	itemsByID    map[string]Item
-	recipesByOut map[string]map[Method]Recipe
+	recipesByOut map[string]map[Method][]Recipe
 	legalMethods map[string][]Method
 }
 
@@ -176,7 +200,7 @@ func (t *Tier1) Validate() error {
 		t.itemsByID[it.ID] = it
 	}
 
-	t.recipesByOut = make(map[string]map[Method]Recipe)
+	t.recipesByOut = make(map[string]map[Method][]Recipe)
 	for _, rc := range t.Recipes {
 		if _, ok := t.itemsByID[rc.Output]; !ok {
 			return fmt.Errorf("%w: recipe output %q: %w", ErrInvalidArtifact, rc.Output, ErrUnknownItem)
@@ -186,6 +210,12 @@ func (t *Tier1) Validate() error {
 		}
 		if rc.Method == MethodRaw {
 			return fmt.Errorf("%w: recipe for %q declares method raw, which is terminal by definition", ErrInvalidArtifact, rc.Output)
+		}
+		if rc.ID == "" {
+			return fmt.Errorf("%w: recipe for %q has no id; a plan cannot name it", ErrInvalidArtifact, rc.Output)
+		}
+		if rc.Yield < 0 {
+			return fmt.Errorf("%w: recipe %q yield must be positive, got %d", ErrInvalidArtifact, rc.ID, rc.Yield)
 		}
 		if len(rc.Inputs) == 0 {
 			return fmt.Errorf("%w: recipe for %q has no inputs", ErrInvalidArtifact, rc.Output)
@@ -198,15 +228,20 @@ func (t *Tier1) Validate() error {
 				return fmt.Errorf("%w: recipe for %q input %q: quantity must be positive, got %d", ErrInvalidArtifact, rc.Output, in.Item, in.Quantity)
 			}
 		}
+		// Many recipes may produce the same item by the same method — 261 of
+		// 403 refiner output/method pairs do (ADR-0005). What must be unique
+		// is the recipe id, since that is what a plan records to name one.
 		byMethod, ok := t.recipesByOut[rc.Output]
 		if !ok {
-			byMethod = make(map[Method]Recipe)
+			byMethod = make(map[Method][]Recipe)
 			t.recipesByOut[rc.Output] = byMethod
 		}
-		if _, dup := byMethod[rc.Method]; dup {
-			return fmt.Errorf("%w: duplicate %s recipe for %q", ErrInvalidArtifact, rc.Method, rc.Output)
+		for _, prev := range byMethod[rc.Method] {
+			if prev.ID == rc.ID {
+				return fmt.Errorf("%w: duplicate recipe id %q for %q", ErrInvalidArtifact, rc.ID, rc.Output)
+			}
 		}
-		byMethod[rc.Method] = rc
+		byMethod[rc.Method] = append(byMethod[rc.Method], rc)
 	}
 
 	// An item's default method must actually be available to it.
@@ -270,8 +305,39 @@ func (t *Tier1) LegalMethods(id string) []Method {
 	return out
 }
 
-// Recipe returns the recipe producing id by method m.
-func (t *Tier1) Recipe(id string, m Method) (Recipe, bool) {
-	rc, ok := t.recipesByOut[id][m]
-	return rc, ok
+// RecipesFor returns every recipe producing id by method m, in artifact
+// order. Named to avoid colliding with the Recipes field.
+//
+// Governing: SPEC-0001 REQ "Recipe Selection" — a method does not identify a
+// recipe; the artifact carries a list because the game does.
+func (t *Tier1) RecipesFor(id string, m Method) []Recipe {
+	rs := t.recipesByOut[id][m]
+	out := make([]Recipe, len(rs))
+	copy(out, rs)
+	return out
+}
+
+// Recipe returns the recipe with the given id producing item by method m.
+func (t *Tier1) Recipe(item string, m Method, recipeID string) (Recipe, bool) {
+	for _, rc := range t.recipesByOut[item][m] {
+		if rc.ID == recipeID {
+			return rc, true
+		}
+	}
+	return Recipe{}, false
+}
+
+// LegalRecipes reports the recipe ids available for an item and method,
+// sorted, so the view can offer the alternatives rather than presenting one
+// route as though it were the only one.
+//
+// Governing: SPEC-0001 REQ "Recipe Selection"
+func (t *Tier1) LegalRecipes(id string, m Method) []string {
+	rs := t.recipesByOut[id][m]
+	out := make([]string, 0, len(rs))
+	for _, rc := range rs {
+		out = append(out, rc.ID)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/normalize/artifact.go
+++ b/internal/normalize/artifact.go
@@ -104,7 +104,12 @@ func sortArtifact(t *domain.Tier1) {
 		if t.Recipes[i].Output != t.Recipes[j].Output {
 			return t.Recipes[i].Output < t.Recipes[j].Output
 		}
-		return t.Recipes[i].Method < t.Recipes[j].Method
+		if t.Recipes[i].Method != t.Recipes[j].Method {
+			return t.Recipes[i].Method < t.Recipes[j].Method
+		}
+		// Output and method no longer identify a recipe — many recipes share
+		// a pair (ADR-0005) — so the id is what makes this key total.
+		return t.Recipes[i].ID < t.Recipes[j].ID
 	})
 	for _, r := range t.Recipes {
 		// Item alone is not total: Validate does not reject a recipe naming

--- a/internal/normalize/artifact_test.go
+++ b/internal/normalize/artifact_test.go
@@ -33,7 +33,7 @@ func seed(b *normalize.Builder) {
 		domain.Item{ID: "REACTION1", Name: "Thermic Condensate", DefaultMethod: domain.MethodRefine},
 	)
 	b.AddRecipes(domain.Recipe{
-		Output: "REACTION1", Method: domain.MethodRefine,
+		ID: "REACTION1_REFINE", Output: "REACTION1", Method: domain.MethodRefine,
 		Inputs: []domain.Input{{Item: "PLANT_SNOW", Quantity: 250}, {Item: "FUEL2", Quantity: 50}},
 	})
 }
@@ -112,7 +112,7 @@ func TestOutputIsByteIdenticalRegardlessOfInsertionOrder(t *testing.T) {
 		domain.Item{ID: "CCC", Name: "C", DefaultMethod: domain.MethodCraft},
 	)
 	forward.AddRecipes(domain.Recipe{
-		Output: "CCC", Method: domain.MethodCraft,
+		ID: "CCC_CRAFT", Output: "CCC", Method: domain.MethodCraft,
 		Inputs: []domain.Input{{Item: "AAA", Quantity: 1}, {Item: "BBB", Quantity: 2}},
 	})
 
@@ -123,7 +123,7 @@ func TestOutputIsByteIdenticalRegardlessOfInsertionOrder(t *testing.T) {
 		domain.Item{ID: "AAA", Name: "A", RawObtainable: true, DefaultMethod: domain.MethodRaw},
 	)
 	reverse.AddRecipes(domain.Recipe{
-		Output: "CCC", Method: domain.MethodCraft,
+		ID: "CCC_CRAFT", Output: "CCC", Method: domain.MethodCraft,
 		Inputs: []domain.Input{{Item: "BBB", Quantity: 2}, {Item: "AAA", Quantity: 1}},
 	})
 
@@ -208,7 +208,7 @@ func TestFailedGenerationNeverReachesTheWriter(t *testing.T) {
 	// A recipe input naming an item no table defines: the graph is not
 	// closed, so assembly must fail before anything is written.
 	b.AddRecipes(domain.Recipe{
-		Output: "REACTION1", Method: domain.MethodCraft,
+		ID: "REACTION1_CRAFT", Output: "REACTION1", Method: domain.MethodCraft,
 		Inputs: []domain.Input{{Item: "NOT_AN_ITEM", Quantity: 1}},
 	})
 
@@ -450,7 +450,7 @@ func TestEconomyOrderingIsTotalAcrossNestedSlices(t *testing.T) {
 			domain.Item{ID: "AAA", Name: "A", RawObtainable: true, DefaultMethod: domain.MethodRaw},
 			domain.Item{ID: "CCC", Name: "C", DefaultMethod: domain.MethodCraft},
 		)
-		b.AddRecipes(domain.Recipe{Output: "CCC", Method: domain.MethodCraft, Inputs: ins})
+		b.AddRecipes(domain.Recipe{ID: "CCC_CRAFT", Output: "CCC", Method: domain.MethodCraft, Inputs: ins})
 		b.SetEconomy(&domain.Economy{
 			Parts: []domain.Part{
 				{ID: "PART1", Primary: domain.Flow{Network: domain.NetworkResources, Rate: 10}, Dependencies: deps},


### PR DESCRIPTION
## What

Implements #29 — the schema and engine half of ADR-0005.

A method does not identify a recipe. 261 of 403 refiner output/method pairs carry more than one, and 156 of 1,681 refiner recipes produce a quantity other than one, up to 250. The old schema rejected the first as a duplicate and silently assumed the second was 1, which made every refining total wrong by up to 250×.

## Changes

| Area | Change |
|---|---|
| `Recipe` | gains `ID` (stable, what a plan records) and optional `Yield` (absent means one, via `Producing()`) |
| `Tier1` | `recipesByOut` becomes `output → method → []Recipe`; `Validate` now rejects a duplicate **recipe id** rather than a duplicate method |
| `Tier1` accessors | `RecipesFor(id, m)`, `Recipe(item, m, recipeID)`, `LegalRecipes(id, m)` |
| `PlanInput` | gains `Recipes map[string]string` — item → recipe id, mirroring `Methods`; absence means default |
| `Node` | gains `Recipe`, `Yield`, `LegalRecipes`, and `Applications()` (exact, unrounded) |
| `Edge` | gains `Yield`, kept separate from `PerUnit` so the edge still reports what the recipe literally says |
| `propagate` | multiplies by `PerUnit/Yield` as a `big.Rat` — a yield of 50 stays `1/50`, never `0.02` |
| `select.go` | new: default selection by smallest raw-input total, ties broken by recipe id, memoized with a cycle guard |
| `normalize` | recipe sort key extended with `ID`, since output+method is no longer total |

## Selection rule

Per SPEC-0001 REQ "Recipe Selection": the candidate whose expansion resolves to the smallest total of raw inputs, ties broken by recipe id. `rawCost` is memoized per item and carries an in-progress set, so a self-referential refiner recipe costs as unresolvable and is never preferred over a route that terminates — it remains selectable only if it is the sole option.

`Applications()` is deliberately **unrounded**. SPEC-0001 enumerates the boundaries at which rounding up is allowed and a recipe application is not one of them, so the engine hands back the exact rational and a caller rounds once, at the point it reports batches.

## Verification

- 26 refine recipes for one output load, validate, and are all reported as legal options
- Demand 125 at yield 50 → Crystal Sulphide total `5/2` exactly, `Applications()` `5/2`, ceiling 3 batches, computed by `big.Int.QuoRem` with no float anywhere
- 25 repeated resolutions select the same recipe for every node
- An override onto a costlier route changes the expansion and the totals; an unknown recipe id errors naming both node and recipe, returning no graph
- The 34-node Stasis Device fixture still resolves to **500 Sulphurine, 500 Nitrogen, 500 Radon, 300 Condensed Carbon**
- `go vet`, `staticcheck v0.8.0-rc.1`, `gofmt -l` all clean

## Migration

Fixtures gained recipe ids (`{output}_{method}`). Two `internal/domain` tests moved from `Recipe(id, method)` to the list-shaped accessors.

Closes #29
Part of #21

Implements SPEC-0001 REQ "Recipe Selection", REQ "Exact Arithmetic and Rounding Discipline" (as amended by ADR-0005).

🤖 Generated with [Claude Code](https://claude.com/claude-code)