### PR TITLE
feat(normalize): extract base economy data from the real tables

### DIFF
--- a/internal/domain/economy.go
+++ b/internal/domain/economy.go
@@ -193,10 +193,22 @@ func (e *Economy) validate(knownItem func(string) bool) error {
 		}
 	}
 
+	seenSearch := make(map[string]bool, len(e.Searches))
 	for _, s := range e.Searches {
 		if s.Value == "" {
 			return fmt.Errorf("%w: search record with empty value", ErrInvalidArtifact)
 		}
+		// Value is what sortArtifact orders Searches by, so it has to be
+		// unique or the emitted order falls back to however the normalizer
+		// happened to append them — the map-iteration order REQ
+		// "Deterministic Output" forbids. Rejecting rather than tiebreaking:
+		// unlike the game tables, these records are ours, so two searches
+		// deriving one value is an authoring mistake — either a duplicate to
+		// merge or two derivations wanting distinguishable names.
+		if seenSearch[s.Value] {
+			return fmt.Errorf("%w: duplicate search record for %q", ErrInvalidArtifact, s.Value)
+		}
+		seenSearch[s.Value] = true
 		if len(s.Searched) == 0 {
 			// A search record that names no sources records nothing; it
 			// would read as diligence while carrying none.

--- a/internal/domain/economy.go
+++ b/internal/domain/economy.go
@@ -26,11 +26,18 @@ const (
 	NetworkResources   Network = "resources"
 	NetworkPlantGrowth Network = "plant_growth"
 	NetworkByteBeat    Network = "byte_beat"
+	// Fuel and Portals appear once and three times respectively in the
+	// source. They carry no planner meaning today, but the vocabulary
+	// mirrors GcLinkNetworkTypes rather than a filtered subset of it, so
+	// that a part using one is emitted rather than rejected.
+	NetworkFuel    Network = "fuel"
+	NetworkPortals Network = "portals"
 )
 
 var validNetworks = map[Network]bool{
 	NetworkPower: true, NetworkResources: true,
 	NetworkPlantGrowth: true, NetworkByteBeat: true,
+	NetworkFuel: true, NetworkPortals: true,
 }
 
 // Valid reports whether n is a known network.
@@ -114,12 +121,35 @@ type Refining struct {
 	SubstancesPerCycleSurvival int64 `json:"substances_per_cycle_survival"`
 }
 
+// Search records how a value was located when it was found by searching
+// rather than read from a known field.
+//
+// Governing: SPEC-0004 REQ "Search Boundaries Are Recorded" — this exists
+// because this project has three recorded instances of a bounded search
+// being reported as a general result. Recording where we looked makes the
+// boundary of a negative result visible to the next reader.
+type Search struct {
+	// Value names what was being derived, e.g. "crop substance".
+	Value string `json:"value"`
+	// Searched lists the sources consulted, in the order consulted.
+	Searched []string `json:"searched"`
+	// Note records what the search concluded, including anything it did
+	// not cover.
+	Note string `json:"note,omitempty"`
+}
+
 // Economy is the base-economy half of the artifact.
 type Economy struct {
 	Parts    []Part    `json:"parts,omitempty"`
 	Hotspots []Hotspot `json:"hotspots,omitempty"`
 	Crops    []Crop    `json:"crops,omitempty"`
 	Refining *Refining `json:"refining,omitempty"`
+
+	// Searches records the derivation of values the normalizer had to hunt
+	// for. Sorted by Value.
+	//
+	// Governing: SPEC-0004 REQ "Search Boundaries Are Recorded"
+	Searches []Search `json:"searches,omitempty"`
 }
 
 // validate checks the economy section's internal consistency. Item
@@ -160,6 +190,17 @@ func (e *Economy) validate(knownItem func(string) bool) error {
 	for _, p := range e.Parts {
 		if p.Hotspot != "" && !seenCat[p.Hotspot] {
 			return fmt.Errorf("%w: part %q references hotspot %q, which is not in this artifact", ErrInvalidArtifact, p.ID, p.Hotspot)
+		}
+	}
+
+	for _, s := range e.Searches {
+		if s.Value == "" {
+			return fmt.Errorf("%w: search record with empty value", ErrInvalidArtifact)
+		}
+		if len(s.Searched) == 0 {
+			// A search record that names no sources records nothing; it
+			// would read as diligence while carrying none.
+			return fmt.Errorf("%w: search record %q lists no sources searched", ErrInvalidArtifact, s.Value)
 		}
 	}
 

--- a/internal/normalize/artifact.go
+++ b/internal/normalize/artifact.go
@@ -151,8 +151,10 @@ func sortArtifact(t *domain.Tier1) {
 		return t.Economy.Hotspots[i].Category < t.Economy.Hotspots[j].Category
 	})
 	sort.Slice(t.Economy.Crops, func(i, j int) bool { return t.Economy.Crops[i].ID < t.Economy.Crops[j].ID })
-	// Searches sort by value; the Searched list inside each is deliberately
-	// left in the order it was consulted, since that sequence is the record.
+	// Searches sort by value, which Validate guarantees unique — the same
+	// key-plus-uniqueness pairing every other collection here uses. The
+	// Searched list inside each is deliberately left in the order it was
+	// consulted, since that sequence is the record rather than a set.
 	sort.Slice(t.Economy.Searches, func(i, j int) bool {
 		return t.Economy.Searches[i].Value < t.Economy.Searches[j].Value
 	})

--- a/internal/normalize/artifact.go
+++ b/internal/normalize/artifact.go
@@ -151,6 +151,11 @@ func sortArtifact(t *domain.Tier1) {
 		return t.Economy.Hotspots[i].Category < t.Economy.Hotspots[j].Category
 	})
 	sort.Slice(t.Economy.Crops, func(i, j int) bool { return t.Economy.Crops[i].ID < t.Economy.Crops[j].ID })
+	// Searches sort by value; the Searched list inside each is deliberately
+	// left in the order it was consulted, since that sequence is the record.
+	sort.Slice(t.Economy.Searches, func(i, j int) bool {
+		return t.Economy.Searches[i].Value < t.Economy.Searches[j].Value
+	})
 }
 
 // Encode marshals the artifact deterministically.

--- a/internal/normalize/economy.go
+++ b/internal/normalize/economy.go
@@ -1,0 +1,631 @@
+package normalize
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jonstump/nms-base-planner/internal/domain"
+)
+
+// Base-economy extraction.
+//
+// Governing: ADR-0001 (two-tier ingestion, corrected 2026-08-18), SPEC-0004
+// REQ "Base Economy Data", REQ "Search Boundaries Are Recorded"
+//
+// ADR-0001 planned these as five hand-curated Tier 2 constants. Four proved
+// extractable, so they are generated here and version-stamped with the rest
+// of the artifact. The one that remains curated is biodome crop capacity,
+// which is not in the tables.
+//
+// The values come from five places, which is the whole reason this is
+// awkward:
+//
+//	metadata/reality/tables/basebuildingobjectstable  per-part rates, storage
+//	metadata/simulation/scanning/regionhotspotstable  class strengths
+//	metadata/reality/tables/rewardtable               crop yields
+//	models/.../interactiveflora/*/entities/           which crop yields what
+//	gcgameplayglobals.global                          refiner throughput
+
+// Source file paths, relative to the root of a decompiled extraction. Named
+// so an error message can say which file it wanted rather than only that
+// something was missing.
+const (
+	objectsTable   = "metadata/reality/tables/basebuildingobjectstable.MXML"
+	hotspotsTable  = "metadata/simulation/scanning/regionhotspotstable.MXML"
+	rewardTable    = "metadata/reality/tables/rewardtable.MXML"
+	gameplayGlobal = "gcgameplayglobals.global.MXML"
+	floraRoot      = "models/planets/biomes/common/interactiveflora"
+)
+
+// networkNames maps GcLinkNetworkTypes to the artifact's vocabulary.
+//
+// "None" is deliberately absent rather than mapped to an empty network: a
+// part whose connection is None has no economic behaviour, and the caller
+// distinguishes "not a network we model" from "a network we failed to
+// recognize" by that absence.
+var networkNames = map[string]domain.Network{
+	"Power":       domain.NetworkPower,
+	"Resources":   domain.NetworkResources,
+	"PlantGrowth": domain.NetworkPlantGrowth,
+	"ByteBeat":    domain.NetworkByteBeat,
+	"Fuel":        domain.NetworkFuel,
+	"Portals":     domain.NetworkPortals,
+}
+
+// ReadEconomy assembles the base-economy section from a decompiled source
+// tree rooted at root.
+//
+// Every stage is fail-closed: a source that is missing, or present with a
+// shape this code does not recognize, aborts generation rather than
+// producing an economy section that is quietly short a few parts.
+func ReadEconomy(root string) (*domain.Economy, error) {
+	objects, err := readMXML(filepath.Join(root, objectsTable), "cGcBaseBuildingTable")
+	if err != nil {
+		return nil, err
+	}
+	rows, err := objectRows(objects)
+	if err != nil {
+		return nil, err
+	}
+
+	parts, err := readParts(rows)
+	if err != nil {
+		return nil, err
+	}
+	hotspots, err := readHotspots(root)
+	if err != nil {
+		return nil, err
+	}
+	crops, searched, err := readCrops(root, rows)
+	if err != nil {
+		return nil, err
+	}
+	refining, err := readRefining(root)
+	if err != nil {
+		return nil, err
+	}
+
+	return &domain.Economy{
+		Parts:    parts,
+		Hotspots: hotspots,
+		Crops:    crops,
+		Refining: refining,
+		Searches: searched,
+	}, nil
+}
+
+// objectRows returns the buildable object rows.
+func objectRows(d *mxmlDoc) ([]node, error) {
+	rows, err := d.rows(objectsTable, "Objects", "GcBaseBuildingEntry")
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// readParts turns each buildable's GcBaseLinkGridData into a Part.
+//
+// Every one of the 1,997 buildables carries link-grid data, but most of it
+// is a Power connection with rate and storage zero — a decoration that
+// neither produces nor consumes. Those are skipped, and the count skipped is
+// recorded on the parts search note so the omission is visible rather than
+// implied.
+func readParts(rows []node) ([]domain.Part, error) {
+	var parts []domain.Part
+	for _, row := range rows {
+		id, err := row.nonEmpty(objectsTable, "", "ID")
+		if err != nil {
+			return nil, err
+		}
+		grid, ok := row.child("LinkGridData")
+		if !ok {
+			return nil, Unrecognized(objectsTable, id, "LinkGridData", "present", "absent")
+		}
+
+		p, keep, err := readPart(id, grid)
+		if err != nil {
+			return nil, err
+		}
+		if keep {
+			parts = append(parts, p)
+		}
+	}
+	if len(parts) == 0 {
+		return nil, Unrecognized(objectsTable, "", "LinkGridData", "at least one part with a rate", "none")
+	}
+	return parts, nil
+}
+
+// readPart decodes one buildable's link-grid data, reporting whether it
+// carries any economic behaviour worth emitting.
+func readPart(id string, grid node) (domain.Part, bool, error) {
+	conn, ok := grid.child("Connection")
+	if !ok {
+		return domain.Part{}, false, Unrecognized(objectsTable, id, "LinkGridData/Connection", "present", "absent")
+	}
+	network, known, err := readNetwork(id, "LinkGridData/Connection", conn)
+	if err != nil {
+		return domain.Part{}, false, err
+	}
+
+	rate, err := grid.int64(objectsTable, id, "Rate")
+	if err != nil {
+		return domain.Part{}, false, err
+	}
+	storage, err := grid.int64(objectsTable, id, "Storage")
+	if err != nil {
+		return domain.Part{}, false, err
+	}
+	hotspot, err := grid.str(objectsTable, id, "DependsOnHotspots")
+	if err != nil {
+		return domain.Part{}, false, err
+	}
+	if hotspot == "None" {
+		hotspot = ""
+	}
+
+	deps, err := readDependencies(id, grid)
+	if err != nil {
+		return domain.Part{}, false, err
+	}
+
+	interesting := rate != 0 || storage != 0 || hotspot != "" || len(deps) > 0
+	if !known || !interesting {
+		return domain.Part{}, false, nil
+	}
+	return domain.Part{
+		ID:           id,
+		Primary:      domain.Flow{Network: network, Rate: rate, Storage: storage},
+		Dependencies: deps,
+		Hotspot:      hotspot,
+	}, true, nil
+}
+
+// readDependencies decodes the dependent connections — typically the power
+// draw that gates a part's primary rate.
+//
+// A dependency with rate zero and effect "None" carries nothing and is
+// dropped; one with rate zero and a real effect is kept, because "needs a
+// power connection but draws nothing" is a fact the planner must not lose.
+func readDependencies(id string, grid node) ([]domain.Dependency, error) {
+	wrapper, ok := grid.child("DependentConnections")
+	if !ok {
+		return nil, nil
+	}
+	var deps []domain.Dependency
+	for _, d := range wrapper.children("DependentConnections") {
+		conn, ok := d.child("Connection")
+		if !ok {
+			return nil, Unrecognized(objectsTable, id, "DependentConnections/Connection", "present", "absent")
+		}
+		network, known, err := readNetwork(id, "DependentConnections/Connection", conn)
+		if err != nil {
+			return nil, err
+		}
+		rate, err := d.int64(objectsTable, id, "DependentRate")
+		if err != nil {
+			return nil, err
+		}
+		effect, err := d.str(objectsTable, id, "DependentEffect")
+		if err != nil {
+			return nil, err
+		}
+		if effect == "None" {
+			effect = ""
+		}
+		if !known || (rate == 0 && effect == "") {
+			continue
+		}
+		deps = append(deps, domain.Dependency{Network: network, Rate: rate, Effect: effect})
+	}
+	return deps, nil
+}
+
+// readNetwork reads a GcLinkNetworkTypes wrapper, reporting whether the
+// value names a network the artifact models.
+//
+// "None" returns known=false with no error; anything else unrecognized is an
+// error, because a network the game added is a structural surprise and the
+// whole posture here is that those fail loudly.
+func readNetwork(id, where string, conn node) (domain.Network, bool, error) {
+	wrapper, ok := conn.child("Network")
+	if !ok {
+		return "", false, Unrecognized(objectsTable, id, where+"/Network", "present", "absent")
+	}
+	raw, err := wrapper.str(objectsTable, id, "LinkNetworkType")
+	if err != nil {
+		return "", false, err
+	}
+	if raw == "None" {
+		return "", false, nil
+	}
+	n, ok := networkNames[raw]
+	if !ok {
+		return "", false, Unrecognized(objectsTable, id, where+"/LinkNetworkType", "a known link network", raw)
+	}
+	return n, true, nil
+}
+
+// readHotspots reads the class strengths and weightings.
+//
+// Governing: SPEC-0004 REQ "Base Economy Data" — "Class scaling MUST be
+// modelled as a property of the hotspot, not of the device." The table's
+// shape is the evidence: strengths hang off the hotspot category, and there
+// are no per-class device variants anywhere to find.
+func readHotspots(root string) ([]domain.Hotspot, error) {
+	doc, err := readMXML(filepath.Join(root, hotspotsTable), "cGcRegionHotspotsTable")
+	if err != nil {
+		return nil, err
+	}
+	wrapper, ok := findChild(doc.Props, "RegionHotspots")
+	if !ok {
+		return nil, Unrecognized(hotspotsTable, "", "RegionHotspots", "present", "absent")
+	}
+
+	// The table names six categories — Power, Mineral1..3, Gas1..2 — but a
+	// part's DependsOnHotspots names a family: "Mineral", "Gas", "Power".
+	// The numbered variants exist to give a planet several distinct mineral
+	// hotspots, not to scale differently, so they collapse to the family the
+	// parts table actually references.
+	//
+	// Collapsing is guarded rather than assumed: members that disagree are a
+	// structural surprise and fail, because silently keeping the first would
+	// put one variant's numbers behind every mineral hotspot in the planner.
+	byFamily := map[string]domain.Hotspot{}
+	var order []string
+	for _, cat := range wrapper.Props {
+		// Unlike the tables, categories are named by element rather than
+		// repeated under one name.
+		if cat.Value != "GcRegionHotspotData" {
+			return nil, Unrecognized(hotspotsTable, cat.Name, "value", "GcRegionHotspotData", cat.Value)
+		}
+		strengths, err := readClassValues(cat, hotspotsTable, cat.Name, "ClassStrengths")
+		if err != nil {
+			return nil, err
+		}
+		weightings, err := readClassValues(cat, hotspotsTable, cat.Name, "ClassWeightings")
+		if err != nil {
+			return nil, err
+		}
+
+		family := hotspotFamily(cat.Name)
+		h := domain.Hotspot{Category: family, Strengths: strengths, Weightings: weightings}
+		prev, seen := byFamily[family]
+		if !seen {
+			byFamily[family] = h
+			order = append(order, family)
+			continue
+		}
+		if prev != h {
+			return nil, Unrecognized(hotspotsTable, cat.Name, "ClassStrengths/ClassWeightings",
+				fmt.Sprintf("the same values as the rest of the %s family", family),
+				fmt.Sprintf("%+v", h))
+		}
+	}
+	if len(order) == 0 {
+		return nil, Unrecognized(hotspotsTable, "", "RegionHotspots", "at least one category", "none")
+	}
+
+	out := make([]domain.Hotspot, 0, len(order))
+	for _, f := range order {
+		out = append(out, byFamily[f])
+	}
+	return out, nil
+}
+
+// hotspotFamily strips the variant index from a category name, so Mineral1,
+// Mineral2 and Mineral3 all become the "Mineral" the parts table names.
+func hotspotFamily(category string) string {
+	return strings.TrimRight(category, "0123456789")
+}
+
+func readClassValues(parent node, table, row, field string) (domain.ClassValues, error) {
+	n, ok := parent.child(field)
+	if !ok {
+		return domain.ClassValues{}, Unrecognized(table, row, field, "present", "absent")
+	}
+	var v domain.ClassValues
+	var err error
+	if v.C, err = n.float(table, row, "C"); err != nil {
+		return domain.ClassValues{}, err
+	}
+	if v.B, err = n.float(table, row, "B"); err != nil {
+		return domain.ClassValues{}, err
+	}
+	if v.A, err = n.float(table, row, "A"); err != nil {
+		return domain.ClassValues{}, err
+	}
+	if v.S, err = n.float(table, row, "S"); err != nil {
+		return domain.ClassValues{}, err
+	}
+	return v, nil
+}
+
+// readCrops derives the farmable plants.
+//
+// This is the searched value, and the reason SPEC-0004 REQ "Search
+// Boundaries Are Recorded" exists. Nothing in the buildables table says what
+// a plant yields. The chain is:
+//
+//	objects table  a buildable whose primary connection is PlantGrowth,
+//	               giving the growth time as the connection's Storage
+//	     |         and the placement scene filename
+//	     v
+//	flora entity   MODELS/.../FARMSNOW_PLACEMENT.SCENE.MBIN becomes
+//	               models/.../farmsnow/entities/plantinteraction.entity,
+//	     |         whose interaction Id is the reward key
+//	     v
+//	reward table   the GcRewardSpecificSubstance under that key, giving the
+//	               substance actually yielded and its min/max amount
+//
+// The last hop matters: the reward key and the substance are not always the
+// same. PLANT_BARREN yields PLANT_DUST.
+func readCrops(root string, rows []node) ([]domain.Crop, []domain.Search, error) {
+	rewards, err := readRewards(root)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var crops []domain.Crop
+	var containers []string
+	for _, row := range rows {
+		id, err := row.nonEmpty(objectsTable, "", "ID")
+		if err != nil {
+			return nil, nil, err
+		}
+		grid, ok := row.child("LinkGridData")
+		if !ok {
+			continue
+		}
+		conn, ok := grid.child("Connection")
+		if !ok {
+			continue
+		}
+		network, known, err := readNetwork(id, "LinkGridData/Connection", conn)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !known || network != domain.NetworkPlantGrowth {
+			continue
+		}
+
+		growth, err := grid.int64(objectsTable, id, "Storage")
+		if err != nil {
+			return nil, nil, err
+		}
+		scene, ok := row.child("PlacementScene")
+		if !ok {
+			return nil, nil, Unrecognized(objectsTable, id, "PlacementScene", "present", "absent")
+		}
+		filename, err := scene.nonEmpty(objectsTable, id, "Filename")
+		if err != nil {
+			return nil, nil, err
+		}
+
+		entityPath, ok := floraEntityPath(filename)
+		if !ok {
+			// A planter or hydroponics tray: it participates in the growth
+			// network but is not itself a plant, and has no flora entity to
+			// resolve a substance through. Recorded rather than dropped.
+			containers = append(containers, id)
+			continue
+		}
+		key, err := readPlantRewardKey(filepath.Join(root, entityPath), entityPath)
+		if err != nil {
+			return nil, nil, err
+		}
+		r, ok := rewards[key]
+		if !ok {
+			return nil, nil, Unresolved(rewardTable, id, "reward key", key)
+		}
+
+		crops = append(crops, domain.Crop{
+			ID:            id,
+			Substance:     r.substance,
+			Yield:         domain.Range{Min: r.min, Max: r.max},
+			GrowthSeconds: growth,
+		})
+	}
+	if len(crops) == 0 {
+		return nil, nil, Unrecognized(objectsTable, "", "LinkGridData/Connection",
+			"at least one buildable on the PlantGrowth network", "none")
+	}
+
+	sort.Slice(crops, func(i, j int) bool { return crops[i].ID < crops[j].ID })
+	sort.Strings(containers)
+
+	note := fmt.Sprintf("The buildables table names no substance. %d plant buildables were found "+
+		"by their PlantGrowth connection, resolved to a reward key through the flora entity "+
+		"their placement scene names, and to a substance and amount through the reward table. "+
+		"The reward key and the substance are not always the same — PLANT_BARREN yields "+
+		"PLANT_DUST. Five of the twelve yield a product rather than a substance, under "+
+		"GcRewardSpecificProduct; SPEC-0004 names only GcRewardSpecificSubstance, so both "+
+		"forms are read. Wild-harvest entries (WILD_*) were not read: they are not farmed.",
+		len(crops))
+	if len(containers) > 0 {
+		note += fmt.Sprintf(" Buildables on the growth network with no flora entity are carried "+
+			"as parts rather than crops: %s.", strings.Join(containers, ", "))
+	}
+	searches := []domain.Search{{
+		Value: "crop substance and yield",
+		Searched: []string{
+			objectsTable,
+			floraRoot + "/*/entities/plantinteraction.entity.MXML",
+			rewardTable,
+		},
+		Note: note,
+	}}
+	return crops, searches, nil
+}
+
+// floraEntityPath turns a placement-scene filename into the interaction
+// entity beside it. Returns false for a scene outside the flora tree, which
+// is how a non-crop that happens to sit on the PlantGrowth network is
+// reported rather than silently mapped to a wrong file.
+func floraEntityPath(sceneFilename string) (string, bool) {
+	p := strings.ToLower(strings.ReplaceAll(sceneFilename, "\\", "/"))
+	if !strings.HasPrefix(p, floraRoot+"/") {
+		return "", false
+	}
+	base := strings.TrimSuffix(filepath.Base(p), ".scene.mbin")
+	base = strings.TrimSuffix(base, "_placement")
+	if base == "" {
+		return "", false
+	}
+	return filepath.Join(floraRoot, base, "entities", "plantinteraction.entity.MXML"), true
+}
+
+// readPlantRewardKey reads the interaction id a plant's entity declares.
+func readPlantRewardKey(path, name string) (string, error) {
+	doc, err := readMXML(path, "cTkAttachmentData")
+	if err != nil {
+		return "", err
+	}
+	components, ok := findChild(doc.Props, "Components")
+	if !ok {
+		return "", Unrecognized(name, "", "Components", "present", "absent")
+	}
+	for _, c := range components.children("Components") {
+		if c.Value != "GcSimpleInteractionComponentData" {
+			continue
+		}
+		inner, ok := c.child("GcSimpleInteractionComponentData")
+		if !ok {
+			return "", Unrecognized(name, "", "GcSimpleInteractionComponentData", "present", "absent")
+		}
+		return inner.nonEmpty(name, "", "Id")
+	}
+	return "", Unrecognized(name, "", "Components", "a GcSimpleInteractionComponentData", "none")
+}
+
+// reward is one reward-table entry's substance and amount range.
+type reward struct {
+	substance string
+	min, max  int64
+}
+
+// rewardKinds are the reward shapes a farmable plant can hand back.
+//
+// SPEC-0004 names only GcRewardSpecificSubstance. Against the real table
+// that covers seven of the twelve farmable plants: the other five —
+// venom sacs, gravitino balls, nip-nip buds, albumen pearls and creature
+// pellets — yield a *product*, under GcRewardSpecificProduct with an
+// identical Amount shape. Reading only the substance form would have
+// dropped them silently, so both are read and the divergence is recorded
+// on the crop search note.
+var rewardKinds = []string{"GcRewardSpecificSubstance", "GcRewardSpecificProduct"}
+
+// readRewards indexes the reward table by entry id.
+//
+// Only entries whose single item is one of rewardKinds are indexed. The
+// table also holds nanite payouts, tech unlocks and multi-item lists; none
+// of those are what a plant hands you, and reading them as if they were
+// would put a wrong number in the artifact.
+func readRewards(root string) (map[string]reward, error) {
+	doc, err := readMXML(filepath.Join(root, rewardTable), "cGcRewardTable")
+	if err != nil {
+		return nil, err
+	}
+	wrapper, ok := findChild(doc.Props, "GenericTable")
+	if !ok {
+		return nil, Unrecognized(rewardTable, "", "GenericTable", "present", "absent")
+	}
+
+	out := make(map[string]reward)
+	for _, row := range wrapper.children("GenericTable") {
+		id, err := row.str(rewardTable, "", "Id")
+		if err != nil || id == "" {
+			continue
+		}
+		list, ok := row.child("List")
+		if !ok {
+			continue
+		}
+		inner, ok := list.child("List")
+		if !ok {
+			continue
+		}
+		items := inner.children("List")
+		if len(items) != 1 {
+			continue
+		}
+		r, ok := items[0].child("Reward")
+		if !ok {
+			continue
+		}
+		kind := ""
+		for _, k := range rewardKinds {
+			if r.Value == k {
+				kind = k
+				break
+			}
+		}
+		if kind == "" {
+			continue
+		}
+		sub, ok := r.child(kind)
+		if !ok {
+			continue
+		}
+		substance, err := sub.nonEmpty(rewardTable, id, "ID")
+		if err != nil {
+			return nil, err
+		}
+		min, err := sub.int64(rewardTable, id, "AmountMin")
+		if err != nil {
+			return nil, err
+		}
+		max, err := sub.int64(rewardTable, id, "AmountMax")
+		if err != nil {
+			return nil, err
+		}
+		out[id] = reward{substance: substance, min: min, max: max}
+	}
+	if len(out) == 0 {
+		return nil, Unrecognized(rewardTable, "", "GenericTable", "at least one substance or product reward", "none")
+	}
+	return out, nil
+}
+
+// readRefining reads refiner throughput, which is difficulty-dependent.
+//
+// Both the standard and Survival variants are carried, settling SPEC-0004's
+// open question by letting the planner choose rather than picking here.
+func readRefining(root string) (*domain.Refining, error) {
+	doc, err := readMXML(filepath.Join(root, gameplayGlobal), "cGcGameplayGlobals")
+	if err != nil {
+		return nil, err
+	}
+	top := node{Props: doc.Props}
+
+	var r domain.Refining
+	fields := []struct {
+		field string
+		into  *int64
+	}{
+		{"RefinerProductsMadeInTime", &r.ProductsPerCycle},
+		{"RefinerSubsMadeInTime", &r.SubstancesPerCycle},
+		{"RefinerProductsMadeInTimeSurvival", &r.ProductsPerCycleSurvival},
+		{"RefinerSubsMadeInTimeSurvival", &r.SubstancesPerCycleSurvival},
+	}
+	for _, f := range fields {
+		v, err := top.int64(gameplayGlobal, "", f.field)
+		if err != nil {
+			return nil, err
+		}
+		*f.into = v
+	}
+	return &r, nil
+}
+
+// findChild returns the first node in a slice with the given name.
+func findChild(props []node, name string) (node, bool) {
+	for _, p := range props {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return node{}, false
+}

--- a/internal/normalize/economy_test.go
+++ b/internal/normalize/economy_test.go
@@ -497,3 +497,49 @@ func copyTree(t *testing.T, src string) string {
 	}
 	return dst
 }
+
+// SPEC-0004 REQ "Deterministic Output": collections are emitted in a
+// defined, stable order — "not map-iteration order".
+//
+// sortArtifact orders Searches by Value, which is only a total key if Value
+// is unique. Every other collection in the artifact pairs its sort key with a
+// uniqueness check in Validate; this is that check for Searches.
+//
+// Rejecting rather than tiebreaking is deliberate. These records are written
+// by the normalizer rather than read out of the game tables, so two searches
+// deriving one value is an authoring mistake — a duplicate that wants merging
+// or two derivations that want distinguishable names — and surfacing it beats
+// silently ordering it.
+func TestDuplicateSearchValueIsRefused(t *testing.T) {
+	dup := []domain.Search{
+		{Value: "crop substance", Searched: []string{"tableA"}, Note: "first"},
+		{Value: "crop substance", Searched: []string{"tableB"}, Note: "second"},
+	}
+
+	b, err := normalize.NewBuilder("NMS 5.97", "6.45.0.1", []string{"a.pak"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.AddItems(domain.Item{ID: "AAA", RawObtainable: true, DefaultMethod: domain.MethodRaw})
+	b.SetEconomy(&domain.Economy{Searches: dup})
+
+	if _, err := b.Artifact(); err == nil {
+		t.Fatal("Artifact accepted two search records deriving the same value")
+	} else if !errors.Is(err, domain.ErrInvalidArtifact) {
+		t.Errorf("error is %v, want ErrInvalidArtifact", err)
+	} else if !strings.Contains(err.Error(), "crop substance") {
+		t.Errorf("error %q does not name the duplicated value", err)
+	}
+}
+
+// The real economy's search records must satisfy the uniqueness the sort
+// depends on — otherwise the check above only ever fires on crafted input.
+func TestRealSearchValuesAreUnique(t *testing.T) {
+	seen := map[string]bool{}
+	for _, s := range economy(t).Searches {
+		if seen[s.Value] {
+			t.Errorf("two search records derive %q", s.Value)
+		}
+		seen[s.Value] = true
+	}
+}

--- a/internal/normalize/economy_test.go
+++ b/internal/normalize/economy_test.go
@@ -1,0 +1,499 @@
+package normalize_test
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jonstump/nms-base-planner/internal/domain"
+	"github.com/jonstump/nms-base-planner/internal/normalize"
+)
+
+// The fixtures under testdata/economy are real content sliced out of a
+// 6.45.0.1 decompilation — see testdata/economy/gen.go for exactly which
+// rows and why. Asserting against hand-authored MXML would test only that
+// the parser agrees with my idea of the format, which is the mistake that
+// cost this project its first parser.
+const economyRoot = "testdata/economy"
+
+func economy(t *testing.T) *domain.Economy {
+	t.Helper()
+	e, err := normalize.ReadEconomy(economyRoot)
+	if err != nil {
+		t.Fatalf("ReadEconomy: %v", err)
+	}
+	return e
+}
+
+func part(t *testing.T, e *domain.Economy, id string) domain.Part {
+	t.Helper()
+	for _, p := range e.Parts {
+		if p.ID == id {
+			return p
+		}
+	}
+	t.Fatalf("part %q missing; got %d parts", id, len(e.Parts))
+	return domain.Part{}
+}
+
+func crop(t *testing.T, e *domain.Economy, id string) domain.Crop {
+	t.Helper()
+	for _, c := range e.Crops {
+		if c.ID == id {
+			return c
+		}
+	}
+	t.Fatalf("crop %q missing; got %d crops", id, len(e.Crops))
+	return domain.Crop{}
+}
+
+// SPEC-0004 REQ "Base Economy Data":
+// WHEN U_EXTRACTOR_S is emitted
+// THEN its rate, its storage, and its dependent power draw are present,
+// each identified by the network it applies to.
+func TestExtractorCarriesRateStorageAndPowerDraw(t *testing.T) {
+	p := part(t, economy(t), "U_EXTRACTOR_S")
+
+	if got, want := p.Primary.Network, domain.NetworkResources; got != want {
+		t.Errorf("primary network = %q, want %q", got, want)
+	}
+	if got, want := p.Primary.Rate, int64(100); got != want {
+		t.Errorf("rate = %d, want %d", got, want)
+	}
+	if got, want := p.Primary.Storage, int64(360000); got != want {
+		t.Errorf("storage = %d, want %d", got, want)
+	}
+	if len(p.Dependencies) != 1 {
+		t.Fatalf("dependencies = %d, want 1", len(p.Dependencies))
+	}
+	d := p.Dependencies[0]
+	if d.Network != domain.NetworkPower || d.Rate != -50 || d.Effect != "EnablesRate" {
+		t.Errorf("dependency = %+v, want power -50 EnablesRate", d)
+	}
+	// The class lives on the hotspot; the part only names which hotspot it
+	// scales with.
+	if got, want := p.Hotspot, "Mineral"; got != want {
+		t.Errorf("hotspot = %q, want %q", got, want)
+	}
+}
+
+// SPEC-0004 REQ "Base Economy Data":
+// WHEN class strengths are emitted
+// THEN they are keyed by hotspot category and class, and no per-class device
+// variants appear.
+func TestHotspotClassStrengthsAndWeightings(t *testing.T) {
+	e := economy(t)
+
+	want := map[string]struct{ strengths, weightings domain.ClassValues }{
+		"Power":   {domain.ClassValues{C: 150, B: 220, A: 250, S: 300}, domain.ClassValues{C: 10, B: 6, A: 2, S: 1}},
+		"Mineral": {domain.ClassValues{C: 1, B: 1.5, A: 2, S: 2.5}, domain.ClassValues{C: 6, B: 4, A: 2, S: 1}},
+		"Gas":     {domain.ClassValues{C: 1, B: 1.5, A: 2, S: 2.5}, domain.ClassValues{C: 20, B: 4, A: 2, S: 1}},
+	}
+	if len(e.Hotspots) != len(want) {
+		t.Fatalf("hotspots = %d, want %d", len(e.Hotspots), len(want))
+	}
+	for _, h := range e.Hotspots {
+		w, ok := want[h.Category]
+		if !ok {
+			t.Errorf("unexpected hotspot category %q", h.Category)
+			continue
+		}
+		if h.Strengths != w.strengths {
+			t.Errorf("%s strengths = %+v, want %+v", h.Category, h.Strengths, w.strengths)
+		}
+		if h.Weightings != w.weightings {
+			t.Errorf("%s weightings = %+v, want %+v", h.Category, h.Weightings, w.weightings)
+		}
+	}
+
+	// Every part that scales names a category the artifact carries; none
+	// carries a class of its own.
+	categories := map[string]bool{}
+	for _, h := range e.Hotspots {
+		categories[h.Category] = true
+	}
+	for _, p := range e.Parts {
+		if p.Hotspot != "" && !categories[p.Hotspot] {
+			t.Errorf("part %q names hotspot %q, which is not emitted", p.ID, p.Hotspot)
+		}
+	}
+}
+
+// SPEC-0004 REQ "Base Economy Data" — "The normalizer MUST NOT emit
+// per-class device variants, which do not exist in the source."
+//
+// Asserted on the encoded form rather than on part IDs, because a name check
+// would trip over U_EXTRACTOR_S, whose trailing S is a size tier and not a
+// class. What must be true is that class-keyed values appear nowhere outside
+// the hotspots section.
+func TestNoPerClassDeviceVariants(t *testing.T) {
+	e := economy(t)
+
+	blob, err := json.Marshal(e.Parts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{`"c":`, `"b":`, `"a":`, `"s":`, `"strengths"`, `"weightings"`} {
+		if strings.Contains(string(blob), key) {
+			t.Errorf("parts carry %s; class scaling belongs to the hotspot, not the device", key)
+		}
+	}
+
+	// And the source really does hold only one extractor of each size, not
+	// four classes of one: a per-class model would have produced siblings.
+	var extractors int
+	for _, p := range e.Parts {
+		if strings.HasPrefix(p.ID, "U_EXTRACTOR") {
+			extractors++
+		}
+	}
+	if extractors != 1 {
+		t.Errorf("extractor parts = %d, want 1 (the fixture carries one size)", extractors)
+	}
+}
+
+// SPEC-0004 REQ "Base Economy Data":
+// WHEN a crop yield is expressed as a minimum and maximum in the source
+// THEN both bounds are emitted, rather than one derived value.
+func TestCropYieldsAndGrowthTimes(t *testing.T) {
+	e := economy(t)
+
+	cases := []struct {
+		id        string
+		substance string
+		min, max  int64
+		growth    int64
+	}{
+		// Frost Crystal. The acceptance case, and the one the wiki quotes:
+		// the yield is on the substance the plant hands you, not the plant.
+		{"SNOWPLANT", "PLANT_SNOW", 50, 50, 3600},
+		// Cactus Flesh. The reward key is PLANT_BARREN but the substance is
+		// PLANT_DUST — reading the key as the substance would be wrong here
+		// and right everywhere else, which is the worst kind of wrong.
+		{"BARRENPLANT", "PLANT_DUST", 100, 100, 57600},
+		// Star Bulb.
+		{"LUSHPLANT", "PLANT_LUSH", 25, 25, 14400},
+		// Venom Sac, whose reward is a product rather than a substance.
+		{"SACVENOMPLANT", "SACVENOM", 1, 1, 12000},
+	}
+	for _, tc := range cases {
+		c := crop(t, e, tc.id)
+		if c.Substance != tc.substance {
+			t.Errorf("%s substance = %q, want %q", tc.id, c.Substance, tc.substance)
+		}
+		if c.Yield.Min != tc.min || c.Yield.Max != tc.max {
+			t.Errorf("%s yield = [%d, %d], want [%d, %d]", tc.id, c.Yield.Min, c.Yield.Max, tc.min, tc.max)
+		}
+		if c.GrowthSeconds != tc.growth {
+			t.Errorf("%s growth = %ds, want %ds", tc.id, c.GrowthSeconds, tc.growth)
+		}
+	}
+}
+
+// A container on the growth network is not a crop: it grows nothing itself.
+func TestGrowthNetworkContainerIsNotACrop(t *testing.T) {
+	e := economy(t)
+
+	for _, c := range e.Crops {
+		if c.ID == "CARBONPLANTER" {
+			t.Fatal("CARBONPLANTER emitted as a crop; it is a planter, with no flora entity and no yield")
+		}
+	}
+	// It is still carried as a part, because it does participate in the
+	// network — dropping it entirely would lose its growth contribution.
+	p := part(t, e, "CARBONPLANTER")
+	if p.Primary.Network != domain.NetworkPlantGrowth {
+		t.Errorf("CARBONPLANTER network = %q, want plant_growth", p.Primary.Network)
+	}
+}
+
+// A buildable with no rate, no storage and no dependency has no economic
+// behaviour and is not emitted.
+func TestPartWithNoEconomicBehaviourIsSkipped(t *testing.T) {
+	e := economy(t)
+	for _, p := range e.Parts {
+		if p.ID == "BUILD_REFINER1" {
+			t.Fatal("BUILD_REFINER1 emitted; it carries no rate, storage or dependency")
+		}
+	}
+
+	// The fixture does contain it, so the absence above is a decision rather
+	// than an accident of what was sliced.
+	blob, err := os.ReadFile(filepath.Join(economyRoot, "metadata/reality/tables/basebuildingobjectstable.MXML"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(blob), `_id="BUILD_REFINER1"`) {
+		t.Fatal("the fixture no longer carries BUILD_REFINER1, so this scenario is not being exercised")
+	}
+}
+
+// SPEC-0004 REQ "Base Economy Data" — refiner throughput including
+// difficulty variants.
+func TestRefinerThroughput(t *testing.T) {
+	r := economy(t).Refining
+	if r == nil {
+		t.Fatal("no refining data emitted")
+	}
+	want := domain.Refining{
+		ProductsPerCycle: 2, SubstancesPerCycle: 250,
+		ProductsPerCycleSurvival: 1, SubstancesPerCycleSurvival: 100,
+	}
+	if *r != want {
+		t.Errorf("refining = %+v, want %+v", *r, want)
+	}
+}
+
+// SPEC-0004 REQ "Search Boundaries Are Recorded":
+// WHEN a value is produced by searching several tables rather than reading
+// one known field
+// THEN the sources searched are recorded alongside it.
+func TestSearchBoundariesAreRecorded(t *testing.T) {
+	e := economy(t)
+	if len(e.Searches) == 0 {
+		t.Fatal("no search recorded; the crop chain spans three sources")
+	}
+
+	var found bool
+	for _, s := range e.Searches {
+		if !strings.Contains(s.Value, "crop") {
+			continue
+		}
+		found = true
+		for _, want := range []string{"basebuildingobjectstable", "plantinteraction.entity", "rewardtable"} {
+			var named bool
+			for _, src := range s.Searched {
+				if strings.Contains(src, want) {
+					named = true
+				}
+			}
+			if !named {
+				t.Errorf("crop search does not name %q among %v", want, s.Searched)
+			}
+		}
+		// The note must say what was left out, not only what was covered.
+		if !strings.Contains(s.Note, "CARBONPLANTER") {
+			t.Errorf("crop search note does not record the container it skipped: %q", s.Note)
+		}
+	}
+	if !found {
+		t.Error("no search record covers the crop derivation")
+	}
+}
+
+// The economy section must survive the artifact's own validation, since
+// that is what a consumer actually loads.
+func TestEconomyLoadsAsPartOfAnArtifact(t *testing.T) {
+	e := economy(t)
+
+	b, err := normalize.NewBuilder("5.97", "6.45.0.1",
+		[]string{"NMSARC.Precache.pak", "NMSARC.globals.pak"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Crop substances have to exist as items, which is the graph half of the
+	// artifact; stand them in here so the economy can be validated on its own.
+	for _, c := range e.Crops {
+		b.AddItems(domain.Item{
+			ID: c.Substance, Name: c.Substance,
+			RawObtainable: true, DefaultMethod: domain.MethodRaw,
+		})
+	}
+	b.SetEconomy(e)
+
+	a1, err := b.Artifact()
+	if err != nil {
+		t.Fatalf("Artifact: %v", err)
+	}
+	if a1.Economy == nil || len(a1.Economy.Parts) == 0 {
+		t.Fatal("economy did not survive assembly")
+	}
+
+	// And it round-trips: what was written loads back with the same values.
+	blob, err := normalize.Encode(a1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := domain.LoadTier1(strings.NewReader(string(blob)))
+	if err != nil {
+		t.Fatalf("reloading the encoded artifact: %v", err)
+	}
+	if back.Economy == nil {
+		t.Fatal("economy absent after a round trip")
+	}
+	if len(back.Economy.Parts) != len(e.Parts) || len(back.Economy.Crops) != len(e.Crops) {
+		t.Errorf("round trip = %d parts / %d crops, want %d / %d",
+			len(back.Economy.Parts), len(back.Economy.Crops), len(e.Parts), len(e.Crops))
+	}
+}
+
+// SPEC-0004 REQ "Deterministic Output" — the artifact is committed, so two
+// runs over one install must produce the same bytes.
+func TestEconomyExtractionIsDeterministic(t *testing.T) {
+	first := encodeEconomy(t)
+	for i := 0; i < 10; i++ {
+		if got := encodeEconomy(t); got != first {
+			t.Fatalf("run %d differs from the first; map iteration is leaking into output", i+2)
+		}
+	}
+}
+
+func encodeEconomy(t *testing.T) string {
+	t.Helper()
+	e := economy(t)
+	b, err := normalize.NewBuilder("5.97", "6.45.0.1", []string{"NMSARC.Precache.pak"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range e.Crops {
+		b.AddItems(domain.Item{ID: c.Substance, Name: c.Substance,
+			RawObtainable: true, DefaultMethod: domain.MethodRaw})
+	}
+	b.SetEconomy(e)
+	a1, err := b.Artifact()
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, err := normalize.Encode(a1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(blob)
+}
+
+// SPEC-0004 REQ "Structural Surprise Fails Loudly" — every failure mode
+// below produces a named error rather than a quietly smaller economy.
+func TestSourcesFailClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		// mutate edits the copied source tree; an empty file path deletes.
+		file, from, to string
+		remove         string
+		want           error
+		mentions       string
+	}{
+		{
+			name:   "a missing source",
+			remove: "metadata/simulation/scanning/regionhotspotstable.MXML",
+			want:   normalize.ErrSourceMissing,
+		},
+		{
+			name: "a link network the vocabulary does not know",
+			file: "metadata/reality/tables/basebuildingobjectstable.MXML",
+			from: `<Property name="LinkNetworkType" value="Resources" />`,
+			to:   `<Property name="LinkNetworkType" value="Antimatter" />`,
+			want: normalize.ErrStructureUnrecognized, mentions: "Antimatter",
+		},
+		{
+			name: "a hotspot family whose members disagree",
+			file: "metadata/simulation/scanning/regionhotspotstable.MXML",
+			from: `<Property name="Mineral2" value="GcRegionHotspotData">
+			<Property name="ProbabilityWeighting" value="1.000000" />
+			<Property name="MinRange" value="190.000000" />
+			<Property name="MaxRange" value="225.000000" />
+			<Property name="ClassWeightings">
+				<Property name="C" value="6.000000" />`,
+			to: `<Property name="Mineral2" value="GcRegionHotspotData">
+			<Property name="ProbabilityWeighting" value="1.000000" />
+			<Property name="MinRange" value="190.000000" />
+			<Property name="MaxRange" value="225.000000" />
+			<Property name="ClassWeightings">
+				<Property name="C" value="99.000000" />`,
+			want: normalize.ErrStructureUnrecognized, mentions: "Mineral2",
+		},
+		{
+			name: "a crop whose reward key is not in the reward table",
+			file: "models/planets/biomes/common/interactiveflora/farmsnow/entities/plantinteraction.entity.MXML",
+			from: `<Property name="Id" value="PLANT_SNOW" />`,
+			to:   `<Property name="Id" value="PLANT_NOT_IN_TABLE" />`,
+			want: normalize.ErrReferenceUnresolved, mentions: "PLANT_NOT_IN_TABLE",
+		},
+		{
+			name:   "a crop whose flora entity is absent",
+			remove: "models/planets/biomes/common/interactiveflora/farmlush/entities/plantinteraction.entity.MXML",
+			want:   normalize.ErrSourceMissing,
+		},
+		{
+			name: "a refiner throughput field that is gone",
+			file: "gcgameplayglobals.global.MXML",
+			from: `<Property name="RefinerSubsMadeInTimeSurvival" value="100" />`,
+			to:   ``,
+			want: normalize.ErrStructureUnrecognized, mentions: "RefinerSubsMadeInTimeSurvival",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := copyTree(t, economyRoot)
+			switch {
+			case tc.remove != "":
+				if err := os.Remove(filepath.Join(root, tc.remove)); err != nil {
+					t.Fatal(err)
+				}
+			default:
+				p := filepath.Join(root, tc.file)
+				blob, err := os.ReadFile(p)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !strings.Contains(string(blob), tc.from) {
+					t.Fatalf("the fixture no longer contains the text this case edits, so it proves nothing")
+				}
+				edited := strings.Replace(string(blob), tc.from, tc.to, 1)
+				if err := os.WriteFile(p, []byte(edited), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			e, err := normalize.ReadEconomy(root)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("error = %v, want %v", err, tc.want)
+			}
+			if e != nil {
+				t.Error("an economy was returned alongside an error; must be nil")
+			}
+			if tc.mentions != "" && !strings.Contains(err.Error(), tc.mentions) {
+				t.Errorf("error %q does not name %q", err, tc.mentions)
+			}
+
+			var se *normalize.SourceError
+			if !errors.As(err, &se) {
+				t.Fatalf("error %v is not a *SourceError, so a logger cannot read its fields", err)
+			}
+			if se.Table == "" {
+				t.Error("the error names no table")
+			}
+		})
+	}
+}
+
+// copyTree copies a fixture tree into a temp dir so a case can break it.
+func copyTree(t *testing.T, src string) string {
+	t.Helper()
+	dst := t.TempDir()
+	err := filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || filepath.Ext(p) != ".MXML" {
+			return err
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		blob, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		out := filepath.Join(dst, rel)
+		if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(out, blob, 0o644)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dst
+}

--- a/internal/normalize/mxml.go
+++ b/internal/normalize/mxml.go
@@ -1,0 +1,211 @@
+package normalize
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+)
+
+// Governing: ADR-0001 (two-tier NMS data ingestion), SPEC-0004 REQ
+// "Structural Surprise Fails Loudly"
+//
+// MBINCompiler emits .MXML: a uniform tree of <Property> elements carrying
+// name/value/_id/_index attributes, where nesting rather than element naming
+// conveys structure.
+//
+//	<Data template="cGcProductTable">
+//	  <Property name="Table">
+//	    <Property name="Table" value="GcProductData" _id="CASING">
+//	      <Property name="ID" value="CASING" />
+//
+// Every accessor here is fail-closed. A field that is absent, or present
+// with an unparseable value, returns an error naming the table and the row
+// rather than a zero value — because a zero value for a recipe quantity or
+// an item ID produces an artifact that loads cleanly and is wrong.
+
+// node is one <Property> element.
+type node struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+	ID    string `xml:"_id,attr"`
+	Index string `xml:"_index,attr"`
+	Props []node `xml:"Property"`
+}
+
+// mxmlDoc is a decompiled .MXML file.
+type mxmlDoc struct {
+	Template string `xml:"template,attr"`
+	Props    []node `xml:"Property"`
+}
+
+// readMXML parses a .MXML file and checks its template.
+//
+// wantTemplate guards against pointing the wrong parser at the right-looking
+// file — a mistake that would otherwise surface as an empty table rather
+// than an error.
+func readMXML(path, wantTemplate string) (*mxmlDoc, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, Missing(path)
+		}
+		return nil, fmt.Errorf("opening %s: %w", path, err)
+	}
+	defer f.Close()
+	return decodeMXML(f, path, wantTemplate)
+}
+
+// decodeMXML parses from a reader, so tests need not touch the filesystem.
+func decodeMXML(r io.Reader, name, wantTemplate string) (*mxmlDoc, error) {
+	var doc mxmlDoc
+	if err := xml.NewDecoder(r).Decode(&doc); err != nil {
+		return nil, fmt.Errorf("%w: parsing %s: %v", ErrStructureUnrecognized, name, err)
+	}
+	if wantTemplate != "" && doc.Template != wantTemplate {
+		return nil, Unrecognized(name, "", "template", wantTemplate, doc.Template)
+	}
+	return &doc, nil
+}
+
+// child returns the first direct child with the given name.
+func (n node) child(name string) (node, bool) {
+	for _, p := range n.Props {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return node{}, false
+}
+
+// children returns every direct child with the given name.
+func (n node) children(name string) []node {
+	var out []node
+	for _, p := range n.Props {
+		if p.Name == name {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// str returns a required string field.
+func (n node) str(table, row, field string) (string, error) {
+	c, ok := n.child(field)
+	if !ok {
+		return "", Unrecognized(table, row, field, "present", "absent")
+	}
+	return c.Value, nil
+}
+
+// nonEmpty returns a required string field that must not be blank.
+func (n node) nonEmpty(table, row, field string) (string, error) {
+	v, err := n.str(table, row, field)
+	if err != nil {
+		return "", err
+	}
+	if v == "" {
+		return "", Unrecognized(table, row, field, "a non-empty value", `""`)
+	}
+	return v, nil
+}
+
+// int64 returns a required integer field.
+func (n node) int64(table, row, field string) (int64, error) {
+	c, ok := n.child(field)
+	if !ok {
+		return 0, Unrecognized(table, row, field, "present", "absent")
+	}
+	v, err := parseInt(c.Value)
+	if err != nil {
+		return 0, Unrecognized(table, row, field, "an integer", c.Value)
+	}
+	return v, nil
+}
+
+// float returns a required float field. MBINCompiler emits every float as a
+// fixed-point decimal ("150.000000"), so this is exact for the values it is
+// used on — class strengths and weightings — and would only lose precision
+// on a value the source does not contain.
+func (n node) float(table, row, field string) (float64, error) {
+	c, ok := n.child(field)
+	if !ok {
+		return 0, Unrecognized(table, row, field, "present", "absent")
+	}
+	v, err := strconv.ParseFloat(c.Value, 64)
+	if err != nil {
+		return 0, Unrecognized(table, row, field, "a number", c.Value)
+	}
+	return v, nil
+}
+
+// rows returns the table's row elements.
+//
+// The outer <Property name="Table"> wraps a repeated inner
+// <Property name="Table" value="GcXxx">; this walks both so callers work in
+// rows rather than in tree shape.
+func (d *mxmlDoc) rows(table, wrapper, rowValue string) ([]node, error) {
+	var outer node
+	var found bool
+	for _, p := range d.Props {
+		if p.Name == wrapper {
+			outer, found = p, true
+			break
+		}
+	}
+	if !found {
+		return nil, Unrecognized(table, "", wrapper, "present", "absent")
+	}
+	rows := outer.children(wrapper)
+	if len(rows) == 0 {
+		return nil, Unrecognized(table, "", wrapper, "at least one row", "none")
+	}
+	for i, r := range rows {
+		if r.Value != rowValue {
+			return nil, Unrecognized(table, fmt.Sprintf("row %d", i), "value", rowValue, r.Value)
+		}
+	}
+	return rows, nil
+}
+
+// parseInt accepts the integer and float-formatted integers MBINCompiler
+// emits ("1", "250", "5.000000") and refuses anything with a fractional
+// part, since every field this is used for is a count.
+func parseInt(s string) (int64, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty")
+	}
+	neg := false
+	i := 0
+	if s[0] == '-' || s[0] == '+' {
+		neg = s[0] == '-'
+		i = 1
+	}
+	var v int64
+	digits := 0
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c == '.' {
+			// A float-formatted integer is fine; a real fraction is not.
+			for j := i + 1; j < len(s); j++ {
+				if s[j] != '0' {
+					return 0, fmt.Errorf("has a fractional part")
+				}
+			}
+			break
+		}
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("not a number")
+		}
+		v = v*10 + int64(c-'0')
+		digits++
+	}
+	if digits == 0 {
+		return 0, fmt.Errorf("no digits")
+	}
+	if neg {
+		v = -v
+	}
+	return v, nil
+}

--- a/internal/normalize/testdata/economy/gcgameplayglobals.global.MXML
+++ b/internal/normalize/testdata/economy/gcgameplayglobals.global.MXML
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--File created using MBINCompiler version (6.45.0.1)-->
+<Data template="cGcGameplayGlobals">
+	<Property name="RefinerProductsMadeInTime" value="2" />
+	<Property name="RefinerSubsMadeInTime" value="250" />
+	<Property name="RefinerProductsMadeInTimeSurvival" value="1" />
+	<Property name="RefinerSubsMadeInTimeSurvival" value="100" />
+</Data>

--- a/internal/normalize/testdata/economy/gen.go
+++ b/internal/normalize/testdata/economy/gen.go
@@ -1,0 +1,239 @@
+//go:build ignore
+
+// Command gen builds the economy fixtures from a real decompiled extraction.
+//
+// Every fixture here is real game content, sliced rather than written: the
+// point of testing against them is that the parser meets the shapes the game
+// actually ships, and a hand-authored approximation of an MXML tree tests
+// only that the parser meets my expectations. That mistake has already cost
+// this project one whole subsystem.
+//
+// Usage, from a tree decompiled with MBINCompiler 6.45.0.1:
+//
+//	nmsextract extract NMSARC.Precache.pak  $SRC metadata/reality/tables/
+//	nmsextract extract NMSARC.Precache.pak  $SRC metadata/simulation/scanning/
+//	nmsextract extract NMSARC.Precache.pak  $SRC interactiveflora/farm
+//	nmsextract extract NMSARC.globals.pak   $SRC gcgameplayglobals
+//	MBINCompiler <each .mbin>
+//	go run gen.go $SRC
+//
+// Slices kept, and why:
+//
+//	basebuildingobjectstable  the parts named in SPEC-0004's acceptance
+//	                          criteria, one crop of each reward shape, one
+//	                          growth-network container, and one part with no
+//	                          rate at all to exercise the skip
+//	rewardtable               the reward entries those crops resolve to,
+//	                          plus one non-substance entry to exercise the
+//	                          filter
+//	regionhotspotstable       whole: 16 KB, and the family collapse needs
+//	                          every variant present to be meaningful
+//	gcgameplayglobals         the four refiner throughput properties
+//	plantinteraction.entity   the interaction component the crop chain reads
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var keepObjects = []string{
+	"U_EXTRACTOR_S",  // rate, storage, dependent power draw, hotspot
+	"U_GENERATOR_S",  // hotspot-scaled generator
+	"U_SOLAR_S",      // flat producer, no dependency
+	"SNOWPLANT",      // crop, substance reward
+	"BARRENPLANT",    // crop whose reward key differs from its substance
+	"LUSHPLANT",      // crop, substance reward
+	"SACVENOMPLANT",  // crop, product reward
+	"CARBONPLANTER",  // growth network, no flora entity: a container
+	"BUILD_REFINER1", // no rate, storage or dependency: must be skipped
+}
+
+var keepRewards = []string{
+	"PLANT_SNOW", "PLANT_BARREN", "PLANT_LUSH", "PLANT_SACVENOM",
+	"WILD_SNOW", // not farmed: must not be reachable from any crop
+}
+
+var keepFlora = []string{"farmsnow", "farmbarren", "farmlush", "farmvenomsac"}
+
+var keepGlobals = []string{
+	"RefinerProductsMadeInTime",
+	"RefinerSubsMadeInTime",
+	"RefinerProductsMadeInTimeSurvival",
+	"RefinerSubsMadeInTimeSurvival",
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run gen.go <decompiled-source-root>")
+		os.Exit(2)
+	}
+	src := os.Args[1]
+
+	must(sliceRows(
+		filepath.Join(src, "metadata/reality/tables/basebuildingobjectstable.MXML"),
+		"metadata/reality/tables/basebuildingobjectstable.MXML",
+		`<Property name="Objects" value="GcBaseBuildingEntry" _id=`, keepObjects,
+		`<Data template="cGcBaseBuildingTable">`, "Objects"))
+
+	must(sliceRows(
+		filepath.Join(src, "metadata/reality/tables/rewardtable.MXML"),
+		"metadata/reality/tables/rewardtable.MXML",
+		`<Property name="GenericTable" value="GcGenericRewardTableEntry" _id=`, keepRewards,
+		`<Data template="cGcRewardTable">`, "GenericTable"))
+
+	must(copyFile(
+		filepath.Join(src, "metadata/simulation/scanning/regionhotspotstable.MXML"),
+		"metadata/simulation/scanning/regionhotspotstable.MXML"))
+
+	must(sliceGlobals(
+		filepath.Join(src, "gcgameplayglobals.global.MXML"),
+		"gcgameplayglobals.global.MXML"))
+
+	for _, f := range keepFlora {
+		rel := filepath.Join("models/planets/biomes/common/interactiveflora", f,
+			"entities/plantinteraction.entity.MXML")
+		must(sliceInteraction(filepath.Join(src, rel), rel))
+	}
+}
+
+// sliceRows keeps the named rows of a table, preserving every byte of each
+// row exactly as the decompiler emitted it.
+func sliceRows(src, dst, marker string, keep []string, header, wrapper string) error {
+	body, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	wanted := map[string]bool{}
+	for _, k := range keep {
+		wanted[k] = true
+	}
+
+	lines := strings.Split(string(body), "\n")
+	var out []string
+	out = append(out, `<?xml version="1.0" encoding="utf-8"?>`,
+		`<!--File created using MBINCompiler version (6.45.0.1)-->`,
+		header, "\t"+`<Property name="`+wrapper+`">`)
+
+	depth := 0
+	var row []string
+	for _, l := range lines {
+		if depth == 0 {
+			if !strings.Contains(l, marker) {
+				continue
+			}
+			id := between(l, `_id="`, `"`)
+			if !wanted[id] {
+				continue
+			}
+			delete(wanted, id)
+			depth, row = 1, []string{l}
+			continue
+		}
+		row = append(row, l)
+		depth += strings.Count(l, "<Property name=") - strings.Count(l, "</Property>")
+		depth -= strings.Count(l, "/>")
+		if depth <= 0 {
+			out = append(out, row...)
+			depth, row = 0, nil
+		}
+	}
+	if len(wanted) > 0 {
+		return fmt.Errorf("%s: rows not found: %v", src, wanted)
+	}
+	out = append(out, "\t</Property>", "</Data>", "")
+	return write(dst, strings.Join(out, "\n"))
+}
+
+// sliceGlobals keeps only the refiner throughput properties.
+func sliceGlobals(src, dst string) error {
+	body, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	out := []string{`<?xml version="1.0" encoding="utf-8"?>`,
+		`<!--File created using MBINCompiler version (6.45.0.1)-->`,
+		`<Data template="cGcGameplayGlobals">`}
+	found := 0
+	for _, l := range strings.Split(string(body), "\n") {
+		for _, f := range keepGlobals {
+			if strings.Contains(l, `<Property name="`+f+`"`) {
+				out = append(out, l)
+				found++
+			}
+		}
+	}
+	if found != len(keepGlobals) {
+		return fmt.Errorf("%s: found %d of %d refiner properties", src, found, len(keepGlobals))
+	}
+	out = append(out, "</Data>", "")
+	return write(dst, strings.Join(out, "\n"))
+}
+
+// sliceInteraction keeps the simple-interaction component, which is the only
+// part of a 46 KB entity file the crop chain reads.
+func sliceInteraction(src, dst string) error {
+	body, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(body), "\n")
+	start, end := -1, -1
+	for i, l := range lines {
+		if start < 0 && strings.Contains(l, `value="GcSimpleInteractionComponentData"`) {
+			start = i
+			continue
+		}
+		if start >= 0 && strings.TrimSpace(l) == "</Property>" &&
+			len(l)-len(strings.TrimLeft(l, "\t")) == len(lines[start])-len(strings.TrimLeft(lines[start], "\t")) {
+			end = i
+			break
+		}
+	}
+	if start < 0 || end < 0 {
+		return fmt.Errorf("%s: no GcSimpleInteractionComponentData block", src)
+	}
+	out := append([]string{`<?xml version="1.0" encoding="utf-8"?>`,
+		`<!--File created using MBINCompiler version (6.45.0.1)-->`,
+		`<Data template="cTkAttachmentData">`, "\t" + `<Property name="Components">`},
+		lines[start:end+1]...)
+	out = append(out, "\t</Property>", "</Data>", "")
+	return write(dst, strings.Join(out, "\n"))
+}
+
+func copyFile(src, dst string) error {
+	b, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return write(dst, string(b))
+}
+
+func write(dst, body string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(dst, []byte(body), 0o644)
+}
+
+func between(s, open, close string) string {
+	i := strings.Index(s, open)
+	if i < 0 {
+		return ""
+	}
+	s = s[i+len(open):]
+	j := strings.Index(s, close)
+	if j < 0 {
+		return ""
+	}
+	return s[:j]
+}
+
+func must(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/internal/normalize/testdata/economy/metadata/reality/tables/basebuildingobjectstable.MXML
+++ b/internal/normalize/testdata/economy/metadata/reality/tables/basebuildingobjectstable.MXML
@@ -1,0 +1,1091 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--File created using MBINCompiler version (6.45.0.1)-->
+<Data template="cGcBaseBuildingTable">
+	<Property name="Objects">
+		<Property name="Objects" value="GcBaseBuildingEntry" _id="BUILD_REFINER1">
+			<Property name="ID" value="BUILD_REFINER1" />
+			<Property name="IsTemporary" value="false" />
+			<Property name="IsFromModFolder" value="false" />
+			<Property name="Style" value="GcBaseBuildingPartStyle">
+				<Property name="Style" value="None" />
+			</Property>
+			<Property name="PlacementScene" value="TkModelResource">
+				<Property name="Filename" value="MODELS/PLANETS/BIOMES/COMMON/BUILDINGS/PARTS/BUILDABLEPARTS/TECH/REFINER1_PLACEMENT.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="SinglePartID" value="" />
+			<Property name="DecorationType" value="GcBaseBuildingObjectDecorationTypes">
+				<Property name="BaseBuildingDecorationType" value="Normal" />
+			</Property>
+			<Property name="IsPlaceable" value="true" />
+			<Property name="IsDecoration" value="false" />
+			<Property name="Biome" value="GcBiomeType">
+				<Property name="Biome" value="All" />
+			</Property>
+			<Property name="BuildableOnPlanetBase" value="true" />
+			<Property name="BuildableOnSpaceBase" value="false" />
+			<Property name="BuildableOnFreighter" value="true" />
+			<Property name="BuildableInShipStructural" value="false" />
+			<Property name="BuildableInShipDecorative" value="true" />
+			<Property name="BuildableOnPlanet" value="true" />
+			<Property name="BuildableOnPlanetWithProduct" value="false" />
+			<Property name="BuildableUnderwater" value="true" />
+			<Property name="BuildableAboveWater" value="true" />
+			<Property name="PlanetLimit" value="0" />
+			<Property name="RegionLimit" value="0" />
+			<Property name="PlanetBaseLimit" value="0" />
+			<Property name="FreighterBaseLimit" value="0" />
+			<Property name="CorvetteBaseLimit" value="0" />
+			<Property name="DoesNotCountTowardsComplexity" value="false" />
+			<Property name="CheckPlaceholderCollision" value="false" />
+			<Property name="CheckPlayerCollision" value="true" />
+			<Property name="CanStack" value="false" />
+			<Property name="SnapRotateBlocked" value="false" />
+			<Property name="CanRotate3D" value="false" />
+			<Property name="CanScale" value="false" />
+			<Property name="Groups">
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="0">
+					<Property name="Group" value="PLANET_TECH" />
+					<Property name="SubGroupName" value="PLANETPORTABLE" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="1">
+					<Property name="Group" value="FREIGHTER_TECH" />
+					<Property name="SubGroupName" value="FRE_TECH_OTHER" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+			</Property>
+			<Property name="StorageContainerIndex" value="-1" />
+			<Property name="ColourPaletteGroupId" value="LEGACY" />
+			<Property name="DefaultColourPaletteId" value="" />
+			<Property name="MaterialGroupId" value="ALL" />
+			<Property name="DefaultMaterialId" value="" />
+			<Property name="CanChangeColour" value="true" />
+			<Property name="CanChangeMaterial" value="true" />
+			<Property name="CanPickUp" value="true" />
+			<Property name="ShowInBuildMenu" value="true" />
+			<Property name="CompositePartObjectIDs" />
+			<Property name="FamilyIDs" />
+			<Property name="BuildEffectAccelerator" value="1.000000" />
+			<Property name="IconOverrideProductID" value="" />
+			<Property name="RemovesAttachedDecoration" value="true" />
+			<Property name="RemovesWhenUnsnapped" value="false" />
+			<Property name="EditsTerrain" value="false" />
+			<Property name="BaseTerrainEditShape" value="Cube" />
+			<Property name="MinimumDeleteDistance" value="1.000000" />
+			<Property name="IsSealed" value="false" />
+			<Property name="CloseMenuAfterBuild" value="true" />
+			<Property name="Tag" value="" />
+			<Property name="LinkGridData" value="GcBaseLinkGridData">
+				<Property name="Connection" value="GcBaseLinkGridConnectionData">
+					<Property name="Network" value="GcLinkNetworkTypes">
+						<Property name="LinkNetworkType" value="Power" />
+					</Property>
+					<Property name="NetworkSubGroup" value="0" />
+					<Property name="NetworkMask" value="0" />
+					<Property name="ConnectionDistance" value="0.100000" />
+					<Property name="UseMinDistance" value="false" />
+					<Property name="LinkSocketPositions" />
+					<Property name="LinkSocketSubGroups" />
+				</Property>
+				<Property name="Rate" value="0" />
+				<Property name="Storage" value="0" />
+				<Property name="DependsOnEnvironment" value="None" />
+				<Property name="DependsOnHotspots" value="None" />
+				<Property name="DependentConnections" />
+			</Property>
+			<Property name="GhostsCountOverride" value="1" />
+			<Property name="ShowGhosts" value="true" />
+			<Property name="SnappingDistanceOverride" value="0.100000" />
+			<Property name="RegionSpawnLOD" value="1" />
+			<Property name="NPCInteractionScene" value="TkModelResource">
+				<Property name="Filename" value="" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="IsModularCustomisation" value="false" />
+			<Property name="ModularCustomisationBaseID" value="" />
+			<Property name="HasDescriptor" value="false" />
+			<Property name="DescriptorID" value="" />
+			<Property name="UseProductIDOverride" value="false" />
+			<Property name="OverrideProductID" value="" />
+			<Property name="FossilDisplayID" value="" />
+		</Property>
+		<Property name="Objects" value="GcBaseBuildingEntry" _id="CARBONPLANTER">
+			<Property name="ID" value="CARBONPLANTER" />
+			<Property name="IsTemporary" value="false" />
+			<Property name="IsFromModFolder" value="false" />
+			<Property name="Style" value="GcBaseBuildingPartStyle">
+				<Property name="Style" value="None" />
+			</Property>
+			<Property name="PlacementScene" value="TkModelResource">
+				<Property name="Filename" value="MODELS/PLANETS/BIOMES/COMMON/BUILDINGS/PARTS/BUILDABLEPARTS/TECH/PLANTER_WALLSHELVES_PLACEMENT.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="SinglePartID" value="" />
+			<Property name="DecorationType" value="GcBaseBuildingObjectDecorationTypes">
+				<Property name="BaseBuildingDecorationType" value="Normal" />
+			</Property>
+			<Property name="IsPlaceable" value="true" />
+			<Property name="IsDecoration" value="true" />
+			<Property name="Biome" value="GcBiomeType">
+				<Property name="Biome" value="Lush" />
+			</Property>
+			<Property name="BuildableOnPlanetBase" value="true" />
+			<Property name="BuildableOnSpaceBase" value="false" />
+			<Property name="BuildableOnFreighter" value="true" />
+			<Property name="BuildableInShipStructural" value="false" />
+			<Property name="BuildableInShipDecorative" value="true" />
+			<Property name="BuildableOnPlanet" value="false" />
+			<Property name="BuildableOnPlanetWithProduct" value="false" />
+			<Property name="BuildableUnderwater" value="true" />
+			<Property name="BuildableAboveWater" value="true" />
+			<Property name="PlanetLimit" value="0" />
+			<Property name="RegionLimit" value="0" />
+			<Property name="PlanetBaseLimit" value="0" />
+			<Property name="FreighterBaseLimit" value="0" />
+			<Property name="CorvetteBaseLimit" value="0" />
+			<Property name="DoesNotCountTowardsComplexity" value="false" />
+			<Property name="CheckPlaceholderCollision" value="false" />
+			<Property name="CheckPlayerCollision" value="true" />
+			<Property name="CanStack" value="true" />
+			<Property name="SnapRotateBlocked" value="false" />
+			<Property name="CanRotate3D" value="false" />
+			<Property name="CanScale" value="false" />
+			<Property name="Groups">
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="0">
+					<Property name="Group" value="BASE_TECH" />
+					<Property name="SubGroupName" value="TECHFARMING" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="1">
+					<Property name="Group" value="FREIGHTER_BIO" />
+					<Property name="SubGroupName" value="FRE_PLANTS" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+			</Property>
+			<Property name="StorageContainerIndex" value="-1" />
+			<Property name="ColourPaletteGroupId" value="LEGACY" />
+			<Property name="DefaultColourPaletteId" value="" />
+			<Property name="MaterialGroupId" value="ALL" />
+			<Property name="DefaultMaterialId" value="" />
+			<Property name="CanChangeColour" value="true" />
+			<Property name="CanChangeMaterial" value="true" />
+			<Property name="CanPickUp" value="false" />
+			<Property name="ShowInBuildMenu" value="true" />
+			<Property name="CompositePartObjectIDs" />
+			<Property name="FamilyIDs" />
+			<Property name="BuildEffectAccelerator" value="1.000000" />
+			<Property name="IconOverrideProductID" value="" />
+			<Property name="RemovesAttachedDecoration" value="true" />
+			<Property name="RemovesWhenUnsnapped" value="false" />
+			<Property name="EditsTerrain" value="false" />
+			<Property name="BaseTerrainEditShape" value="Cube" />
+			<Property name="MinimumDeleteDistance" value="1.000000" />
+			<Property name="IsSealed" value="false" />
+			<Property name="CloseMenuAfterBuild" value="false" />
+			<Property name="Tag" value="" />
+			<Property name="LinkGridData" value="GcBaseLinkGridData">
+				<Property name="Connection" value="GcBaseLinkGridConnectionData">
+					<Property name="Network" value="GcLinkNetworkTypes">
+						<Property name="LinkNetworkType" value="PlantGrowth" />
+					</Property>
+					<Property name="NetworkSubGroup" value="0" />
+					<Property name="NetworkMask" value="2" />
+					<Property name="ConnectionDistance" value="0.100000" />
+					<Property name="UseMinDistance" value="false" />
+					<Property name="LinkSocketPositions" />
+					<Property name="LinkSocketSubGroups" />
+				</Property>
+				<Property name="Rate" value="1" />
+				<Property name="Storage" value="600" />
+				<Property name="DependsOnEnvironment" value="None" />
+				<Property name="DependsOnHotspots" value="None" />
+				<Property name="DependentConnections">
+					<Property name="DependentConnections" value="GcBaseLinkGridConnectionDependency" _index="0">
+						<Property name="Connection" value="GcBaseLinkGridConnectionData">
+							<Property name="Network" value="GcLinkNetworkTypes">
+								<Property name="LinkNetworkType" value="Power" />
+							</Property>
+							<Property name="NetworkSubGroup" value="8" />
+							<Property name="NetworkMask" value="1052" />
+							<Property name="ConnectionDistance" value="4.500000" />
+							<Property name="UseMinDistance" value="false" />
+							<Property name="LinkSocketPositions" />
+							<Property name="LinkSocketSubGroups" />
+						</Property>
+						<Property name="DependentRate" value="-5" />
+						<Property name="DependentEffect" value="EnablesRate" />
+						<Property name="DisableWhenOffline" value="false" />
+						<Property name="TransfersConnections" value="true" />
+					</Property>
+				</Property>
+			</Property>
+			<Property name="GhostsCountOverride" value="0" />
+			<Property name="ShowGhosts" value="true" />
+			<Property name="SnappingDistanceOverride" value="0.000000" />
+			<Property name="RegionSpawnLOD" value="1" />
+			<Property name="NPCInteractionScene" value="TkModelResource">
+				<Property name="Filename" value="MODELS/PLANETS/BIOMES/COMMON/BUILDINGS/PARTS/BUILDABLEPARTS/NPCINTERACTION/PLANTER_WALLSHELVES.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="IsModularCustomisation" value="false" />
+			<Property name="ModularCustomisationBaseID" value="" />
+			<Property name="HasDescriptor" value="false" />
+			<Property name="DescriptorID" value="" />
+			<Property name="UseProductIDOverride" value="false" />
+			<Property name="OverrideProductID" value="" />
+			<Property name="FossilDisplayID" value="" />
+		</Property>
+		<Property name="Objects" value="GcBaseBuildingEntry" _id="U_EXTRACTOR_S">
+			<Property name="ID" value="U_EXTRACTOR_S" />
+			<Property name="IsTemporary" value="false" />
+			<Property name="IsFromModFolder" value="false" />
+			<Property name="Style" value="GcBaseBuildingPartStyle">
+				<Property name="Style" value="None" />
+			</Property>
+			<Property name="PlacementScene" value="TkModelResource">
+				<Property name="Filename" value="MODELS/PLANETS/BIOMES/COMMON/BUILDINGS/PARTS/BUILDABLEPARTS/UTILITYPARTS/MODULE_PUMPS_PLACEMENT.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="SinglePartID" value="" />
+			<Property name="DecorationType" value="GcBaseBuildingObjectDecorationTypes">
+				<Property name="BaseBuildingDecorationType" value="Normal" />
+			</Property>
+			<Property name="IsPlaceable" value="true" />
+			<Property name="IsDecoration" value="false" />
+			<Property name="Biome" value="GcBiomeType">
+				<Property name="Biome" value="Lush" />
+			</Property>
+			<Property name="BuildableOnPlanetBase" value="true" />
+			<Property name="BuildableOnSpaceBase" value="false" />
+			<Property name="BuildableOnFreighter" value="false" />
+			<Property name="BuildableInShipStructural" value="false" />
+			<Property name="BuildableInShipDecorative" value="false" />
+			<Property name="BuildableOnPlanet" value="false" />
+			<Property name="BuildableOnPlanetWithProduct" value="false" />
+			<Property name="BuildableUnderwater" value="true" />
+			<Property name="BuildableAboveWater" value="true" />
+			<Property name="PlanetLimit" value="0" />
+			<Property name="RegionLimit" value="0" />
+			<Property name="PlanetBaseLimit" value="0" />
+			<Property name="FreighterBaseLimit" value="0" />
+			<Property name="CorvetteBaseLimit" value="0" />
+			<Property name="DoesNotCountTowardsComplexity" value="false" />
+			<Property name="CheckPlaceholderCollision" value="false" />
+			<Property name="CheckPlayerCollision" value="true" />
+			<Property name="CanStack" value="true" />
+			<Property name="SnapRotateBlocked" value="false" />
+			<Property name="CanRotate3D" value="false" />
+			<Property name="CanScale" value="false" />
+			<Property name="Groups">
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="0">
+					<Property name="Group" value="POWER" />
+					<Property name="SubGroupName" value="POWERINDUSTRY" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+			</Property>
+			<Property name="StorageContainerIndex" value="-1" />
+			<Property name="ColourPaletteGroupId" value="LEGACY" />
+			<Property name="DefaultColourPaletteId" value="" />
+			<Property name="MaterialGroupId" value="" />
+			<Property name="DefaultMaterialId" value="" />
+			<Property name="CanChangeColour" value="true" />
+			<Property name="CanChangeMaterial" value="false" />
+			<Property name="CanPickUp" value="false" />
+			<Property name="ShowInBuildMenu" value="true" />
+			<Property name="CompositePartObjectIDs" />
+			<Property name="FamilyIDs" />
+			<Property name="BuildEffectAccelerator" value="1.000000" />
+			<Property name="IconOverrideProductID" value="" />
+			<Property name="RemovesAttachedDecoration" value="true" />
+			<Property name="RemovesWhenUnsnapped" value="false" />
+			<Property name="EditsTerrain" value="false" />
+			<Property name="BaseTerrainEditShape" value="Cube" />
+			<Property name="MinimumDeleteDistance" value="1.000000" />
+			<Property name="IsSealed" value="false" />
+			<Property name="CloseMenuAfterBuild" value="false" />
+			<Property name="Tag" value="" />
+			<Property name="LinkGridData" value="GcBaseLinkGridData">
+				<Property name="Connection" value="GcBaseLinkGridConnectionData">
+					<Property name="Network" value="GcLinkNetworkTypes">
+						<Property name="LinkNetworkType" value="Resources" />
+					</Property>
+					<Property name="NetworkSubGroup" value="0" />
+					<Property name="NetworkMask" value="2" />
+					<Property name="ConnectionDistance" value="3.000000" />
+					<Property name="UseMinDistance" value="false" />
+					<Property name="LinkSocketPositions" />
+					<Property name="LinkSocketSubGroups" />
+				</Property>
+				<Property name="Rate" value="100" />
+				<Property name="Storage" value="360000" />
+				<Property name="DependsOnEnvironment" value="None" />
+				<Property name="DependsOnHotspots" value="Mineral" />
+				<Property name="DependentConnections">
+					<Property name="DependentConnections" value="GcBaseLinkGridConnectionDependency" _index="0">
+						<Property name="Connection" value="GcBaseLinkGridConnectionData">
+							<Property name="Network" value="GcLinkNetworkTypes">
+								<Property name="LinkNetworkType" value="Power" />
+							</Property>
+							<Property name="NetworkSubGroup" value="1" />
+							<Property name="NetworkMask" value="4" />
+							<Property name="ConnectionDistance" value="0.100000" />
+							<Property name="UseMinDistance" value="false" />
+							<Property name="LinkSocketPositions" />
+							<Property name="LinkSocketSubGroups" />
+						</Property>
+						<Property name="DependentRate" value="-50" />
+						<Property name="DependentEffect" value="EnablesRate" />
+						<Property name="DisableWhenOffline" value="false" />
+						<Property name="TransfersConnections" value="true" />
+					</Property>
+				</Property>
+			</Property>
+			<Property name="GhostsCountOverride" value="0" />
+			<Property name="ShowGhosts" value="true" />
+			<Property name="SnappingDistanceOverride" value="0.000000" />
+			<Property name="RegionSpawnLOD" value="1" />
+			<Property name="NPCInteractionScene" value="TkModelResource">
+				<Property name="Filename" value="" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="IsModularCustomisation" value="false" />
+			<Property name="ModularCustomisationBaseID" value="" />
+			<Property name="HasDescriptor" value="false" />
+			<Property name="DescriptorID" value="" />
+			<Property name="UseProductIDOverride" value="false" />
+			<Property name="OverrideProductID" value="" />
+			<Property name="FossilDisplayID" value="" />
+		</Property>
+		<Property name="Objects" value="GcBaseBuildingEntry" _id="U_SOLAR_S">
+			<Property name="ID" value="U_SOLAR_S" />
+			<Property name="IsTemporary" value="false" />
+			<Property name="IsFromModFolder" value="false" />
+			<Property name="Style" value="GcBaseBuildingPartStyle">
+				<Property name="Style" value="None" />
+			</Property>
+			<Property name="PlacementScene" value="TkModelResource">
+				<Property name="Filename" value="MODELS/PLANETS/BIOMES/COMMON/BUILDINGS/PARTS/BUILDABLEPARTS/UTILITYPARTS/MODULE_SOLARPANELS_PLACEMENT.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="SinglePartID" value="" />
+			<Property name="DecorationType" value="GcBaseBuildingObjectDecorationTypes">
+				<Property name="BaseBuildingDecorationType" value="Normal" />
+			</Property>
+			<Property name="IsPlaceable" value="true" />
+			<Property name="IsDecoration" value="false" />
+			<Property name="Biome" value="GcBiomeType">
+				<Property name="Biome" value="Lush" />
+			</Property>
+			<Property name="BuildableOnPlanetBase" value="true" />
+			<Property name="BuildableOnSpaceBase" value="false" />
+			<Property name="BuildableOnFreighter" value="false" />
+			<Property name="BuildableInShipStructural" value="false" />
+			<Property name="BuildableInShipDecorative" value="false" />
+			<Property name="BuildableOnPlanet" value="false" />
+			<Property name="BuildableOnPlanetWithProduct" value="false" />
+			<Property name="BuildableUnderwater" value="true" />
+			<Property name="BuildableAboveWater" value="true" />
+			<Property name="PlanetLimit" value="0" />
+			<Property name="RegionLimit" value="0" />
+			<Property name="PlanetBaseLimit" value="0" />
+			<Property name="FreighterBaseLimit" value="0" />
+			<Property name="CorvetteBaseLimit" value="0" />
+			<Property name="DoesNotCountTowardsComplexity" value="false" />
+			<Property name="CheckPlaceholderCollision" value="false" />
+			<Property name="CheckPlayerCollision" value="true" />
+			<Property name="CanStack" value="true" />
+			<Property name="SnapRotateBlocked" value="false" />
+			<Property name="CanRotate3D" value="false" />
+			<Property name="CanScale" value="false" />
+			<Property name="Groups">
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="0">
+					<Property name="Group" value="POWER" />
+					<Property name="SubGroupName" value="POWERPOWER" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+			</Property>
+			<Property name="StorageContainerIndex" value="-1" />
+			<Property name="ColourPaletteGroupId" value="LEGACY" />
+			<Property name="DefaultColourPaletteId" value="" />
+			<Property name="MaterialGroupId" value="" />
+			<Property name="DefaultMaterialId" value="" />
+			<Property name="CanChangeColour" value="true" />
+			<Property name="CanChangeMaterial" value="false" />
+			<Property name="CanPickUp" value="false" />
+			<Property name="ShowInBuildMenu" value="true" />
+			<Property name="CompositePartObjectIDs" />
+			<Property name="FamilyIDs" />
+			<Property name="BuildEffectAccelerator" value="1.000000" />
+			<Property name="IconOverrideProductID" value="" />
+			<Property name="RemovesAttachedDecoration" value="true" />
+			<Property name="RemovesWhenUnsnapped" value="false" />
+			<Property name="EditsTerrain" value="false" />
+			<Property name="BaseTerrainEditShape" value="Cube" />
+			<Property name="MinimumDeleteDistance" value="1.000000" />
+			<Property name="IsSealed" value="false" />
+			<Property name="CloseMenuAfterBuild" value="false" />
+			<Property name="Tag" value="" />
+			<Property name="LinkGridData" value="GcBaseLinkGridData">
+				<Property name="Connection" value="GcBaseLinkGridConnectionData">
+					<Property name="Network" value="GcLinkNetworkTypes">
+						<Property name="LinkNetworkType" value="Power" />
+					</Property>
+					<Property name="NetworkSubGroup" value="0" />
+					<Property name="NetworkMask" value="12" />
+					<Property name="ConnectionDistance" value="0.100000" />
+					<Property name="UseMinDistance" value="false" />
+					<Property name="LinkSocketPositions" />
+					<Property name="LinkSocketSubGroups" />
+				</Property>
+				<Property name="Rate" value="50" />
+				<Property name="Storage" value="0" />
+				<Property name="DependsOnEnvironment" value="DayNight" />
+				<Property name="DependsOnHotspots" value="None" />
+				<Property name="DependentConnections" />
+			</Property>
+			<Property name="GhostsCountOverride" value="6" />
+			<Property name="ShowGhosts" value="true" />
+			<Property name="SnappingDistanceOverride" value="0.000000" />
+			<Property name="RegionSpawnLOD" value="1" />
+			<Property name="NPCInteractionScene" value="TkModelResource">
+				<Property name="Filename" value="" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="IsModularCustomisation" value="false" />
+			<Property name="ModularCustomisationBaseID" value="" />
+			<Property name="HasDescriptor" value="false" />
+			<Property name="DescriptorID" value="" />
+			<Property name="UseProductIDOverride" value="false" />
+			<Property name="OverrideProductID" value="" />
+			<Property name="FossilDisplayID" value="" />
+		</Property>
+		<Property name="Objects" value="GcBaseBuildingEntry" _id="U_GENERATOR_S">
+			<Property name="ID" value="U_GENERATOR_S" />
+			<Property name="IsTemporary" value="false" />
+			<Property name="IsFromModFolder" value="false" />
+			<Property name="Style" value="GcBaseBuildingPartStyle">
+				<Property name="Style" value="None" />
+			</Property>
+			<Property name="PlacementScene" value="TkModelResource">
+				<Property name="Filename" value="MODELS/PLANETS/BIOMES/COMMON/BUILDINGS/PARTS/BUILDABLEPARTS/UTILITYPARTS/MODULE_GENERATORS_PLACEMENT.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="SinglePartID" value="" />
+			<Property name="DecorationType" value="GcBaseBuildingObjectDecorationTypes">
+				<Property name="BaseBuildingDecorationType" value="Normal" />
+			</Property>
+			<Property name="IsPlaceable" value="true" />
+			<Property name="IsDecoration" value="false" />
+			<Property name="Biome" value="GcBiomeType">
+				<Property name="Biome" value="Lush" />
+			</Property>
+			<Property name="BuildableOnPlanetBase" value="true" />
+			<Property name="BuildableOnSpaceBase" value="false" />
+			<Property name="BuildableOnFreighter" value="false" />
+			<Property name="BuildableInShipStructural" value="false" />
+			<Property name="BuildableInShipDecorative" value="false" />
+			<Property name="BuildableOnPlanet" value="false" />
+			<Property name="BuildableOnPlanetWithProduct" value="false" />
+			<Property name="BuildableUnderwater" value="true" />
+			<Property name="BuildableAboveWater" value="true" />
+			<Property name="PlanetLimit" value="0" />
+			<Property name="RegionLimit" value="0" />
+			<Property name="PlanetBaseLimit" value="0" />
+			<Property name="FreighterBaseLimit" value="0" />
+			<Property name="CorvetteBaseLimit" value="0" />
+			<Property name="DoesNotCountTowardsComplexity" value="false" />
+			<Property name="CheckPlaceholderCollision" value="false" />
+			<Property name="CheckPlayerCollision" value="true" />
+			<Property name="CanStack" value="true" />
+			<Property name="SnapRotateBlocked" value="false" />
+			<Property name="CanRotate3D" value="false" />
+			<Property name="CanScale" value="false" />
+			<Property name="Groups">
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="0">
+					<Property name="Group" value="POWER" />
+					<Property name="SubGroupName" value="POWERPOWER" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+			</Property>
+			<Property name="StorageContainerIndex" value="-1" />
+			<Property name="ColourPaletteGroupId" value="LEGACY" />
+			<Property name="DefaultColourPaletteId" value="" />
+			<Property name="MaterialGroupId" value="" />
+			<Property name="DefaultMaterialId" value="" />
+			<Property name="CanChangeColour" value="true" />
+			<Property name="CanChangeMaterial" value="false" />
+			<Property name="CanPickUp" value="false" />
+			<Property name="ShowInBuildMenu" value="true" />
+			<Property name="CompositePartObjectIDs" />
+			<Property name="FamilyIDs" />
+			<Property name="BuildEffectAccelerator" value="1.000000" />
+			<Property name="IconOverrideProductID" value="" />
+			<Property name="RemovesAttachedDecoration" value="true" />
+			<Property name="RemovesWhenUnsnapped" value="false" />
+			<Property name="EditsTerrain" value="false" />
+			<Property name="BaseTerrainEditShape" value="Cube" />
+			<Property name="MinimumDeleteDistance" value="1.000000" />
+			<Property name="IsSealed" value="false" />
+			<Property name="CloseMenuAfterBuild" value="false" />
+			<Property name="Tag" value="" />
+			<Property name="LinkGridData" value="GcBaseLinkGridData">
+				<Property name="Connection" value="GcBaseLinkGridConnectionData">
+					<Property name="Network" value="GcLinkNetworkTypes">
+						<Property name="LinkNetworkType" value="Power" />
+					</Property>
+					<Property name="NetworkSubGroup" value="1" />
+					<Property name="NetworkMask" value="4" />
+					<Property name="ConnectionDistance" value="0.100000" />
+					<Property name="UseMinDistance" value="false" />
+					<Property name="LinkSocketPositions" />
+					<Property name="LinkSocketSubGroups" />
+				</Property>
+				<Property name="Rate" value="1" />
+				<Property name="Storage" value="0" />
+				<Property name="DependsOnEnvironment" value="None" />
+				<Property name="DependsOnHotspots" value="Power" />
+				<Property name="DependentConnections" />
+			</Property>
+			<Property name="GhostsCountOverride" value="0" />
+			<Property name="ShowGhosts" value="true" />
+			<Property name="SnappingDistanceOverride" value="0.000000" />
+			<Property name="RegionSpawnLOD" value="1" />
+			<Property name="NPCInteractionScene" value="TkModelResource">
+				<Property name="Filename" value="" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="IsModularCustomisation" value="false" />
+			<Property name="ModularCustomisationBaseID" value="" />
+			<Property name="HasDescriptor" value="false" />
+			<Property name="DescriptorID" value="" />
+			<Property name="UseProductIDOverride" value="false" />
+			<Property name="OverrideProductID" value="" />
+			<Property name="FossilDisplayID" value="" />
+		</Property>
+		<Property name="Objects" value="GcBaseBuildingEntry" _id="SNOWPLANT">
+			<Property name="ID" value="SNOWPLANT" />
+			<Property name="IsTemporary" value="false" />
+			<Property name="IsFromModFolder" value="false" />
+			<Property name="Style" value="GcBaseBuildingPartStyle">
+				<Property name="Style" value="None" />
+			</Property>
+			<Property name="PlacementScene" value="TkModelResource">
+				<Property name="Filename" value="MODELS/PLANETS/BIOMES/COMMON/INTERACTIVEFLORA/FARMSNOW_PLACEMENT.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="SinglePartID" value="" />
+			<Property name="DecorationType" value="GcBaseBuildingObjectDecorationTypes">
+				<Property name="BaseBuildingDecorationType" value="Plant" />
+			</Property>
+			<Property name="IsPlaceable" value="false" />
+			<Property name="IsDecoration" value="true" />
+			<Property name="Biome" value="GcBiomeType">
+				<Property name="Biome" value="Frozen" />
+			</Property>
+			<Property name="BuildableOnPlanetBase" value="true" />
+			<Property name="BuildableOnSpaceBase" value="false" />
+			<Property name="BuildableOnFreighter" value="true" />
+			<Property name="BuildableInShipStructural" value="false" />
+			<Property name="BuildableInShipDecorative" value="true" />
+			<Property name="BuildableOnPlanet" value="false" />
+			<Property name="BuildableOnPlanetWithProduct" value="true" />
+			<Property name="BuildableUnderwater" value="true" />
+			<Property name="BuildableAboveWater" value="true" />
+			<Property name="PlanetLimit" value="0" />
+			<Property name="RegionLimit" value="0" />
+			<Property name="PlanetBaseLimit" value="0" />
+			<Property name="FreighterBaseLimit" value="0" />
+			<Property name="CorvetteBaseLimit" value="0" />
+			<Property name="DoesNotCountTowardsComplexity" value="false" />
+			<Property name="CheckPlaceholderCollision" value="false" />
+			<Property name="CheckPlayerCollision" value="true" />
+			<Property name="CanStack" value="true" />
+			<Property name="SnapRotateBlocked" value="false" />
+			<Property name="CanRotate3D" value="false" />
+			<Property name="CanScale" value="false" />
+			<Property name="Groups">
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="0">
+					<Property name="Group" value="BASE_TECH" />
+					<Property name="SubGroupName" value="TECHFARMING" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="1">
+					<Property name="Group" value="FREIGHTER_BIO" />
+					<Property name="SubGroupName" value="FRE_PLANTS" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="2">
+					<Property name="Group" value="BIGGS_LOW_PERF" />
+					<Property name="SubGroupName" value="BIGGSFARMING" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+			</Property>
+			<Property name="StorageContainerIndex" value="-1" />
+			<Property name="ColourPaletteGroupId" value="" />
+			<Property name="DefaultColourPaletteId" value="" />
+			<Property name="MaterialGroupId" value="" />
+			<Property name="DefaultMaterialId" value="" />
+			<Property name="CanChangeColour" value="false" />
+			<Property name="CanChangeMaterial" value="false" />
+			<Property name="CanPickUp" value="false" />
+			<Property name="ShowInBuildMenu" value="true" />
+			<Property name="CompositePartObjectIDs" />
+			<Property name="FamilyIDs" />
+			<Property name="BuildEffectAccelerator" value="1.000000" />
+			<Property name="IconOverrideProductID" value="" />
+			<Property name="RemovesAttachedDecoration" value="false" />
+			<Property name="RemovesWhenUnsnapped" value="false" />
+			<Property name="EditsTerrain" value="false" />
+			<Property name="BaseTerrainEditShape" value="Cube" />
+			<Property name="MinimumDeleteDistance" value="1.000000" />
+			<Property name="IsSealed" value="false" />
+			<Property name="CloseMenuAfterBuild" value="false" />
+			<Property name="Tag" value="" />
+			<Property name="LinkGridData" value="GcBaseLinkGridData">
+				<Property name="Connection" value="GcBaseLinkGridConnectionData">
+					<Property name="Network" value="GcLinkNetworkTypes">
+						<Property name="LinkNetworkType" value="PlantGrowth" />
+					</Property>
+					<Property name="NetworkSubGroup" value="0" />
+					<Property name="NetworkMask" value="2" />
+					<Property name="ConnectionDistance" value="0.100000" />
+					<Property name="UseMinDistance" value="false" />
+					<Property name="LinkSocketPositions" />
+					<Property name="LinkSocketSubGroups" />
+				</Property>
+				<Property name="Rate" value="1" />
+				<Property name="Storage" value="3600" />
+				<Property name="DependsOnEnvironment" value="None" />
+				<Property name="DependsOnHotspots" value="None" />
+				<Property name="DependentConnections">
+					<Property name="DependentConnections" value="GcBaseLinkGridConnectionDependency" _index="0">
+						<Property name="Connection" value="GcBaseLinkGridConnectionData">
+							<Property name="Network" value="GcLinkNetworkTypes">
+								<Property name="LinkNetworkType" value="Power" />
+							</Property>
+							<Property name="NetworkSubGroup" value="9" />
+							<Property name="NetworkMask" value="1280" />
+							<Property name="ConnectionDistance" value="0.400000" />
+							<Property name="UseMinDistance" value="false" />
+							<Property name="LinkSocketPositions" />
+							<Property name="LinkSocketSubGroups" />
+						</Property>
+						<Property name="DependentRate" value="0" />
+						<Property name="DependentEffect" value="EnablesRate" />
+						<Property name="DisableWhenOffline" value="false" />
+						<Property name="TransfersConnections" value="true" />
+					</Property>
+				</Property>
+			</Property>
+			<Property name="GhostsCountOverride" value="4" />
+			<Property name="ShowGhosts" value="true" />
+			<Property name="SnappingDistanceOverride" value="0.100000" />
+			<Property name="RegionSpawnLOD" value="1" />
+			<Property name="NPCInteractionScene" value="TkModelResource">
+				<Property name="Filename" value="" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="IsModularCustomisation" value="false" />
+			<Property name="ModularCustomisationBaseID" value="" />
+			<Property name="HasDescriptor" value="false" />
+			<Property name="DescriptorID" value="" />
+			<Property name="UseProductIDOverride" value="false" />
+			<Property name="OverrideProductID" value="" />
+			<Property name="FossilDisplayID" value="" />
+		</Property>
+		<Property name="Objects" value="GcBaseBuildingEntry" _id="SACVENOMPLANT">
+			<Property name="ID" value="SACVENOMPLANT" />
+			<Property name="IsTemporary" value="false" />
+			<Property name="IsFromModFolder" value="false" />
+			<Property name="Style" value="GcBaseBuildingPartStyle">
+				<Property name="Style" value="None" />
+			</Property>
+			<Property name="PlacementScene" value="TkModelResource">
+				<Property name="Filename" value="MODELS/PLANETS/BIOMES/COMMON/INTERACTIVEFLORA/FARMVENOMSAC_PLACEMENT.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="SinglePartID" value="" />
+			<Property name="DecorationType" value="GcBaseBuildingObjectDecorationTypes">
+				<Property name="BaseBuildingDecorationType" value="Plant" />
+			</Property>
+			<Property name="IsPlaceable" value="false" />
+			<Property name="IsDecoration" value="true" />
+			<Property name="Biome" value="GcBiomeType">
+				<Property name="Biome" value="All" />
+			</Property>
+			<Property name="BuildableOnPlanetBase" value="true" />
+			<Property name="BuildableOnSpaceBase" value="false" />
+			<Property name="BuildableOnFreighter" value="true" />
+			<Property name="BuildableInShipStructural" value="false" />
+			<Property name="BuildableInShipDecorative" value="true" />
+			<Property name="BuildableOnPlanet" value="false" />
+			<Property name="BuildableOnPlanetWithProduct" value="false" />
+			<Property name="BuildableUnderwater" value="true" />
+			<Property name="BuildableAboveWater" value="true" />
+			<Property name="PlanetLimit" value="0" />
+			<Property name="RegionLimit" value="0" />
+			<Property name="PlanetBaseLimit" value="0" />
+			<Property name="FreighterBaseLimit" value="0" />
+			<Property name="CorvetteBaseLimit" value="0" />
+			<Property name="DoesNotCountTowardsComplexity" value="false" />
+			<Property name="CheckPlaceholderCollision" value="false" />
+			<Property name="CheckPlayerCollision" value="true" />
+			<Property name="CanStack" value="true" />
+			<Property name="SnapRotateBlocked" value="false" />
+			<Property name="CanRotate3D" value="false" />
+			<Property name="CanScale" value="false" />
+			<Property name="Groups">
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="0">
+					<Property name="Group" value="BASE_TECH" />
+					<Property name="SubGroupName" value="TECHFARMING" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="1">
+					<Property name="Group" value="FREIGHTER_BIO" />
+					<Property name="SubGroupName" value="FRE_PLANTS" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="2">
+					<Property name="Group" value="BIGGS_LOW_PERF" />
+					<Property name="SubGroupName" value="BIGGSFARMING" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+			</Property>
+			<Property name="StorageContainerIndex" value="-1" />
+			<Property name="ColourPaletteGroupId" value="" />
+			<Property name="DefaultColourPaletteId" value="" />
+			<Property name="MaterialGroupId" value="" />
+			<Property name="DefaultMaterialId" value="" />
+			<Property name="CanChangeColour" value="false" />
+			<Property name="CanChangeMaterial" value="false" />
+			<Property name="CanPickUp" value="false" />
+			<Property name="ShowInBuildMenu" value="true" />
+			<Property name="CompositePartObjectIDs" />
+			<Property name="FamilyIDs" />
+			<Property name="BuildEffectAccelerator" value="1.000000" />
+			<Property name="IconOverrideProductID" value="" />
+			<Property name="RemovesAttachedDecoration" value="false" />
+			<Property name="RemovesWhenUnsnapped" value="false" />
+			<Property name="EditsTerrain" value="false" />
+			<Property name="BaseTerrainEditShape" value="Cube" />
+			<Property name="MinimumDeleteDistance" value="1.000000" />
+			<Property name="IsSealed" value="false" />
+			<Property name="CloseMenuAfterBuild" value="false" />
+			<Property name="Tag" value="" />
+			<Property name="LinkGridData" value="GcBaseLinkGridData">
+				<Property name="Connection" value="GcBaseLinkGridConnectionData">
+					<Property name="Network" value="GcLinkNetworkTypes">
+						<Property name="LinkNetworkType" value="PlantGrowth" />
+					</Property>
+					<Property name="NetworkSubGroup" value="0" />
+					<Property name="NetworkMask" value="2" />
+					<Property name="ConnectionDistance" value="0.100000" />
+					<Property name="UseMinDistance" value="false" />
+					<Property name="LinkSocketPositions" />
+					<Property name="LinkSocketSubGroups" />
+				</Property>
+				<Property name="Rate" value="1" />
+				<Property name="Storage" value="12000" />
+				<Property name="DependsOnEnvironment" value="None" />
+				<Property name="DependsOnHotspots" value="None" />
+				<Property name="DependentConnections">
+					<Property name="DependentConnections" value="GcBaseLinkGridConnectionDependency" _index="0">
+						<Property name="Connection" value="GcBaseLinkGridConnectionData">
+							<Property name="Network" value="GcLinkNetworkTypes">
+								<Property name="LinkNetworkType" value="Power" />
+							</Property>
+							<Property name="NetworkSubGroup" value="9" />
+							<Property name="NetworkMask" value="1280" />
+							<Property name="ConnectionDistance" value="0.400000" />
+							<Property name="UseMinDistance" value="false" />
+							<Property name="LinkSocketPositions" />
+							<Property name="LinkSocketSubGroups" />
+						</Property>
+						<Property name="DependentRate" value="0" />
+						<Property name="DependentEffect" value="EnablesRate" />
+						<Property name="DisableWhenOffline" value="false" />
+						<Property name="TransfersConnections" value="true" />
+					</Property>
+				</Property>
+			</Property>
+			<Property name="GhostsCountOverride" value="4" />
+			<Property name="ShowGhosts" value="true" />
+			<Property name="SnappingDistanceOverride" value="0.100000" />
+			<Property name="RegionSpawnLOD" value="1" />
+			<Property name="NPCInteractionScene" value="TkModelResource">
+				<Property name="Filename" value="" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="IsModularCustomisation" value="false" />
+			<Property name="ModularCustomisationBaseID" value="" />
+			<Property name="HasDescriptor" value="false" />
+			<Property name="DescriptorID" value="" />
+			<Property name="UseProductIDOverride" value="false" />
+			<Property name="OverrideProductID" value="" />
+			<Property name="FossilDisplayID" value="" />
+		</Property>
+		<Property name="Objects" value="GcBaseBuildingEntry" _id="BARRENPLANT">
+			<Property name="ID" value="BARRENPLANT" />
+			<Property name="IsTemporary" value="false" />
+			<Property name="IsFromModFolder" value="false" />
+			<Property name="Style" value="GcBaseBuildingPartStyle">
+				<Property name="Style" value="None" />
+			</Property>
+			<Property name="PlacementScene" value="TkModelResource">
+				<Property name="Filename" value="MODELS/PLANETS/BIOMES/COMMON/INTERACTIVEFLORA/FARMBARREN_PLACEMENT.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="SinglePartID" value="" />
+			<Property name="DecorationType" value="GcBaseBuildingObjectDecorationTypes">
+				<Property name="BaseBuildingDecorationType" value="Plant" />
+			</Property>
+			<Property name="IsPlaceable" value="false" />
+			<Property name="IsDecoration" value="true" />
+			<Property name="Biome" value="GcBiomeType">
+				<Property name="Biome" value="Barren" />
+			</Property>
+			<Property name="BuildableOnPlanetBase" value="true" />
+			<Property name="BuildableOnSpaceBase" value="false" />
+			<Property name="BuildableOnFreighter" value="true" />
+			<Property name="BuildableInShipStructural" value="false" />
+			<Property name="BuildableInShipDecorative" value="true" />
+			<Property name="BuildableOnPlanet" value="false" />
+			<Property name="BuildableOnPlanetWithProduct" value="true" />
+			<Property name="BuildableUnderwater" value="true" />
+			<Property name="BuildableAboveWater" value="true" />
+			<Property name="PlanetLimit" value="0" />
+			<Property name="RegionLimit" value="0" />
+			<Property name="PlanetBaseLimit" value="0" />
+			<Property name="FreighterBaseLimit" value="0" />
+			<Property name="CorvetteBaseLimit" value="0" />
+			<Property name="DoesNotCountTowardsComplexity" value="false" />
+			<Property name="CheckPlaceholderCollision" value="false" />
+			<Property name="CheckPlayerCollision" value="true" />
+			<Property name="CanStack" value="true" />
+			<Property name="SnapRotateBlocked" value="false" />
+			<Property name="CanRotate3D" value="false" />
+			<Property name="CanScale" value="false" />
+			<Property name="Groups">
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="0">
+					<Property name="Group" value="BASE_TECH" />
+					<Property name="SubGroupName" value="TECHFARMING" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="1">
+					<Property name="Group" value="FREIGHTER_BIO" />
+					<Property name="SubGroupName" value="FRE_PLANTS" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="2">
+					<Property name="Group" value="BIGGS_LOW_PERF" />
+					<Property name="SubGroupName" value="BIGGSFARMING" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+			</Property>
+			<Property name="StorageContainerIndex" value="-1" />
+			<Property name="ColourPaletteGroupId" value="" />
+			<Property name="DefaultColourPaletteId" value="" />
+			<Property name="MaterialGroupId" value="" />
+			<Property name="DefaultMaterialId" value="" />
+			<Property name="CanChangeColour" value="false" />
+			<Property name="CanChangeMaterial" value="false" />
+			<Property name="CanPickUp" value="false" />
+			<Property name="ShowInBuildMenu" value="true" />
+			<Property name="CompositePartObjectIDs" />
+			<Property name="FamilyIDs" />
+			<Property name="BuildEffectAccelerator" value="1.000000" />
+			<Property name="IconOverrideProductID" value="" />
+			<Property name="RemovesAttachedDecoration" value="false" />
+			<Property name="RemovesWhenUnsnapped" value="false" />
+			<Property name="EditsTerrain" value="false" />
+			<Property name="BaseTerrainEditShape" value="Cube" />
+			<Property name="MinimumDeleteDistance" value="1.000000" />
+			<Property name="IsSealed" value="false" />
+			<Property name="CloseMenuAfterBuild" value="false" />
+			<Property name="Tag" value="" />
+			<Property name="LinkGridData" value="GcBaseLinkGridData">
+				<Property name="Connection" value="GcBaseLinkGridConnectionData">
+					<Property name="Network" value="GcLinkNetworkTypes">
+						<Property name="LinkNetworkType" value="PlantGrowth" />
+					</Property>
+					<Property name="NetworkSubGroup" value="0" />
+					<Property name="NetworkMask" value="2" />
+					<Property name="ConnectionDistance" value="0.100000" />
+					<Property name="UseMinDistance" value="false" />
+					<Property name="LinkSocketPositions" />
+					<Property name="LinkSocketSubGroups" />
+				</Property>
+				<Property name="Rate" value="1" />
+				<Property name="Storage" value="57600" />
+				<Property name="DependsOnEnvironment" value="None" />
+				<Property name="DependsOnHotspots" value="None" />
+				<Property name="DependentConnections">
+					<Property name="DependentConnections" value="GcBaseLinkGridConnectionDependency" _index="0">
+						<Property name="Connection" value="GcBaseLinkGridConnectionData">
+							<Property name="Network" value="GcLinkNetworkTypes">
+								<Property name="LinkNetworkType" value="Power" />
+							</Property>
+							<Property name="NetworkSubGroup" value="9" />
+							<Property name="NetworkMask" value="1280" />
+							<Property name="ConnectionDistance" value="0.400000" />
+							<Property name="UseMinDistance" value="false" />
+							<Property name="LinkSocketPositions" />
+							<Property name="LinkSocketSubGroups" />
+						</Property>
+						<Property name="DependentRate" value="0" />
+						<Property name="DependentEffect" value="EnablesRate" />
+						<Property name="DisableWhenOffline" value="false" />
+						<Property name="TransfersConnections" value="true" />
+					</Property>
+				</Property>
+			</Property>
+			<Property name="GhostsCountOverride" value="4" />
+			<Property name="ShowGhosts" value="true" />
+			<Property name="SnappingDistanceOverride" value="0.100000" />
+			<Property name="RegionSpawnLOD" value="1" />
+			<Property name="NPCInteractionScene" value="TkModelResource">
+				<Property name="Filename" value="" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="IsModularCustomisation" value="false" />
+			<Property name="ModularCustomisationBaseID" value="" />
+			<Property name="HasDescriptor" value="false" />
+			<Property name="DescriptorID" value="" />
+			<Property name="UseProductIDOverride" value="false" />
+			<Property name="OverrideProductID" value="" />
+			<Property name="FossilDisplayID" value="" />
+		</Property>
+		<Property name="Objects" value="GcBaseBuildingEntry" _id="LUSHPLANT">
+			<Property name="ID" value="LUSHPLANT" />
+			<Property name="IsTemporary" value="false" />
+			<Property name="IsFromModFolder" value="false" />
+			<Property name="Style" value="GcBaseBuildingPartStyle">
+				<Property name="Style" value="None" />
+			</Property>
+			<Property name="PlacementScene" value="TkModelResource">
+				<Property name="Filename" value="MODELS/PLANETS/BIOMES/COMMON/INTERACTIVEFLORA/FARMLUSH_PLACEMENT.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="SinglePartID" value="" />
+			<Property name="DecorationType" value="GcBaseBuildingObjectDecorationTypes">
+				<Property name="BaseBuildingDecorationType" value="Plant" />
+			</Property>
+			<Property name="IsPlaceable" value="false" />
+			<Property name="IsDecoration" value="true" />
+			<Property name="Biome" value="GcBiomeType">
+				<Property name="Biome" value="Lush" />
+			</Property>
+			<Property name="BuildableOnPlanetBase" value="true" />
+			<Property name="BuildableOnSpaceBase" value="false" />
+			<Property name="BuildableOnFreighter" value="true" />
+			<Property name="BuildableInShipStructural" value="false" />
+			<Property name="BuildableInShipDecorative" value="true" />
+			<Property name="BuildableOnPlanet" value="false" />
+			<Property name="BuildableOnPlanetWithProduct" value="true" />
+			<Property name="BuildableUnderwater" value="true" />
+			<Property name="BuildableAboveWater" value="true" />
+			<Property name="PlanetLimit" value="0" />
+			<Property name="RegionLimit" value="0" />
+			<Property name="PlanetBaseLimit" value="0" />
+			<Property name="FreighterBaseLimit" value="0" />
+			<Property name="CorvetteBaseLimit" value="0" />
+			<Property name="DoesNotCountTowardsComplexity" value="false" />
+			<Property name="CheckPlaceholderCollision" value="false" />
+			<Property name="CheckPlayerCollision" value="true" />
+			<Property name="CanStack" value="true" />
+			<Property name="SnapRotateBlocked" value="false" />
+			<Property name="CanRotate3D" value="false" />
+			<Property name="CanScale" value="false" />
+			<Property name="Groups">
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="0">
+					<Property name="Group" value="BASE_TECH" />
+					<Property name="SubGroupName" value="TECHFARMING" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="1">
+					<Property name="Group" value="FREIGHTER_BIO" />
+					<Property name="SubGroupName" value="FRE_PLANTS" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+				<Property name="Groups" value="GcBaseBuildingEntryGroup" _index="2">
+					<Property name="Group" value="BIGGS_LOW_PERF" />
+					<Property name="SubGroupName" value="BIGGSFARMING" />
+					<Property name="SubGroup" value="0" />
+				</Property>
+			</Property>
+			<Property name="StorageContainerIndex" value="-1" />
+			<Property name="ColourPaletteGroupId" value="" />
+			<Property name="DefaultColourPaletteId" value="" />
+			<Property name="MaterialGroupId" value="" />
+			<Property name="DefaultMaterialId" value="" />
+			<Property name="CanChangeColour" value="false" />
+			<Property name="CanChangeMaterial" value="false" />
+			<Property name="CanPickUp" value="false" />
+			<Property name="ShowInBuildMenu" value="true" />
+			<Property name="CompositePartObjectIDs" />
+			<Property name="FamilyIDs" />
+			<Property name="BuildEffectAccelerator" value="1.000000" />
+			<Property name="IconOverrideProductID" value="" />
+			<Property name="RemovesAttachedDecoration" value="false" />
+			<Property name="RemovesWhenUnsnapped" value="false" />
+			<Property name="EditsTerrain" value="false" />
+			<Property name="BaseTerrainEditShape" value="Cube" />
+			<Property name="MinimumDeleteDistance" value="1.000000" />
+			<Property name="IsSealed" value="false" />
+			<Property name="CloseMenuAfterBuild" value="false" />
+			<Property name="Tag" value="" />
+			<Property name="LinkGridData" value="GcBaseLinkGridData">
+				<Property name="Connection" value="GcBaseLinkGridConnectionData">
+					<Property name="Network" value="GcLinkNetworkTypes">
+						<Property name="LinkNetworkType" value="PlantGrowth" />
+					</Property>
+					<Property name="NetworkSubGroup" value="0" />
+					<Property name="NetworkMask" value="2" />
+					<Property name="ConnectionDistance" value="0.100000" />
+					<Property name="UseMinDistance" value="false" />
+					<Property name="LinkSocketPositions" />
+					<Property name="LinkSocketSubGroups" />
+				</Property>
+				<Property name="Rate" value="1" />
+				<Property name="Storage" value="14400" />
+				<Property name="DependsOnEnvironment" value="None" />
+				<Property name="DependsOnHotspots" value="None" />
+				<Property name="DependentConnections">
+					<Property name="DependentConnections" value="GcBaseLinkGridConnectionDependency" _index="0">
+						<Property name="Connection" value="GcBaseLinkGridConnectionData">
+							<Property name="Network" value="GcLinkNetworkTypes">
+								<Property name="LinkNetworkType" value="Power" />
+							</Property>
+							<Property name="NetworkSubGroup" value="9" />
+							<Property name="NetworkMask" value="1280" />
+							<Property name="ConnectionDistance" value="0.400000" />
+							<Property name="UseMinDistance" value="false" />
+							<Property name="LinkSocketPositions" />
+							<Property name="LinkSocketSubGroups" />
+						</Property>
+						<Property name="DependentRate" value="0" />
+						<Property name="DependentEffect" value="EnablesRate" />
+						<Property name="DisableWhenOffline" value="false" />
+						<Property name="TransfersConnections" value="true" />
+					</Property>
+				</Property>
+			</Property>
+			<Property name="GhostsCountOverride" value="4" />
+			<Property name="ShowGhosts" value="true" />
+			<Property name="SnappingDistanceOverride" value="0.100000" />
+			<Property name="RegionSpawnLOD" value="1" />
+			<Property name="NPCInteractionScene" value="TkModelResource">
+				<Property name="Filename" value="" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="IsModularCustomisation" value="false" />
+			<Property name="ModularCustomisationBaseID" value="" />
+			<Property name="HasDescriptor" value="false" />
+			<Property name="DescriptorID" value="" />
+			<Property name="UseProductIDOverride" value="false" />
+			<Property name="OverrideProductID" value="" />
+			<Property name="FossilDisplayID" value="" />
+		</Property>
+	</Property>
+</Data>

--- a/internal/normalize/testdata/economy/metadata/reality/tables/rewardtable.MXML
+++ b/internal/normalize/testdata/economy/metadata/reality/tables/rewardtable.MXML
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--File created using MBINCompiler version (6.45.0.1)-->
+<Data template="cGcRewardTable">
+	<Property name="GenericTable">
+		<Property name="GenericTable" value="GcGenericRewardTableEntry" _id="WILD_SNOW">
+			<Property name="Id" value="WILD_SNOW" />
+			<Property name="List" value="GcRewardTableItemList">
+				<Property name="RewardChoice" value="GiveAll" />
+				<Property name="OverrideZeroSeed" value="false" />
+				<Property name="UseInventoryChoiceOverride" value="false" />
+				<Property name="IncrementStat" value="" />
+				<Property name="List">
+					<Property name="List" value="GcRewardTableItem" _index="0">
+						<Property name="PercentageChance" value="100.000000" />
+						<Property name="LabelID" value="" />
+						<Property name="Reward" value="GcRewardSpecificSubstance">
+							<Property name="GcRewardSpecificSubstance">
+								<Property name="Default" value="GcDefaultMissionSubstanceEnum">
+									<Property name="DefaultSubstanceType" value="None" />
+								</Property>
+								<Property name="ID" value="PLANT_SNOW" />
+								<Property name="AmountMin" value="18" />
+								<Property name="AmountMax" value="30" />
+								<Property name="DisableMultiplier" value="false" />
+								<Property name="RewardAsBlobs" value="false" />
+								<Property name="UseFuelMultiplier" value="false" />
+								<Property name="Silent" value="false" />
+								<Property name="UseMissionBoardDifficultyScale" value="false" />
+							</Property>
+						</Property>
+					</Property>
+				</Property>
+			</Property>
+		</Property>
+		<Property name="GenericTable" value="GcGenericRewardTableEntry" _id="PLANT_SACVENOM">
+			<Property name="Id" value="PLANT_SACVENOM" />
+			<Property name="List" value="GcRewardTableItemList">
+				<Property name="RewardChoice" value="GiveAll" />
+				<Property name="OverrideZeroSeed" value="false" />
+				<Property name="UseInventoryChoiceOverride" value="false" />
+				<Property name="IncrementStat" value="" />
+				<Property name="List">
+					<Property name="List" value="GcRewardTableItem" _index="0">
+						<Property name="PercentageChance" value="100.000000" />
+						<Property name="LabelID" value="" />
+						<Property name="Reward" value="GcRewardSpecificProduct">
+							<Property name="GcRewardSpecificProduct">
+								<Property name="Default" value="GcDefaultMissionProductEnum">
+									<Property name="DefaultProductType" value="None" />
+								</Property>
+								<Property name="ID" value="SACVENOM" />
+								<Property name="AmountMin" value="1" />
+								<Property name="AmountMax" value="1" />
+								<Property name="HideAmountInMessage" value="false" />
+								<Property name="ForceSpecialMessage" value="false" />
+								<Property name="HideInSeasonRewards" value="false" />
+								<Property name="Silent" value="false" />
+								<Property name="SeasonRewardListFormat" value="" />
+								<Property name="RequiresTech" value="" />
+							</Property>
+						</Property>
+					</Property>
+				</Property>
+			</Property>
+		</Property>
+		<Property name="GenericTable" value="GcGenericRewardTableEntry" _id="PLANT_BARREN">
+			<Property name="Id" value="PLANT_BARREN" />
+			<Property name="List" value="GcRewardTableItemList">
+				<Property name="RewardChoice" value="GiveAll" />
+				<Property name="OverrideZeroSeed" value="false" />
+				<Property name="UseInventoryChoiceOverride" value="false" />
+				<Property name="IncrementStat" value="" />
+				<Property name="List">
+					<Property name="List" value="GcRewardTableItem" _index="0">
+						<Property name="PercentageChance" value="100.000000" />
+						<Property name="LabelID" value="" />
+						<Property name="Reward" value="GcRewardSpecificSubstance">
+							<Property name="GcRewardSpecificSubstance">
+								<Property name="Default" value="GcDefaultMissionSubstanceEnum">
+									<Property name="DefaultSubstanceType" value="None" />
+								</Property>
+								<Property name="ID" value="PLANT_DUST" />
+								<Property name="AmountMin" value="100" />
+								<Property name="AmountMax" value="100" />
+								<Property name="DisableMultiplier" value="true" />
+								<Property name="RewardAsBlobs" value="false" />
+								<Property name="UseFuelMultiplier" value="false" />
+								<Property name="Silent" value="false" />
+								<Property name="UseMissionBoardDifficultyScale" value="false" />
+							</Property>
+						</Property>
+					</Property>
+				</Property>
+			</Property>
+		</Property>
+		<Property name="GenericTable" value="GcGenericRewardTableEntry" _id="PLANT_LUSH">
+			<Property name="Id" value="PLANT_LUSH" />
+			<Property name="List" value="GcRewardTableItemList">
+				<Property name="RewardChoice" value="GiveAll" />
+				<Property name="OverrideZeroSeed" value="false" />
+				<Property name="UseInventoryChoiceOverride" value="false" />
+				<Property name="IncrementStat" value="" />
+				<Property name="List">
+					<Property name="List" value="GcRewardTableItem" _index="0">
+						<Property name="PercentageChance" value="100.000000" />
+						<Property name="LabelID" value="" />
+						<Property name="Reward" value="GcRewardSpecificSubstance">
+							<Property name="GcRewardSpecificSubstance">
+								<Property name="Default" value="GcDefaultMissionSubstanceEnum">
+									<Property name="DefaultSubstanceType" value="None" />
+								</Property>
+								<Property name="ID" value="PLANT_LUSH" />
+								<Property name="AmountMin" value="25" />
+								<Property name="AmountMax" value="25" />
+								<Property name="DisableMultiplier" value="true" />
+								<Property name="RewardAsBlobs" value="false" />
+								<Property name="UseFuelMultiplier" value="false" />
+								<Property name="Silent" value="false" />
+								<Property name="UseMissionBoardDifficultyScale" value="false" />
+							</Property>
+						</Property>
+					</Property>
+				</Property>
+			</Property>
+		</Property>
+		<Property name="GenericTable" value="GcGenericRewardTableEntry" _id="PLANT_SNOW">
+			<Property name="Id" value="PLANT_SNOW" />
+			<Property name="List" value="GcRewardTableItemList">
+				<Property name="RewardChoice" value="GiveAll" />
+				<Property name="OverrideZeroSeed" value="false" />
+				<Property name="UseInventoryChoiceOverride" value="false" />
+				<Property name="IncrementStat" value="" />
+				<Property name="List">
+					<Property name="List" value="GcRewardTableItem" _index="0">
+						<Property name="PercentageChance" value="100.000000" />
+						<Property name="LabelID" value="" />
+						<Property name="Reward" value="GcRewardSpecificSubstance">
+							<Property name="GcRewardSpecificSubstance">
+								<Property name="Default" value="GcDefaultMissionSubstanceEnum">
+									<Property name="DefaultSubstanceType" value="None" />
+								</Property>
+								<Property name="ID" value="PLANT_SNOW" />
+								<Property name="AmountMin" value="50" />
+								<Property name="AmountMax" value="50" />
+								<Property name="DisableMultiplier" value="true" />
+								<Property name="RewardAsBlobs" value="false" />
+								<Property name="UseFuelMultiplier" value="false" />
+								<Property name="Silent" value="false" />
+								<Property name="UseMissionBoardDifficultyScale" value="false" />
+							</Property>
+						</Property>
+					</Property>
+				</Property>
+			</Property>
+		</Property>
+	</Property>
+</Data>

--- a/internal/normalize/testdata/economy/metadata/simulation/scanning/regionhotspotstable.MXML
+++ b/internal/normalize/testdata/economy/metadata/simulation/scanning/regionhotspotstable.MXML
@@ -1,0 +1,356 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--File created using MBINCompiler version (6.45.0.1)-->
+<Data template="cGcRegionHotspotsTable">
+	<Property name="RegionHotspotsPoleSpacing" value="900.000000" />
+	<Property name="RegionHotspotsPerPoleMin" value="1.900000" />
+	<Property name="RegionHotspotsPerPoleMax" value="3.800000" />
+	<Property name="RegionHotspotsMinSameCategorySpacing" value="10.000000" />
+	<Property name="RegionHotspotsMaxDifferentCategoryOverlap" value="150.000000" />
+	<Property name="RegionHotspots">
+		<Property name="Power" value="GcRegionHotspotData">
+			<Property name="ProbabilityWeighting" value="1.000000" />
+			<Property name="MinRange" value="200.000000" />
+			<Property name="MaxRange" value="250.000000" />
+			<Property name="ClassWeightings">
+				<Property name="C" value="10.000000" />
+				<Property name="B" value="6.000000" />
+				<Property name="A" value="2.000000" />
+				<Property name="S" value="1.000000" />
+			</Property>
+			<Property name="ClassStrengths">
+				<Property name="C" value="150.000000" />
+				<Property name="B" value="220.000000" />
+				<Property name="A" value="250.000000" />
+				<Property name="S" value="300.000000" />
+			</Property>
+			<Property name="DiscoveryDistanceThreshold" value="0.950000" />
+		</Property>
+		<Property name="Mineral1" value="GcRegionHotspotData">
+			<Property name="ProbabilityWeighting" value="1.000000" />
+			<Property name="MinRange" value="190.000000" />
+			<Property name="MaxRange" value="225.000000" />
+			<Property name="ClassWeightings">
+				<Property name="C" value="6.000000" />
+				<Property name="B" value="4.000000" />
+				<Property name="A" value="2.000000" />
+				<Property name="S" value="1.000000" />
+			</Property>
+			<Property name="ClassStrengths">
+				<Property name="C" value="1.000000" />
+				<Property name="B" value="1.500000" />
+				<Property name="A" value="2.000000" />
+				<Property name="S" value="2.500000" />
+			</Property>
+			<Property name="DiscoveryDistanceThreshold" value="0.950000" />
+		</Property>
+		<Property name="Mineral2" value="GcRegionHotspotData">
+			<Property name="ProbabilityWeighting" value="1.000000" />
+			<Property name="MinRange" value="190.000000" />
+			<Property name="MaxRange" value="225.000000" />
+			<Property name="ClassWeightings">
+				<Property name="C" value="6.000000" />
+				<Property name="B" value="4.000000" />
+				<Property name="A" value="2.000000" />
+				<Property name="S" value="1.000000" />
+			</Property>
+			<Property name="ClassStrengths">
+				<Property name="C" value="1.000000" />
+				<Property name="B" value="1.500000" />
+				<Property name="A" value="2.000000" />
+				<Property name="S" value="2.500000" />
+			</Property>
+			<Property name="DiscoveryDistanceThreshold" value="0.950000" />
+		</Property>
+		<Property name="Mineral3" value="GcRegionHotspotData">
+			<Property name="ProbabilityWeighting" value="1.000000" />
+			<Property name="MinRange" value="190.000000" />
+			<Property name="MaxRange" value="225.000000" />
+			<Property name="ClassWeightings">
+				<Property name="C" value="6.000000" />
+				<Property name="B" value="4.000000" />
+				<Property name="A" value="2.000000" />
+				<Property name="S" value="1.000000" />
+			</Property>
+			<Property name="ClassStrengths">
+				<Property name="C" value="1.000000" />
+				<Property name="B" value="1.500000" />
+				<Property name="A" value="2.000000" />
+				<Property name="S" value="2.500000" />
+			</Property>
+			<Property name="DiscoveryDistanceThreshold" value="0.950000" />
+		</Property>
+		<Property name="Gas1" value="GcRegionHotspotData">
+			<Property name="ProbabilityWeighting" value="1.000000" />
+			<Property name="MinRange" value="190.000000" />
+			<Property name="MaxRange" value="225.000000" />
+			<Property name="ClassWeightings">
+				<Property name="C" value="20.000000" />
+				<Property name="B" value="4.000000" />
+				<Property name="A" value="2.000000" />
+				<Property name="S" value="1.000000" />
+			</Property>
+			<Property name="ClassStrengths">
+				<Property name="C" value="1.000000" />
+				<Property name="B" value="1.500000" />
+				<Property name="A" value="2.000000" />
+				<Property name="S" value="2.500000" />
+			</Property>
+			<Property name="DiscoveryDistanceThreshold" value="0.950000" />
+		</Property>
+		<Property name="Gas2" value="GcRegionHotspotData">
+			<Property name="ProbabilityWeighting" value="1.000000" />
+			<Property name="MinRange" value="190.000000" />
+			<Property name="MaxRange" value="225.000000" />
+			<Property name="ClassWeightings">
+				<Property name="C" value="20.000000" />
+				<Property name="B" value="4.000000" />
+				<Property name="A" value="2.000000" />
+				<Property name="S" value="1.000000" />
+			</Property>
+			<Property name="ClassStrengths">
+				<Property name="C" value="1.000000" />
+				<Property name="B" value="1.500000" />
+				<Property name="A" value="2.000000" />
+				<Property name="S" value="2.500000" />
+			</Property>
+			<Property name="DiscoveryDistanceThreshold" value="0.950000" />
+		</Property>
+	</Property>
+	<Property name="RegionHotspotBiomeGases">
+		<Property name="Lush" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="GAS3" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="Toxic" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="GAS3" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="Scorched" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="GAS1" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="Radioactive" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="GAS2" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="Frozen" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="GAS2" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="Barren" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="GAS1" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="Dead" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="OXYGEN" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="Weird" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="OXYGEN" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="Red" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="GAS1" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="Green" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="GAS2" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="Blue" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="GAS3" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="Test" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="" />
+			<Property name="Gas2Id" value="" />
+		</Property>
+		<Property name="Swamp" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="GAS3" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="Lava" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="GAS1" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="Waterworld" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="GAS4" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="GasGiant" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="GAS4" />
+			<Property name="Gas2Id" value="OXYGEN" />
+		</Property>
+		<Property name="All" value="GcRegionHotspotBiomeGases">
+			<Property name="Gas1Id" value="" />
+			<Property name="Gas2Id" value="" />
+		</Property>
+	</Property>
+	<Property name="RegionHotspotSubstances">
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="0">
+			<Property name="SubstanceId" value="GAS1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="1">
+			<Property name="SubstanceId" value="GAS2" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="2">
+			<Property name="SubstanceId" value="GAS3" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="3">
+			<Property name="SubstanceId" value="GAS4" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="4">
+			<Property name="SubstanceId" value="OXYGEN" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="5">
+			<Property name="SubstanceId" value="YELLOW2" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="6">
+			<Property name="SubstanceId" value="RED2" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="7">
+			<Property name="SubstanceId" value="GREEN2" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="8">
+			<Property name="SubstanceId" value="BLUE2" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="9">
+			<Property name="SubstanceId" value="PURPLE2" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="10">
+			<Property name="SubstanceId" value="EX_YELLOW" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="11">
+			<Property name="SubstanceId" value="EX_RED" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="12">
+			<Property name="SubstanceId" value="EX_GREEN" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="13">
+			<Property name="SubstanceId" value="EX_BLUE" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="14">
+			<Property name="SubstanceId" value="EX_PURPLE" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="15">
+			<Property name="SubstanceId" value="DUSTY1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="16">
+			<Property name="SubstanceId" value="LUSH1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="17">
+			<Property name="SubstanceId" value="TOXIC1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="18">
+			<Property name="SubstanceId" value="RADIO1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="19">
+			<Property name="SubstanceId" value="COLD1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="20">
+			<Property name="SubstanceId" value="HOT1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="21">
+			<Property name="SubstanceId" value="WATER1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="22">
+			<Property name="SubstanceId" value="CAVE1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="23">
+			<Property name="SubstanceId" value="ASTEROID1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="24">
+			<Property name="SubstanceId" value="LAND3" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="25">
+			<Property name="SubstanceId" value="SPACEGUNK3" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="26">
+			<Property name="SubstanceId" value="ASTEROID2" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="27">
+			<Property name="SubstanceId" value="CATALYST1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="28">
+			<Property name="SubstanceId" value="LAVA1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="29">
+			<Property name="SubstanceId" value="PLANT_POOP" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="30">
+			<Property name="SubstanceId" value="CREATURE1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="31">
+			<Property name="SubstanceId" value="GASGIANT1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+		<Property name="RegionHotspotSubstances" value="GcRegionHotspotSubstance" _index="32">
+			<Property name="SubstanceId" value="WATERWORLD1" />
+			<Property name="AmountCost" value="360000" />
+			<Property name="SubstanceYeild" value="250" />
+		</Property>
+	</Property>
+</Data>

--- a/internal/normalize/testdata/economy/models/planets/biomes/common/interactiveflora/farmbarren/entities/plantinteraction.entity.MXML
+++ b/internal/normalize/testdata/economy/models/planets/biomes/common/interactiveflora/farmbarren/entities/plantinteraction.entity.MXML
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--File created using MBINCompiler version (6.45.0.1)-->
+<Data template="cTkAttachmentData">
+	<Property name="Components">
+		<Property name="Components" value="GcSimpleInteractionComponentData">
+			<Property name="GcSimpleInteractionComponentData">
+				<Property name="SimpleInteractionType" value="GenericReward" />
+				<Property name="InteractDistance" value="0.000000" />
+				<Property name="Use2dInteractDistance" value="false" />
+				<Property name="InteractAngle" value="360.000000" />
+				<Property name="Id" value="PLANT_BARREN" />
+				<Property name="Rarity" value="GcRarity">
+					<Property name="Rarity" value="Common" />
+				</Property>
+				<Property name="Size" value="GcSizeIndicator">
+					<Property name="SizeIndicator" value="Medium" />
+				</Property>
+				<Property name="TriggerAction" value="STEP0" />
+				<Property name="TriggerActionOnPrepare" value="" />
+				<Property name="TriggerActionToggle" value="" />
+				<Property name="DeactivateSimilarInteractionsNearbyRadius" value="0.000000" />
+				<Property name="BroadcastTriggerAction" value="false" />
+				<Property name="Delay" value="0.000000" />
+				<Property name="HideContents" value="false" />
+				<Property name="InteractIsCrime" value="false" />
+				<Property name="InteractFiendCrimeType" value="GcFiendCrime">
+					<Property name="FiendCrime" value="None" />
+				</Property>
+				<Property name="InteractFiendCrimeChance" value="1.000000" />
+				<Property name="InteractCrimeLevel" value="0" />
+				<Property name="IncreaseCorruptSentinelWanted" value="0" />
+				<Property name="NotifyEncounter" value="false" />
+				<Property name="ActivationCost" value="GcInteractionActivationCost">
+					<Property name="SubstanceId" value="" />
+					<Property name="AltIds" />
+					<Property name="Cost" value="0" />
+					<Property name="Repeat" value="false" />
+					<Property name="RequiredTech" value="" />
+					<Property name="UseCostID" value="" />
+					<Property name="StartMissionOnCantAfford" value="" />
+					<Property name="OnlyChargeDuringSeasons" />
+				</Property>
+				<Property name="StatToTrack" value="GcStatsEnum">
+					<Property name="StatEnum" value="PLANTS_PLANTED" />
+				</Property>
+				<Property name="StartsBuried" value="false" />
+				<Property name="MustBeVisibleToInteract" value="false" />
+				<Property name="NeedsStorm" value="false" />
+				<Property name="Name" value="UI_PLANT_9_NAME_L" />
+				<Property name="ForceSubtitle" value="" />
+				<Property name="VRInteractMessage" value="" />
+				<Property name="TerminalHeading" value="" />
+				<Property name="TerminalMessage" value="" />
+				<Property name="ScanType" value="BINOC_HARVEST_PLANT" />
+				<Property name="ScanData" value="UI_PLANT_9_DESC" />
+				<Property name="ScanIcon" value="GcDiscoveryType">
+					<Property name="DiscoveryType" value="HarvestPlant" />
+				</Property>
+				<Property name="ActivateLocatorsFromRarity" value="false" />
+				<Property name="RarityLocators">
+					<Property name="Common" value="" />
+					<Property name="Uncommon" value="" />
+					<Property name="Rare" value="" />
+				</Property>
+				<Property name="BaseBuildingTriggerActions">
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="0">
+						<Property name="TriggerAction" value="STEP0_ENTER" />
+						<Property name="Time" value="0" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="1">
+						<Property name="TriggerAction" value="STEP0" />
+						<Property name="Time" value="1" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="2">
+						<Property name="TriggerAction" value="STEP1_ENTER" />
+						<Property name="Time" value="28799" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="3">
+						<Property name="TriggerAction" value="STEP1" />
+						<Property name="Time" value="28800" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="4">
+						<Property name="TriggerAction" value="STEP2_ENTER" />
+						<Property name="Time" value="57599" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="5">
+						<Property name="TriggerAction" value="STEP2" />
+						<Property name="Time" value="57600" />
+					</Property>
+				</Property>
+				<Property name="RewardOverrideTable" />
+				<Property name="PersistencyBufferOverride" />
+				<Property name="UsePersonalPersistentBuffer" value="false" />
+				<Property name="ReseedOnRewardSuccess" value="false" />
+				<Property name="CanCollectInMech" value="true" />
+				<Property name="AnimateOnInteract" value="true" />
+				<Property name="DisableAnimationUntilInteract" value="false" />
+				<Property name="OnlyActiveDuringSeasons" />
+			</Property>
+		</Property>
+	</Property>
+</Data>

--- a/internal/normalize/testdata/economy/models/planets/biomes/common/interactiveflora/farmlush/entities/plantinteraction.entity.MXML
+++ b/internal/normalize/testdata/economy/models/planets/biomes/common/interactiveflora/farmlush/entities/plantinteraction.entity.MXML
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--File created using MBINCompiler version (6.45.0.1)-->
+<Data template="cTkAttachmentData">
+	<Property name="Components">
+		<Property name="Components" value="GcSimpleInteractionComponentData">
+			<Property name="GcSimpleInteractionComponentData">
+				<Property name="SimpleInteractionType" value="GenericReward" />
+				<Property name="InteractDistance" value="0.000000" />
+				<Property name="Use2dInteractDistance" value="false" />
+				<Property name="InteractAngle" value="360.000000" />
+				<Property name="Id" value="PLANT_LUSH" />
+				<Property name="Rarity" value="GcRarity">
+					<Property name="Rarity" value="Common" />
+				</Property>
+				<Property name="Size" value="GcSizeIndicator">
+					<Property name="SizeIndicator" value="Medium" />
+				</Property>
+				<Property name="TriggerAction" value="STEP0" />
+				<Property name="TriggerActionOnPrepare" value="" />
+				<Property name="TriggerActionToggle" value="" />
+				<Property name="DeactivateSimilarInteractionsNearbyRadius" value="0.000000" />
+				<Property name="BroadcastTriggerAction" value="false" />
+				<Property name="Delay" value="0.000000" />
+				<Property name="HideContents" value="false" />
+				<Property name="InteractIsCrime" value="false" />
+				<Property name="InteractFiendCrimeType" value="GcFiendCrime">
+					<Property name="FiendCrime" value="None" />
+				</Property>
+				<Property name="InteractFiendCrimeChance" value="1.000000" />
+				<Property name="InteractCrimeLevel" value="0" />
+				<Property name="IncreaseCorruptSentinelWanted" value="0" />
+				<Property name="NotifyEncounter" value="false" />
+				<Property name="ActivationCost" value="GcInteractionActivationCost">
+					<Property name="SubstanceId" value="" />
+					<Property name="AltIds" />
+					<Property name="Cost" value="0" />
+					<Property name="Repeat" value="false" />
+					<Property name="RequiredTech" value="POWERGLOVE" />
+					<Property name="UseCostID" value="" />
+					<Property name="StartMissionOnCantAfford" value="" />
+					<Property name="OnlyChargeDuringSeasons" />
+				</Property>
+				<Property name="StatToTrack" value="GcStatsEnum">
+					<Property name="StatEnum" value="PLANTS_PLANTED" />
+				</Property>
+				<Property name="StartsBuried" value="false" />
+				<Property name="MustBeVisibleToInteract" value="false" />
+				<Property name="NeedsStorm" value="false" />
+				<Property name="Name" value="UI_PLANT_10_NAME_L" />
+				<Property name="ForceSubtitle" value="" />
+				<Property name="VRInteractMessage" value="" />
+				<Property name="TerminalHeading" value="" />
+				<Property name="TerminalMessage" value="" />
+				<Property name="ScanType" value="BINOC_HARVEST_PLANT" />
+				<Property name="ScanData" value="UI_PLANT_10_DESC" />
+				<Property name="ScanIcon" value="GcDiscoveryType">
+					<Property name="DiscoveryType" value="HarvestPlant" />
+				</Property>
+				<Property name="ActivateLocatorsFromRarity" value="false" />
+				<Property name="RarityLocators">
+					<Property name="Common" value="" />
+					<Property name="Uncommon" value="" />
+					<Property name="Rare" value="" />
+				</Property>
+				<Property name="BaseBuildingTriggerActions">
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="0">
+						<Property name="TriggerAction" value="STEP0_ENTER" />
+						<Property name="Time" value="0" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="1">
+						<Property name="TriggerAction" value="STEP0" />
+						<Property name="Time" value="1" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="2">
+						<Property name="TriggerAction" value="STEP1_ENTER" />
+						<Property name="Time" value="7199" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="3">
+						<Property name="TriggerAction" value="STEP1" />
+						<Property name="Time" value="7200" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="4">
+						<Property name="TriggerAction" value="STEP2_ENTER" />
+						<Property name="Time" value="14399" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="5">
+						<Property name="TriggerAction" value="STEP2" />
+						<Property name="Time" value="14400" />
+					</Property>
+				</Property>
+				<Property name="RewardOverrideTable" />
+				<Property name="PersistencyBufferOverride" />
+				<Property name="UsePersonalPersistentBuffer" value="false" />
+				<Property name="ReseedOnRewardSuccess" value="false" />
+				<Property name="CanCollectInMech" value="true" />
+				<Property name="AnimateOnInteract" value="true" />
+				<Property name="DisableAnimationUntilInteract" value="false" />
+				<Property name="OnlyActiveDuringSeasons" />
+			</Property>
+		</Property>
+	</Property>
+</Data>

--- a/internal/normalize/testdata/economy/models/planets/biomes/common/interactiveflora/farmsnow/entities/plantinteraction.entity.MXML
+++ b/internal/normalize/testdata/economy/models/planets/biomes/common/interactiveflora/farmsnow/entities/plantinteraction.entity.MXML
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--File created using MBINCompiler version (6.45.0.1)-->
+<Data template="cTkAttachmentData">
+	<Property name="Components">
+		<Property name="Components" value="GcSimpleInteractionComponentData">
+			<Property name="GcSimpleInteractionComponentData">
+				<Property name="SimpleInteractionType" value="GenericReward" />
+				<Property name="InteractDistance" value="0.000000" />
+				<Property name="Use2dInteractDistance" value="false" />
+				<Property name="InteractAngle" value="360.000000" />
+				<Property name="Id" value="PLANT_SNOW" />
+				<Property name="Rarity" value="GcRarity">
+					<Property name="Rarity" value="Common" />
+				</Property>
+				<Property name="Size" value="GcSizeIndicator">
+					<Property name="SizeIndicator" value="Medium" />
+				</Property>
+				<Property name="TriggerAction" value="STEP0" />
+				<Property name="TriggerActionOnPrepare" value="" />
+				<Property name="TriggerActionToggle" value="" />
+				<Property name="DeactivateSimilarInteractionsNearbyRadius" value="0.000000" />
+				<Property name="BroadcastTriggerAction" value="false" />
+				<Property name="Delay" value="0.000000" />
+				<Property name="HideContents" value="false" />
+				<Property name="InteractIsCrime" value="false" />
+				<Property name="InteractFiendCrimeType" value="GcFiendCrime">
+					<Property name="FiendCrime" value="None" />
+				</Property>
+				<Property name="InteractFiendCrimeChance" value="1.000000" />
+				<Property name="InteractCrimeLevel" value="0" />
+				<Property name="IncreaseCorruptSentinelWanted" value="0" />
+				<Property name="NotifyEncounter" value="false" />
+				<Property name="ActivationCost" value="GcInteractionActivationCost">
+					<Property name="SubstanceId" value="" />
+					<Property name="AltIds" />
+					<Property name="Cost" value="0" />
+					<Property name="Repeat" value="false" />
+					<Property name="RequiredTech" value="POWERGLOVE" />
+					<Property name="UseCostID" value="" />
+					<Property name="StartMissionOnCantAfford" value="" />
+					<Property name="OnlyChargeDuringSeasons" />
+				</Property>
+				<Property name="StatToTrack" value="GcStatsEnum">
+					<Property name="StatEnum" value="PLANTS_PLANTED" />
+				</Property>
+				<Property name="StartsBuried" value="false" />
+				<Property name="MustBeVisibleToInteract" value="false" />
+				<Property name="NeedsStorm" value="false" />
+				<Property name="Name" value="UI_PLANT_7_NAME_L" />
+				<Property name="ForceSubtitle" value="" />
+				<Property name="VRInteractMessage" value="" />
+				<Property name="TerminalHeading" value="" />
+				<Property name="TerminalMessage" value="" />
+				<Property name="ScanType" value="BINOC_HARVEST_PLANT" />
+				<Property name="ScanData" value="UI_PLANT_7_DESC" />
+				<Property name="ScanIcon" value="GcDiscoveryType">
+					<Property name="DiscoveryType" value="HarvestPlant" />
+				</Property>
+				<Property name="ActivateLocatorsFromRarity" value="false" />
+				<Property name="RarityLocators">
+					<Property name="Common" value="" />
+					<Property name="Uncommon" value="" />
+					<Property name="Rare" value="" />
+				</Property>
+				<Property name="BaseBuildingTriggerActions">
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="0">
+						<Property name="TriggerAction" value="STEP0_ENTER" />
+						<Property name="Time" value="0" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="1">
+						<Property name="TriggerAction" value="STEP0" />
+						<Property name="Time" value="1" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="2">
+						<Property name="TriggerAction" value="STEP1_ENTER" />
+						<Property name="Time" value="1799" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="3">
+						<Property name="TriggerAction" value="STEP1" />
+						<Property name="Time" value="1800" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="4">
+						<Property name="TriggerAction" value="STEP2_ENTER" />
+						<Property name="Time" value="3599" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="5">
+						<Property name="TriggerAction" value="STEP2" />
+						<Property name="Time" value="3600" />
+					</Property>
+				</Property>
+				<Property name="RewardOverrideTable" />
+				<Property name="PersistencyBufferOverride" />
+				<Property name="UsePersonalPersistentBuffer" value="false" />
+				<Property name="ReseedOnRewardSuccess" value="false" />
+				<Property name="CanCollectInMech" value="true" />
+				<Property name="AnimateOnInteract" value="true" />
+				<Property name="DisableAnimationUntilInteract" value="false" />
+				<Property name="OnlyActiveDuringSeasons" />
+			</Property>
+		</Property>
+	</Property>
+</Data>

--- a/internal/normalize/testdata/economy/models/planets/biomes/common/interactiveflora/farmvenomsac/entities/plantinteraction.entity.MXML
+++ b/internal/normalize/testdata/economy/models/planets/biomes/common/interactiveflora/farmvenomsac/entities/plantinteraction.entity.MXML
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--File created using MBINCompiler version (6.45.0.1)-->
+<Data template="cTkAttachmentData">
+	<Property name="Components">
+		<Property name="Components" value="GcSimpleInteractionComponentData">
+			<Property name="GcSimpleInteractionComponentData">
+				<Property name="SimpleInteractionType" value="GenericReward" />
+				<Property name="InteractDistance" value="0.000000" />
+				<Property name="Use2dInteractDistance" value="false" />
+				<Property name="InteractAngle" value="360.000000" />
+				<Property name="Id" value="PLANT_SACVENOM" />
+				<Property name="Rarity" value="GcRarity">
+					<Property name="Rarity" value="Common" />
+				</Property>
+				<Property name="Size" value="GcSizeIndicator">
+					<Property name="SizeIndicator" value="Medium" />
+				</Property>
+				<Property name="TriggerAction" value="STEP0" />
+				<Property name="TriggerActionOnPrepare" value="" />
+				<Property name="TriggerActionToggle" value="" />
+				<Property name="DeactivateSimilarInteractionsNearbyRadius" value="0.000000" />
+				<Property name="BroadcastTriggerAction" value="false" />
+				<Property name="Delay" value="0.000000" />
+				<Property name="HideContents" value="false" />
+				<Property name="InteractIsCrime" value="false" />
+				<Property name="InteractFiendCrimeType" value="GcFiendCrime">
+					<Property name="FiendCrime" value="None" />
+				</Property>
+				<Property name="InteractFiendCrimeChance" value="1.000000" />
+				<Property name="InteractCrimeLevel" value="0" />
+				<Property name="IncreaseCorruptSentinelWanted" value="0" />
+				<Property name="NotifyEncounter" value="false" />
+				<Property name="ActivationCost" value="GcInteractionActivationCost">
+					<Property name="SubstanceId" value="" />
+					<Property name="AltIds" />
+					<Property name="Cost" value="0" />
+					<Property name="Repeat" value="false" />
+					<Property name="RequiredTech" value="POWERGLOVE" />
+					<Property name="UseCostID" value="" />
+					<Property name="StartMissionOnCantAfford" value="" />
+					<Property name="OnlyChargeDuringSeasons" />
+				</Property>
+				<Property name="StatToTrack" value="GcStatsEnum">
+					<Property name="StatEnum" value="PLANTS_PLANTED" />
+				</Property>
+				<Property name="StartsBuried" value="false" />
+				<Property name="MustBeVisibleToInteract" value="false" />
+				<Property name="NeedsStorm" value="false" />
+				<Property name="Name" value="" />
+				<Property name="ForceSubtitle" value="" />
+				<Property name="VRInteractMessage" value="" />
+				<Property name="TerminalHeading" value="" />
+				<Property name="TerminalMessage" value="" />
+				<Property name="ScanType" value="BINOC_HARVEST_PLANT" />
+				<Property name="ScanData" value="UI_PLANT_12_DESC" />
+				<Property name="ScanIcon" value="GcDiscoveryType">
+					<Property name="DiscoveryType" value="HarvestPlant" />
+				</Property>
+				<Property name="ActivateLocatorsFromRarity" value="false" />
+				<Property name="RarityLocators">
+					<Property name="Common" value="" />
+					<Property name="Uncommon" value="" />
+					<Property name="Rare" value="" />
+				</Property>
+				<Property name="BaseBuildingTriggerActions">
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="0">
+						<Property name="TriggerAction" value="STEP0_ENTER" />
+						<Property name="Time" value="0" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="1">
+						<Property name="TriggerAction" value="STEP0" />
+						<Property name="Time" value="1" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="2">
+						<Property name="TriggerAction" value="STEP1_ENTER" />
+						<Property name="Time" value="5999" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="3">
+						<Property name="TriggerAction" value="STEP1" />
+						<Property name="Time" value="6000" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="4">
+						<Property name="TriggerAction" value="STEP2_ENTER" />
+						<Property name="Time" value="11999" />
+					</Property>
+					<Property name="BaseBuildingTriggerActions" value="GcInteractionBaseBuildingState" _index="5">
+						<Property name="TriggerAction" value="STEP2" />
+						<Property name="Time" value="12000" />
+					</Property>
+				</Property>
+				<Property name="RewardOverrideTable" />
+				<Property name="PersistencyBufferOverride" />
+				<Property name="UsePersonalPersistentBuffer" value="false" />
+				<Property name="ReseedOnRewardSuccess" value="false" />
+				<Property name="CanCollectInMech" value="true" />
+				<Property name="AnimateOnInteract" value="true" />
+				<Property name="DisableAnimationUntilInteract" value="false" />
+				<Property name="OnlyActiveDuringSeasons" />
+			</Property>
+		</Property>
+	</Property>
+</Data>


### PR DESCRIPTION
## What

Implements #24. The four base-economy constants ADR-0001 planned to hand-curate are now generated from the game tables, so they are version-stamped and regenerated rather than maintained by hand. Only biodome crop capacity remains curated — it is not in the tables.

## Where the values come from

| Source | Gives |
|---|---|
| `metadata/reality/tables/basebuildingobjectstable` | per-part rate, storage, dependent draws, hotspot dependence |
| `metadata/simulation/scanning/regionhotspotstable` | C/B/A/S class strengths and weightings |
| `metadata/reality/tables/rewardtable` | crop yields |
| `models/.../interactiveflora/*/entities/plantinteraction.entity` | which crop yields what |
| `gcgameplayglobals.global` | refiner throughput, including the Survival variants |

Nothing in the buildables table says what a plant yields. The chain is: a buildable whose primary connection is `PlantGrowth` (growth time is that connection's `Storage`) → its `PlacementScene` names a flora directory → that directory's interaction entity gives a reward key → the reward table gives the substance and its min/max. That derivation is recorded in the artifact under `economy.searches`, per SPEC-0004 REQ "Search Boundaries Are Recorded".

## Two things the source does that the spec's wording did not anticipate

Both are implemented correctly and recorded on the search note rather than quietly handled:

1. **Five of the twelve farmable plants yield a *product*, not a substance** — `GcRewardSpecificProduct` with an identical `Amount` shape. SPEC-0004 REQ "Base Economy Data" names only `GcRewardSpecificSubstance`. Reading only that form would have silently dropped venom sacs, gravitino balls, nip-nip buds, albumen pearls and creature pellets. **This wording is worth amending in a follow-up.**
2. **The reward key and the substance are not always the same** — `PLANT_BARREN` yields `PLANT_DUST`. Treating the key as the substance would be wrong in exactly one of twelve cases, which is the worst kind of wrong.

## Modelling decisions

- **Hotspot families.** The table names six categories (`Power`, `Mineral1..3`, `Gas1..2`) but a part's `DependsOnHotspots` names a family (`Mineral`). The numbered variants exist to give a planet several distinct hotspots, not to scale differently, so they collapse to the family. The collapse is **guarded**: members that disagree fail loudly rather than letting one variant's numbers stand in for the rest.
- **Parts with no economic behaviour are skipped.** All 1,997 buildables carry `LinkGridData`; 108 have a non-zero rate, storage, dependency or hotspot dependence. The rest are decorations.
- **A growth-network container is not a crop.** `CARBONPLANTER` sits on `PlantGrowth` but has no flora entity and no yield. It is carried as a part and named in the search note, not dropped.
- **`Fuel` and `Portals` added to the network vocabulary** so a part using one is emitted rather than rejected.

## Verification against the real install

Run against a full 6.45.0.1 decompilation of NMS 5.97 — 108 parts, 3 hotspot families, 12 crops:

- `U_EXTRACTOR_S` → rate 100, storage 360000, dependent Power −50 `EnablesRate`, hotspot `Mineral`
- Power 150/220/250/300; Mineral and Gas 1/1.5/2/2.5 — keyed by category, never by device
- Frost Crystal 50/50, Cactus Flesh 100/100, Star Bulb 25/25, growth 3600 s for frostwart
- Refining 2 products / 250 substances per cycle; 1 / 100 on Survival
- No per-class device variants anywhere in the output

## Tests

Fixtures under `internal/normalize/testdata/economy/` are **real content sliced out of a real decompilation** — see `testdata/economy/gen.go` for exactly which rows and why. Hand-authored MXML would test only that the parser agrees with my idea of the format, which is the mistake that cost this project its first parser.

26 test cases including six fail-closed scenarios: a missing source, an unknown link network, a hotspot family whose members disagree, a crop whose reward key is unresolvable, a crop whose flora entity is absent, and a refiner field that is gone. Each must produce a `*SourceError` naming the table and return no partial economy.

`go vet`, `staticcheck v0.8.0-rc.1`, `gofmt -l` all clean.

## Note on ordering

`internal/normalize/mxml.go` comes over from the parked #23 work, because the economy pass needs the MXML reader and lands first. #23 should drop its copy and build the recipe tables on top of this one.

Closes #24
Part of #21

Implements SPEC-0004 REQ "Base Economy Data", REQ "Search Boundaries Are Recorded".

🤖 Generated with [Claude Code](https://claude.com/claude-code)