### PR TITLE
feat(normalize): build the recipe graph from the reality tables

### DIFF
--- a/internal/domain/tier1.go
+++ b/internal/domain/tier1.go
@@ -121,6 +121,19 @@ type Provenance struct {
 	Archives []string `json:"archives"`
 	// MBINCompiler is the decompiler version that produced the .MXML input.
 	MBINCompiler string `json:"mbincompiler"`
+
+	// SelfReferentialRecipesOmitted counts the recipes dropped for naming
+	// their own output among their ingredients — a doubling strategy rather
+	// than a production path, and a cycle if expanded. There are 27 in NMS
+	// 5.97.
+	//
+	// Not omitempty: a zero here is a finding, not an absence, and a silent
+	// change in this number is exactly what recording it prevents.
+	//
+	// Governing: SPEC-0004 REQ "Recipe Graph Construction" — "MUST record
+	// how many it omitted in the artifact's provenance, so a change in that
+	// number is visible rather than silent."
+	SelfReferentialRecipesOmitted int `json:"self_referential_recipes_omitted"`
 }
 
 // Tier1 is the extracted recipe graph.

--- a/internal/normalize/artifact.go
+++ b/internal/normalize/artifact.go
@@ -28,6 +28,8 @@ type Builder struct {
 	items   []domain.Item
 	recipes []domain.Recipe
 	economy *domain.Economy
+
+	selfReferentialOmitted int
 }
 
 // NewBuilder starts an artifact for the named game build.
@@ -63,6 +65,12 @@ func (b *Builder) AddRecipes(recipes ...domain.Recipe) { b.recipes = append(b.re
 // SetEconomy attaches the base-economy section.
 func (b *Builder) SetEconomy(e *domain.Economy) { b.economy = e }
 
+// SetSelfReferentialOmitted records how many recipes the graph pass dropped
+// for naming their own output among their ingredients.
+//
+// Governing: SPEC-0004 REQ "Recipe Graph Construction"
+func (b *Builder) SetSelfReferentialOmitted(n int) { b.selfReferentialOmitted = n }
+
 // Artifact assembles and validates the artifact.
 //
 // Every collection is sorted into a defined order here rather than at the
@@ -76,8 +84,9 @@ func (b *Builder) Artifact() (*domain.Tier1, error) {
 		Source:        fmt.Sprintf("%s via MBINCompiler %s", joinArchives(b.archives), b.mbinCompiler),
 		Note:          b.note,
 		Provenance: &domain.Provenance{
-			Archives:     sortedCopy(b.archives),
-			MBINCompiler: b.mbinCompiler,
+			Archives:                      sortedCopy(b.archives),
+			MBINCompiler:                  b.mbinCompiler,
+			SelfReferentialRecipesOmitted: b.selfReferentialOmitted,
 		},
 		Items:   append([]domain.Item(nil), b.items...),
 		Recipes: append([]domain.Recipe(nil), b.recipes...),

--- a/internal/normalize/localisation.go
+++ b/internal/normalize/localisation.go
@@ -1,0 +1,104 @@
+package normalize
+
+import (
+	"path/filepath"
+	"sort"
+)
+
+// Governing: ADR-0001 (two-tier NMS data ingestion), SPEC-0004 REQ "Display
+// Name Resolution"
+//
+// Reality tables carry localisation *keys*, not names. The Stasis Device's
+// NameLower is UI_ULTRAPROD_2_NAME_L; the string "Stasis Device" lives in
+// language/nms_loc*_english.mbin, inside a different archive from the
+// product table. Searching the product table for a display name therefore
+// finds nothing, which is a dead end worth failing loudly about rather than
+// papering over.
+
+// Localisation resolves localisation keys to English strings.
+type Localisation struct {
+	byKey map[string]string
+	// files records what was read, so a failure to resolve can say where we
+	// looked rather than only what was missing.
+	files []string
+}
+
+// LoadLocalisation reads every localisation table matching pattern and
+// indexes its entries by key.
+//
+// Later files do not override earlier ones: the tables partition the key
+// space rather than layering, so a duplicate key across two files means the
+// input set is wrong (both a base and a patch table, say) and is reported.
+func LoadLocalisation(paths []string) (*Localisation, error) {
+	if len(paths) == 0 {
+		return nil, Missing("language/nms_loc*_english")
+	}
+	l := &Localisation{byKey: make(map[string]string, 64_000)}
+	for _, p := range sortedStrings(paths) {
+		doc, err := readMXML(p, "cTkLocalisationTable")
+		if err != nil {
+			return nil, err
+		}
+		name := filepath.Base(p)
+		l.files = append(l.files, name)
+		rows, err := doc.rows(name, "Table", "TkLocalisationEntry")
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range rows {
+			key, err := r.nonEmpty(name, r.ID, "Id")
+			if err != nil {
+				return nil, err
+			}
+			// A key present with an empty English value is a real state in
+			// these tables (placeholder entries), and is kept as such: the
+			// caller decides whether an empty name is acceptable, rather
+			// than this layer silently dropping the key and reporting it as
+			// missing later.
+			val, err := r.str(name, key, "English")
+			if err != nil {
+				return nil, err
+			}
+			if prev, dup := l.byKey[key]; dup && prev != val {
+				return nil, Unrecognized(name, key, "Id", "one definition per key", "a conflicting duplicate")
+			}
+			l.byKey[key] = val
+		}
+	}
+	return l, nil
+}
+
+// Len reports how many keys were indexed.
+func (l *Localisation) Len() int { return len(l.byKey) }
+
+// Files reports the localisation tables that were read, in sorted order.
+//
+// Governing: SPEC-0004 REQ "Search Boundaries Are Recorded" — a name
+// resolved by consulting several tables should be able to say which ones.
+func (l *Localisation) Files() []string { return sortedStrings(l.files) }
+
+// Resolve returns the English string for a key.
+//
+// A key that does not resolve fails rather than falling back to the key or
+// the item ID. An artifact full of UI_ULTRAPROD_2_NAME_L loads cleanly and
+// looks like data, which surfaces as a confusing UI long after the cause —
+// strictly worse than failing here.
+func (l *Localisation) Resolve(table, row, key string) (string, error) {
+	if key == "" {
+		return "", Unrecognized(table, row, "name key", "a localisation key", `""`)
+	}
+	v, ok := l.byKey[key]
+	if !ok {
+		return "", UnresolvedName(table, row, key)
+	}
+	if v == "" {
+		return "", Unrecognized(table, row, "name", "a non-empty English string", "an empty localisation entry")
+	}
+	return v, nil
+}
+
+func sortedStrings(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}

--- a/internal/normalize/mxml.go
+++ b/internal/normalize/mxml.go
@@ -124,6 +124,22 @@ func (n node) int64(table, row, field string) (int64, error) {
 	return v, nil
 }
 
+// boolean returns a required boolean field.
+func (n node) boolean(table, row, field string) (bool, error) {
+	c, ok := n.child(field)
+	if !ok {
+		return false, Unrecognized(table, row, field, "present", "absent")
+	}
+	switch c.Value {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, Unrecognized(table, row, field, "true or false", c.Value)
+	}
+}
+
 // float returns a required float field. MBINCompiler emits every float as a
 // fixed-point decimal ("150.000000"), so this is exact for the values it is
 // used on — class strengths and weightings — and would only lose precision

--- a/internal/normalize/tables.go
+++ b/internal/normalize/tables.go
@@ -1,0 +1,438 @@
+package normalize
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/jonstump/nms-base-planner/internal/domain"
+)
+
+// Governing: ADR-0001 (two-tier NMS data ingestion), ADR-0005 (multiple
+// recipes per output), SPEC-0004 REQ "Recipe Graph Construction",
+// REQ "Identifier Policy", REQ "Display Name Resolution",
+// REQ "Excluded Content"
+
+// Sources names the decompiled tables the recipe graph is built from.
+type Sources struct {
+	// Products is nms_reality_gcproducttable.MXML.
+	Products string
+	// Substances is nms_reality_gcsubstancetable.MXML.
+	Substances string
+	// Recipes is nms_reality_gcrecipetable.MXML — refining and cooking, one
+	// table distinguished by a per-recipe Cooking flag.
+	Recipes string
+	// Localisation is the set of language/nms_loc*_english.MXML files.
+	Localisation []string
+}
+
+// Graph is what the reality tables yield: the artifact's items and recipes,
+// plus the counts a reader needs to tell a complete extraction from a
+// quietly partial one.
+type Graph struct {
+	Items   []domain.Item
+	Recipes []domain.Recipe
+
+	// SelfReferentialOmitted counts recipes dropped for naming their own
+	// output among their ingredients.
+	//
+	// Governing: SPEC-0004 REQ "Recipe Graph Construction"
+	SelfReferentialOmitted int
+
+	// UnnamedOmitted lists items dropped because no English table defines
+	// their name key, sorted. Every one is checked to be unreferenced.
+	UnnamedOmitted []string
+
+	// LocalisationFiles records which tables the name resolution read.
+	//
+	// Governing: SPEC-0004 REQ "Search Boundaries Are Recorded"
+	LocalisationFiles []string
+}
+
+// BuildGraph parses the reality tables into the artifact's items and recipes.
+//
+// Identifiers are the game's own, verbatim: ULTRAPROD2, PLANT_SNOW. They are
+// never normalized or case-folded, because they are what save files carry
+// and what ADR-0002's import will join against, and a bespoke scheme would
+// have to be re-derived and re-verified on every regeneration.
+//
+// Only structure and quantities are read. Description, Subtitle, Hint and
+// asset paths are never touched — per ADR-0001 that text is Hello Games'
+// creative expression, and exclusion by construction beats exclusion by
+// filtering.
+func BuildGraph(src Sources) (*Graph, error) {
+	loc, err := LoadLocalisation(src.Localisation)
+	if err != nil {
+		return nil, err
+	}
+
+	subItems, err := parseSubstances(src.Substances, loc)
+	if err != nil {
+		return nil, err
+	}
+	prodItems, craft, skipped, err := parseProducts(src.Products, loc)
+	if err != nil {
+		return nil, err
+	}
+	refined, selfRef, err := parseRecipes(src.Recipes)
+	if err != nil {
+		return nil, err
+	}
+
+	items := append(subItems, prodItems...)
+	recipes := append(craft, refined...)
+
+	resolveMethods(items, recipes)
+
+	// Omitting an unnamed item is only safe while nothing references it.
+	// Asserted rather than assumed: a game update could start using one, and
+	// the failure would otherwise be a silently incomplete graph.
+	if err := checkSkippedUnreferenced(skipped, recipes); err != nil {
+		return nil, err
+	}
+	if err := checkClosed(items, recipes); err != nil {
+		return nil, err
+	}
+	return &Graph{
+		Items:                  items,
+		Recipes:                recipes,
+		SelfReferentialOmitted: selfRef,
+		UnnamedOmitted:         sortedStrings(skipped),
+		LocalisationFiles:      loc.Files(),
+	}, nil
+}
+
+// parseSubstances reads the substance table. Substances have no recipe of
+// their own; anything craftable from them lives in the product or recipe
+// tables.
+func parseSubstances(path string, loc *Localisation) ([]domain.Item, error) {
+	name := filepath.Base(path)
+	doc, err := readMXML(path, "cGcSubstanceTable")
+	if err != nil {
+		return nil, err
+	}
+	rows, err := doc.rows(name, "Table", "GcRealitySubstanceData")
+	if err != nil {
+		return nil, err
+	}
+	items := make([]domain.Item, 0, len(rows))
+	for _, r := range rows {
+		id, err := r.nonEmpty(name, r.ID, "ID")
+		if err != nil {
+			return nil, err
+		}
+		key, err := r.nonEmpty(name, id, "NameLower")
+		if err != nil {
+			return nil, err
+		}
+		display, err := loc.Resolve(name, id, key)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, domain.Item{ID: id, Name: display})
+	}
+	return items, nil
+}
+
+// parseProducts reads the product table, emitting one item per product and a
+// craft recipe for every product that declares requirements.
+//
+// A product declares exactly one craft route: AltRequirements is present on
+// every row and empty on all 2,144 of them. The recipe therefore takes the
+// product's own ID, which is unique by construction and stable across
+// regenerations — the two things SPEC-0001 REQ "Recipe Selection" needs of
+// an identifier a plan can record.
+func parseProducts(path string, loc *Localisation) ([]domain.Item, []domain.Recipe, []string, error) {
+	name := filepath.Base(path)
+	doc, err := readMXML(path, "cGcProductTable")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	rows, err := doc.rows(name, "Table", "GcProductData")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	items := make([]domain.Item, 0, len(rows))
+	var recipes []domain.Recipe
+	var skipped []string
+	for _, r := range rows {
+		id, err := r.nonEmpty(name, r.ID, "ID")
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		key, err := r.nonEmpty(name, id, "NameLower")
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		display, err := loc.Resolve(name, id, key)
+		if err != nil {
+			// A handful of products carry keys no English table defines.
+			// The allowlist is enumerated and checked by ID *and* key, so a
+			// game update that renames one fails here rather than being
+			// skipped on a stale entry.
+			if skipUnnamed(id, key) {
+				skipped = append(skipped, id)
+				continue
+			}
+			return nil, nil, nil, err
+		}
+		items = append(items, domain.Item{ID: id, Name: display})
+
+		// A second craft route would need a second recipe id, and the id
+		// scheme above assumes there is only one. Checked rather than
+		// assumed, so a game update that starts using AltRequirements fails
+		// here instead of silently colliding two recipes onto one id.
+		if alt, ok := r.child("AltRequirements"); ok && len(alt.children("AltRequirements")) > 0 {
+			return nil, nil, nil, Unrecognized(name, id, "AltRequirements",
+				"empty, as on every product in NMS 5.97", "an alternative craft route")
+		}
+
+		reqs, ok := r.child("Requirements")
+		if !ok {
+			continue
+		}
+		inputs, err := parseRequirements(name, id, reqs)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if len(inputs) == 0 {
+			continue
+		}
+		// The yield is read, never assumed: 2,143 products craft one at a
+		// time and exactly one crafts 25, which is precisely the shape of
+		// error a default would hide.
+		// Governing: SPEC-0004 REQ "Recipe Graph Construction" — "A yield
+		// MUST NOT default silently to one."
+		yield, err := r.int64(name, id, "DefaultCraftAmount")
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if yield <= 0 {
+			return nil, nil, nil, Unrecognized(name, id, "DefaultCraftAmount", "a positive quantity", yield)
+		}
+		recipes = append(recipes, domain.Recipe{
+			ID:     id,
+			Output: id,
+			Method: domain.MethodCraft,
+			Inputs: inputs,
+			Yield:  yield,
+		})
+	}
+	return items, recipes, skipped, nil
+}
+
+// parseRequirements reads a product's crafting inputs.
+func parseRequirements(table, row string, reqs node) ([]domain.Input, error) {
+	var out []domain.Input
+	for _, e := range reqs.children("Requirements") {
+		id, err := e.nonEmpty(table, row, "ID")
+		if err != nil {
+			return nil, err
+		}
+		amt, err := e.int64(table, row, "Amount")
+		if err != nil {
+			return nil, err
+		}
+		if amt <= 0 {
+			// A non-positive requirement is a structural surprise, not a
+			// free ingredient; the rollup engine rejects it downstream and
+			// the error is more useful here.
+			return nil, Unrecognized(table, row, "Amount", "a positive quantity", amt)
+		}
+		out = append(out, domain.Input{Item: id, Quantity: amt})
+	}
+	return out, nil
+}
+
+// parseRecipes reads the refiner table, returning every recipe it defines
+// and the count of self-referential ones omitted.
+//
+// One table carries both refining and cooking, distinguished by the
+// per-recipe Cooking flag — which is why the design's question about whether
+// cooking needs a separate source resolves to "no".
+//
+// Nothing is selected or deduplicated here. Per ADR-0005 the artifact
+// carries every route the game defines — 261 of 403 output/method pairs have
+// more than one, up to 61 — and choosing between them requires expansion
+// this pass does not perform.
+func parseRecipes(path string) ([]domain.Recipe, int, error) {
+	name := filepath.Base(path)
+	doc, err := readMXML(path, "cGcRecipeTable")
+	if err != nil {
+		return nil, 0, err
+	}
+	rows, err := doc.rows(name, "Table", "GcRefinerRecipe")
+	if err != nil {
+		return nil, 0, err
+	}
+	var out []domain.Recipe
+	var selfReferential int
+	for _, r := range rows {
+		rid, err := r.nonEmpty(name, r.ID, "Id")
+		if err != nil {
+			return nil, 0, err
+		}
+		cooking, err := r.boolean(name, rid, "Cooking")
+		if err != nil {
+			return nil, 0, err
+		}
+		method := domain.MethodRefine
+		if cooking {
+			method = domain.MethodCook
+		}
+
+		result, ok := r.child("Result")
+		if !ok {
+			return nil, 0, Unrecognized(name, rid, "Result", "present", "absent")
+		}
+		outID, err := result.nonEmpty(name, rid, "Id")
+		if err != nil {
+			return nil, 0, err
+		}
+		yield, err := result.int64(name, rid, "Amount")
+		if err != nil {
+			return nil, 0, err
+		}
+		if yield <= 0 {
+			return nil, 0, Unrecognized(name, rid, "Result/Amount", "a positive quantity", yield)
+		}
+
+		ing, ok := r.child("Ingredients")
+		if !ok {
+			return nil, 0, Unrecognized(name, rid, "Ingredients", "present", "absent")
+		}
+		var inputs []domain.Input
+		selfRef := false
+		for _, e := range ing.children("Ingredients") {
+			id, err := e.nonEmpty(name, rid, "Id")
+			if err != nil {
+				return nil, 0, err
+			}
+			amt, err := e.int64(name, rid, "Amount")
+			if err != nil {
+				return nil, 0, err
+			}
+			if amt <= 0 {
+				return nil, 0, Unrecognized(name, rid, "Amount", "a positive quantity", amt)
+			}
+			if id == outID {
+				selfRef = true
+			}
+			inputs = append(inputs, domain.Input{Item: id, Quantity: amt})
+		}
+		if len(inputs) == 0 {
+			return nil, 0, Unrecognized(name, rid, "Ingredients", "at least one ingredient", "none")
+		}
+		// A recipe naming its own output among its ingredients is a
+		// doubling strategy, not a production path, and expanding it is a
+		// cycle. Counted rather than silently dropped, so a change in the
+		// number is visible in provenance.
+		// Governing: SPEC-0004 REQ "Recipe Graph Construction".
+		if selfRef {
+			selfReferential++
+			continue
+		}
+		out = append(out, domain.Recipe{
+			ID:     rid,
+			Output: outID,
+			Method: method,
+			Inputs: inputs,
+			Yield:  yield,
+		})
+	}
+	return out, selfReferential, nil
+}
+
+// resolveMethods assigns each item its default method and marks the leaves.
+//
+// Precedence is craft, then refine, then cook, then raw. An item with no
+// recipe at all becomes a raw-obtainable terminal, which is what the rollup
+// engine's terminal-node handling expects to find at the bottom of a tree.
+func resolveMethods(items []domain.Item, recipes []domain.Recipe) {
+	byOutput := make(map[string]map[domain.Method]bool, len(recipes))
+	for _, r := range recipes {
+		m, ok := byOutput[r.Output]
+		if !ok {
+			m = make(map[domain.Method]bool, 3)
+			byOutput[r.Output] = m
+		}
+		m[r.Method] = true
+	}
+	for i := range items {
+		methods := byOutput[items[i].ID]
+		switch {
+		case methods[domain.MethodCraft]:
+			items[i].DefaultMethod = domain.MethodCraft
+		case methods[domain.MethodRefine]:
+			items[i].DefaultMethod = domain.MethodRefine
+		case methods[domain.MethodCook]:
+			items[i].DefaultMethod = domain.MethodCook
+		default:
+			items[i].DefaultMethod = domain.MethodRaw
+			items[i].RawObtainable = true
+		}
+	}
+}
+
+// checkClosed verifies every recipe endpoint resolves to an item in the
+// artifact, and that no two recipes for one output and method share an id.
+//
+// Governing: SPEC-0004 REQ "Recipe Graph Construction" — a dangling edge
+// fails generation rather than being emitted, because the rollup engine
+// would otherwise resolve a tree with a hole in it.
+func checkClosed(items []domain.Item, recipes []domain.Recipe) error {
+	known := make(map[string]bool, len(items))
+	for _, it := range items {
+		known[it.ID] = true
+	}
+	seen := make(map[string]bool, len(recipes))
+	for _, r := range recipes {
+		if !known[r.Output] {
+			return Unresolved("recipe graph", r.Output, "output", r.Output)
+		}
+		// A plan records a recipe by id, so a collision would make two
+		// different routes indistinguishable in saved plan state.
+		// Governing: SPEC-0001 REQ "Recipe Selection".
+		key := r.Output + "\x00" + string(r.Method) + "\x00" + r.ID
+		if seen[key] {
+			return Unrecognized("recipe graph", r.Output, "recipe id",
+				"one recipe per id for an output and method", fmt.Sprintf("a second %q", r.ID))
+		}
+		seen[key] = true
+		for _, in := range r.Inputs {
+			if !known[in.Item] {
+				return Unresolved("recipe graph", r.Output, "input", in.Item)
+			}
+		}
+	}
+	return nil
+}
+
+// checkSkippedUnreferenced verifies that no omitted known-unnamed item is
+// named by a recipe.
+//
+// Governing: SPEC-0004 REQ "Display Name Resolution" — the allowlist omits
+// items that have no display name. That is only defensible while they are
+// unreachable; the moment one becomes an ingredient, omitting it would open
+// a hole in the graph instead of trimming a leaf.
+func checkSkippedUnreferenced(skipped []string, recipes []domain.Recipe) error {
+	if len(skipped) == 0 {
+		return nil
+	}
+	omitted := make(map[string]bool, len(skipped))
+	for _, id := range skipped {
+		omitted[id] = true
+	}
+	for _, r := range recipes {
+		if omitted[r.Output] {
+			return Unrecognized("recipe graph", r.Output, "output",
+				"a named item, or no recipe at all", "a recipe producing a known-unnamed item")
+		}
+		for _, in := range r.Inputs {
+			if omitted[in.Item] {
+				return Unrecognized("recipe graph", r.Output, "input",
+					"a named item", "a known-unnamed item used as an ingredient")
+			}
+		}
+	}
+	return nil
+}

--- a/internal/normalize/tables_real_test.go
+++ b/internal/normalize/tables_real_test.go
@@ -1,0 +1,165 @@
+package normalize_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jonstump/nms-base-planner/internal/domain"
+	"github.com/jonstump/nms-base-planner/internal/normalize"
+)
+
+// A pass over a whole decompiled install, opt-in via NMS_SOURCE_DIR.
+//
+// The fixtures under testdata/graph are real rows, but they are a slice —
+// 69 items out of 2,255 — chosen by someone who already knew what the parser
+// expects. A slice cannot show that the *rest* of the table holds no shape
+// this code has never seen. That is precisely the failure this project has
+// recorded three times: a bounded search reported as a general result.
+//
+// The counts asserted below are the ones SPEC-0004 and ADR-0005 quote. If a
+// game update moves them, this test says so and the documents are wrong
+// rather than the code being quietly wrong.
+//
+// Point NMS_SOURCE_DIR at a directory holding metadata/reality/tables/ and
+// language/, decompiled with MBINCompiler:
+//
+//	NMS_SOURCE_DIR=/path/to/decompiled go test ./internal/normalize/ -run RealInstall -v
+func TestRealInstallGraphMatchesTheRecordedCounts(t *testing.T) {
+	root := os.Getenv("NMS_SOURCE_DIR")
+	if root == "" {
+		t.Skip("NMS_SOURCE_DIR is not set; skipping the pass over a real decompiled install")
+	}
+
+	tables := filepath.Join(root, "metadata/reality/tables")
+	loc, err := filepath.Glob(filepath.Join(root, "language", "nms_*_english.MXML"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loc) == 0 {
+		t.Fatalf("no English localisation tables under %s/language", root)
+	}
+
+	g, err := normalize.BuildGraph(normalize.Sources{
+		Products:     filepath.Join(tables, "nms_reality_gcproducttable.MXML"),
+		Substances:   filepath.Join(tables, "nms_reality_gcsubstancetable.MXML"),
+		Recipes:      filepath.Join(tables, "nms_reality_gcrecipetable.MXML"),
+		Localisation: loc,
+	})
+	if err != nil {
+		t.Fatalf("BuildGraph over the real tables: %v", err)
+	}
+
+	// 2,144 products less the 18 the allowlist omits, plus 111 substances.
+	if got, want := len(g.Items), 2237; got != want {
+		t.Errorf("items = %d, want %d", got, want)
+	}
+	if got, want := len(g.UnnamedOmitted), 18; got != want {
+		t.Errorf("unnamed items omitted = %d, want %d", got, want)
+	}
+	// SPEC-0004: "There are 27."
+	if got, want := g.SelfReferentialOmitted, 27; got != want {
+		t.Errorf("self-referential recipes omitted = %d, want %d", got, want)
+	}
+
+	var craft, refine, cook int
+	var maxYield int64
+	pairs := map[string]int{}
+	for _, r := range g.Recipes {
+		switch r.Method {
+		case domain.MethodCraft:
+			craft++
+		case domain.MethodRefine:
+			refine++
+			pairs[r.Output+"/refine"]++
+		case domain.MethodCook:
+			cook++
+			pairs[r.Output+"/cook"]++
+		default:
+			t.Fatalf("recipe %q declares method %q", r.ID, r.Method)
+		}
+		if r.Yield > maxYield {
+			maxYield = r.Yield
+		}
+	}
+	// 1,681 refiner recipes less the 27 excluded.
+	if got, want := refine+cook, 1654; got != want {
+		t.Errorf("refiner recipes = %d, want %d", got, want)
+	}
+	if craft == 0 {
+		t.Error("no craft recipes were built from the product table")
+	}
+	// ADR-0005: yields run up to 250.
+	if got, want := maxYield, int64(250); got != want {
+		t.Errorf("largest yield = %d, want %d", got, want)
+	}
+	var multi int
+	for _, n := range pairs {
+		if n > 1 {
+			multi++
+		}
+	}
+	if multi == 0 {
+		t.Error("no output/method pair has more than one recipe; ADR-0005 says 261 do")
+	}
+
+	// The whole graph must assemble and validate, which is the real bar: a
+	// duplicate recipe id or a dangling edge anywhere in 2,000+ recipes
+	// fails here and nowhere in the fixture.
+	b, err := normalize.NewBuilder("real-install", "6.45.0.1", []string{"NMSARC.Precache.pak"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.AddItems(g.Items...)
+	b.AddRecipes(g.Recipes...)
+	b.SetSelfReferentialOmitted(g.SelfReferentialOmitted)
+	a1, err := b.Artifact()
+	if err != nil {
+		t.Fatalf("assembling the whole graph: %v", err)
+	}
+
+	if got := len(a1.RecipesFor("CATALYST2", domain.MethodRefine)); got != 19 {
+		t.Errorf("CATALYST2 refine recipes = %d, want 19 (26 defined, 7 self-referential)", got)
+	}
+	it, ok := a1.Item("ULTRAPROD2")
+	if !ok {
+		t.Fatal("ULTRAPROD2 missing from the real graph")
+	}
+	if it.Name != "Stasis Device" {
+		t.Errorf("ULTRAPROD2 name = %q, want %q", it.Name, "Stasis Device")
+	}
+
+	// A recorded finding, not desired behaviour.
+	//
+	// SPEC-0004 derives raw-obtainability from the absence of a recipe, so
+	// a substance you gather with a mining beam *and* can refine — Cobalt,
+	// Sodium, the gases — comes out defaulting to refine. Refining runs
+	// both ways between several of those pairs, so resolving under pure
+	// defaults hits a cycle: 571 of the 2,237 items do, all of them
+	// refine loops between gatherable substances.
+	//
+	// The engine is right to refuse; SPEC-0001 REQ "Cycle Detection" calls
+	// this a runtime condition rather than one to assume away. What is
+	// missing is a source of truth for gatherability, and the substance
+	// table has one — PinObjective, which reads UI_REFINE_OBJ for the six
+	// substances that are refined only and some flavour of gather, find or
+	// process for the rest. Marking raw-obtainability from it resolves all
+	// 2,237 with no cycles.
+	//
+	// That is a modelling decision SPEC-0004 does not make, so it is
+	// recorded here rather than invented in the normalizer. When the spec
+	// is amended, this assertion changes with it.
+	_, err = domain.Resolve(a1, domain.PlanInput{Target: "ULTRAPROD2", Quantity: 1})
+	if !errors.Is(err, domain.ErrCycleDetected) {
+		t.Fatalf("resolving the Stasis Device: error = %v, want ErrCycleDetected until "+
+			"raw-obtainability is read from the source", err)
+	}
+
+	// The cycle is between refinable substances, not anywhere in the craft
+	// tree: every craft input still resolves to an item, which is what this
+	// story is responsible for.
+	if got := len(a1.RecipesFor("ULTRAPROD2", domain.MethodCraft)); got != 1 {
+		t.Errorf("ULTRAPROD2 craft recipes = %d, want 1", got)
+	}
+}

--- a/internal/normalize/tables_test.go
+++ b/internal/normalize/tables_test.go
@@ -1,0 +1,694 @@
+package normalize_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jonstump/nms-base-planner/internal/domain"
+	"github.com/jonstump/nms-base-planner/internal/normalize"
+)
+
+// The fixtures under testdata/graph are whole rows lifted out of a real
+// 6.45.0.1 decompilation — see testdata/graph/gen.go for which rows and why.
+// Each seed is there for a property that has to be exercised against real
+// data rather than an invented approximation of it: the Stasis Device's
+// craft closure, Sodium Nitrate's many refine routes, a cooked product, and
+// the one product in the game that crafts twenty-five at a time.
+const graphRoot = "testdata/graph"
+
+func graphSources(root string) normalize.Sources {
+	return normalize.Sources{
+		Products:     filepath.Join(root, "products.MXML"),
+		Substances:   filepath.Join(root, "substances.MXML"),
+		Recipes:      filepath.Join(root, "recipes.MXML"),
+		Localisation: []string{filepath.Join(root, "localisation.MXML")},
+	}
+}
+
+func buildGraph(t *testing.T) *normalize.Graph {
+	t.Helper()
+	g, err := normalize.BuildGraph(graphSources(graphRoot))
+	if err != nil {
+		t.Fatalf("BuildGraph: %v", err)
+	}
+	return g
+}
+
+// graphArtifact assembles the graph into a validated artifact, which is what
+// a consumer actually loads.
+func graphArtifact(t *testing.T) *domain.Tier1 {
+	t.Helper()
+	g := buildGraph(t)
+	b, err := normalize.NewBuilder("5.97", "6.45.0.1", []string{"NMSARC.Precache.pak"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.AddItems(g.Items...)
+	b.AddRecipes(g.Recipes...)
+	b.SetSelfReferentialOmitted(g.SelfReferentialOmitted)
+	a1, err := b.Artifact()
+	if err != nil {
+		t.Fatalf("Artifact: %v", err)
+	}
+	return a1
+}
+
+func itemsByID(g *normalize.Graph) map[string]domain.Item {
+	out := make(map[string]domain.Item, len(g.Items))
+	for _, it := range g.Items {
+		out[it.ID] = it
+	}
+	return out
+}
+
+// SPEC-0004 REQ "Recipe Graph Construction":
+// WHEN an artifact is generated
+// THEN every recipe input and output resolves to an item in the same artifact.
+func TestGraphIsClosed(t *testing.T) {
+	g := buildGraph(t)
+	known := itemsByID(g)
+
+	if len(g.Items) == 0 || len(g.Recipes) == 0 {
+		t.Fatalf("graph is empty: %d items, %d recipes", len(g.Items), len(g.Recipes))
+	}
+	for _, r := range g.Recipes {
+		if _, ok := known[r.Output]; !ok {
+			t.Errorf("recipe %q produces %q, which is not an item", r.ID, r.Output)
+		}
+		for _, in := range r.Inputs {
+			if _, ok := known[in.Item]; !ok {
+				t.Errorf("recipe %q consumes %q, which is not an item", r.ID, in.Item)
+			}
+			if in.Quantity <= 0 {
+				t.Errorf("recipe %q consumes %d of %q", r.ID, in.Quantity, in.Item)
+			}
+		}
+	}
+}
+
+// The graph must survive the artifact's own validation, and the artifact
+// must carry the omission count in its provenance.
+//
+// Governing: SPEC-0004 REQ "Recipe Graph Construction" — "MUST record how
+// many it omitted in the artifact's provenance."
+func TestGraphAssemblesIntoAValidArtifact(t *testing.T) {
+	g := buildGraph(t)
+	a1 := graphArtifact(t)
+
+	if a1.Provenance == nil {
+		t.Fatal("no provenance recorded")
+	}
+	if got, want := a1.Provenance.SelfReferentialRecipesOmitted, g.SelfReferentialOmitted; got != want {
+		t.Errorf("provenance records %d omitted self-referential recipes, want %d", got, want)
+	}
+	if g.SelfReferentialOmitted == 0 {
+		t.Fatal("the fixture omitted none, so this scenario is not being exercised")
+	}
+
+	// And the number survives a round trip, which is the point of recording
+	// it: a change between regenerations shows up as a diff.
+	blob, err := normalize.Encode(a1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := domain.LoadTier1(strings.NewReader(string(blob)))
+	if err != nil {
+		t.Fatalf("reloading: %v", err)
+	}
+	if back.Provenance.SelfReferentialRecipesOmitted != g.SelfReferentialOmitted {
+		t.Errorf("count did not survive a round trip: %d", back.Provenance.SelfReferentialRecipesOmitted)
+	}
+}
+
+// SPEC-0004 REQ "Identifier Policy":
+// WHEN the Stasis Device is emitted
+// THEN its item ID is ULTRAPROD2, exactly as the product table spells it.
+func TestIdentifiersAreGameIDsVerbatim(t *testing.T) {
+	g := buildGraph(t)
+	byID := itemsByID(g)
+
+	if _, ok := byID["ULTRAPROD2"]; !ok {
+		t.Fatal("ULTRAPROD2 missing from the graph")
+	}
+	// The engine fixture's short codes (fc, sb, sd) illustrate shape, not
+	// identifier policy. None of them may appear here.
+	for _, short := range []string{"sd", "fc", "sb", "cc", "gla"} {
+		if _, ok := byID[short]; ok {
+			t.Errorf("short code %q leaked into the generated graph", short)
+		}
+	}
+	for _, it := range g.Items {
+		if it.ID != strings.ToUpper(it.ID) && it.ID != strings.ToLower(it.ID) {
+			continue // mixed case is the game's own business
+		}
+		if lower := strings.ToLower(it.ID); it.ID == lower && lower != strings.ToUpper(it.ID) {
+			t.Errorf("item %q looks case-folded; game IDs are not rewritten", it.ID)
+		}
+	}
+}
+
+// SPEC-0004 REQ "Display Name Resolution":
+// WHEN ULTRAPROD2 is emitted
+// THEN its name is "Stasis Device", resolved through UI_ULTRAPROD_2_NAME_L.
+func TestNamesComeFromTheLocalisationTables(t *testing.T) {
+	g := buildGraph(t)
+	byID := itemsByID(g)
+
+	cases := map[string]string{
+		"ULTRAPROD2": "Stasis Device",
+		"CATALYST2":  "Sodium Nitrate",
+		"VENTGEM":    "Crystal Sulphide",
+	}
+	for id, want := range cases {
+		it, ok := byID[id]
+		if !ok {
+			t.Errorf("%s missing", id)
+			continue
+		}
+		if it.Name != want {
+			t.Errorf("%s name = %q, want %q", id, it.Name, want)
+		}
+	}
+
+	// No name may be a localisation key or an item ID wearing a name's
+	// clothes — the failure mode SPEC-0004 forbids falling back to.
+	for _, it := range g.Items {
+		if it.Name == "" {
+			t.Errorf("item %q has an empty name", it.ID)
+		}
+		if strings.HasPrefix(it.Name, "UI_") || strings.HasSuffix(it.Name, "_NAME_L") {
+			t.Errorf("item %q name %q is a localisation key, not a resolved string", it.ID, it.Name)
+		}
+		if it.Name == it.ID {
+			t.Errorf("item %q name fell back to its ID", it.ID)
+		}
+	}
+
+	// The tables consulted are recorded, so a name that fails to resolve can
+	// say where we looked.
+	// Governing: SPEC-0004 REQ "Search Boundaries Are Recorded".
+	if len(g.LocalisationFiles) == 0 {
+		t.Error("no localisation files recorded")
+	}
+}
+
+// SPEC-0004 REQ "Display Name Resolution":
+// WHEN an item's name key is absent from the localisation tables
+// THEN generation fails naming the key and the item, and no artifact is
+// written.
+func TestUnresolvedNameFailsRatherThanLeaking(t *testing.T) {
+	root := copyGraphTree(t)
+	p := filepath.Join(root, "localisation.MXML")
+	blob, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const key = "UI_ULTRAPROD_2_NAME_L"
+	if !strings.Contains(string(blob), key) {
+		t.Fatalf("the fixture no longer defines %s, so this case proves nothing", key)
+	}
+	edited := strings.ReplaceAll(string(blob), key, "UI_SOMETHING_ELSE_NAME_L")
+	if err := os.WriteFile(p, []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := normalize.BuildGraph(graphSources(root))
+	if !errors.Is(err, normalize.ErrLocalisationUnresolved) {
+		t.Fatalf("error = %v, want ErrLocalisationUnresolved", err)
+	}
+	if g != nil {
+		t.Error("a graph was returned alongside an error; must be nil")
+	}
+	for _, want := range []string{key, "ULTRAPROD2"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name %q", err, want)
+		}
+	}
+}
+
+// The allowlist omits products no English table names. That is only
+// defensible while nothing references them, which is asserted rather than
+// assumed.
+//
+// Governing: SPEC-0004 REQ "Display Name Resolution"
+func TestKnownUnnamedItemsAreOmittedAndUnreferenced(t *testing.T) {
+	g := buildGraph(t)
+	byID := itemsByID(g)
+
+	for _, id := range []string{"CHART_BUILDER", "WORLDSMB_SOUL"} {
+		if _, ok := byID[id]; ok {
+			t.Errorf("%s was emitted; no English table defines its name", id)
+		}
+	}
+	if len(g.UnnamedOmitted) != 2 {
+		t.Errorf("omitted %v, want the two the fixture carries", g.UnnamedOmitted)
+	}
+	// Sorted, so the artifact's record of them is stable across runs.
+	for i := 1; i < len(g.UnnamedOmitted); i++ {
+		if g.UnnamedOmitted[i-1] >= g.UnnamedOmitted[i] {
+			t.Errorf("omitted list is not sorted: %v", g.UnnamedOmitted)
+		}
+	}
+	if normalize.KnownUnnamedCount() != 18 {
+		t.Errorf("allowlist holds %d entries, want the 18 verified against NMS 5.97",
+			normalize.KnownUnnamedCount())
+	}
+
+	// Nothing in the graph names one of them.
+	omitted := map[string]bool{}
+	for _, id := range g.UnnamedOmitted {
+		omitted[id] = true
+	}
+	for _, r := range g.Recipes {
+		if omitted[r.Output] {
+			t.Errorf("recipe %q produces omitted item %q", r.ID, r.Output)
+		}
+		for _, in := range r.Inputs {
+			if omitted[in.Item] {
+				t.Errorf("recipe %q consumes omitted item %q", r.ID, in.Item)
+			}
+		}
+	}
+}
+
+// SPEC-0004 REQ "Recipe Graph Construction":
+// WHEN the source defines 26 refine recipes producing CATALYST2
+// THEN the artifact carries all of them, and the normalizer selects none.
+//
+// Seven of the 26 are self-referential and excluded by the requirement
+// below, so 19 reach the artifact. The point of the scenario is that the
+// normalizer discards nothing on its own account.
+func TestEveryAlternativeIsEmitted(t *testing.T) {
+	a1 := graphArtifact(t)
+
+	got := a1.RecipesFor("CATALYST2", domain.MethodRefine)
+	if len(got) != 19 {
+		t.Fatalf("CATALYST2 refine recipes = %d, want 19 (26 defined, 7 self-referential)", len(got))
+	}
+	// The source really does define 26, so the 19 above is an exclusion
+	// rather than an incomplete read.
+	if defined := countRecipesFor(t, "CATALYST2"); defined != 26 {
+		t.Fatalf("the fixture defines %d CATALYST2 recipes, want 26", defined)
+	}
+
+	// Ids are distinct, because a plan records one to name a route.
+	seen := map[string]bool{}
+	for _, r := range got {
+		if r.ID == "" {
+			t.Error("a recipe reached the artifact with no id")
+		}
+		if seen[r.ID] {
+			t.Errorf("duplicate recipe id %q", r.ID)
+		}
+		seen[r.ID] = true
+	}
+	// And the engine's view agrees: every one is a legal option.
+	if legal := a1.LegalRecipes("CATALYST2", domain.MethodRefine); len(legal) != len(got) {
+		t.Errorf("legal recipes = %d, want %d", len(legal), len(got))
+	}
+}
+
+// countRecipesFor counts the recipes the fixture defines for an output,
+// before any exclusion, by reading the source rather than the artifact.
+func countRecipesFor(t *testing.T, output string) int {
+	t.Helper()
+	blob, err := os.ReadFile(filepath.Join(graphRoot, "recipes.MXML"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for _, row := range strings.Split(string(blob), `<Property name="Table" value="GcRefinerRecipe"`)[1:] {
+		result, _, ok := strings.Cut(row, `<Property name="Ingredients">`)
+		if !ok {
+			continue
+		}
+		if strings.Contains(result, `<Property name="Id" value="`+output+`" />`) {
+			n++
+		}
+	}
+	return n
+}
+
+// SPEC-0004 REQ "Recipe Graph Construction":
+// WHEN a recipe producing 50 units from one input is read
+// THEN its yield is 50 in the artifact, not 1.
+func TestYieldsAreReadNotDefaulted(t *testing.T) {
+	a1 := graphArtifact(t)
+
+	// ADR-0005's worked example: 1x Crystal Sulphide -> 50x Sodium Nitrate.
+	r, ok := a1.Recipe("CATALYST2", domain.MethodRefine, "REFINERECIPE_5")
+	if !ok {
+		t.Fatal("REFINERECIPE_5 missing")
+	}
+	if r.Yield != 50 {
+		t.Errorf("yield = %d, want 50", r.Yield)
+	}
+	if len(r.Inputs) != 1 || r.Inputs[0].Item != "VENTGEM" || r.Inputs[0].Quantity != 1 {
+		t.Errorf("inputs = %+v, want one VENTGEM", r.Inputs)
+	}
+
+	// Crafting has yields too, read from DefaultCraftAmount rather than
+	// assumed: AMMO is the single product in the table that makes 25.
+	ammo, ok := a1.Recipe("AMMO", domain.MethodCraft, "AMMO")
+	if !ok {
+		t.Fatal("AMMO craft recipe missing")
+	}
+	if ammo.Yield != 25 {
+		t.Errorf("AMMO yield = %d, want 25", ammo.Yield)
+	}
+
+	// Every recipe states a yield; none was left at the zero value.
+	for _, rec := range a1.Recipes {
+		if rec.Yield <= 0 {
+			t.Errorf("recipe %q yield = %d; yields are read, never defaulted", rec.ID, rec.Yield)
+		}
+	}
+}
+
+// SPEC-0004 REQ "Recipe Graph Construction":
+// WHEN a recipe's output quantity cannot be read from the source
+// THEN generation fails naming the recipe, rather than assuming a yield of
+// one.
+func TestAbsentYieldFailsRatherThanDefaults(t *testing.T) {
+	root := copyGraphTree(t)
+	p := filepath.Join(root, "recipes.MXML")
+	blob, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// REFINERECIPE_5's Result block, with its Amount removed.
+	const marker = `<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_5">`
+	i := strings.Index(string(blob), marker)
+	if i < 0 {
+		t.Fatal("REFINERECIPE_5 is not in the fixture, so this case proves nothing")
+	}
+	head, tail := string(blob)[:i], string(blob)[i:]
+	amount := `<Property name="Amount" value="50" />`
+	if !strings.Contains(tail, amount) {
+		t.Fatal("REFINERECIPE_5 no longer states Amount 50")
+	}
+	edited := head + strings.Replace(tail, amount, "", 1)
+	if err := os.WriteFile(p, []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := normalize.BuildGraph(graphSources(root))
+	if !errors.Is(err, normalize.ErrStructureUnrecognized) {
+		t.Fatalf("error = %v, want ErrStructureUnrecognized", err)
+	}
+	if g != nil {
+		t.Error("a graph was returned alongside an error")
+	}
+	if !strings.Contains(err.Error(), "REFINERECIPE_5") {
+		t.Errorf("error %q does not name the recipe", err)
+	}
+}
+
+// SPEC-0004 REQ "Recipe Graph Construction":
+// WHEN a refiner recipe carries Cooking true
+// THEN its method is cook, and a recipe carrying Cooking false is refine.
+func TestCookingFlagDistinguishesMethod(t *testing.T) {
+	a1 := graphArtifact(t)
+
+	// RECIPE_2 is the fixture's cooked recipe; REFINERECIPE_5 is refined.
+	if _, ok := a1.Recipe("FOOD_P_STELLAR", domain.MethodCook, "RECIPE_2"); !ok {
+		t.Error("RECIPE_2 did not resolve to method cook")
+	}
+	if _, ok := a1.Recipe("FOOD_P_STELLAR", domain.MethodRefine, "RECIPE_2"); ok {
+		t.Error("RECIPE_2 also appears as refine")
+	}
+	if _, ok := a1.Recipe("CATALYST2", domain.MethodRefine, "REFINERECIPE_5"); !ok {
+		t.Error("REFINERECIPE_5 did not resolve to method refine")
+	}
+
+	// Both values of the flag are present, so neither branch passes because
+	// the other never occurs.
+	var cook, refine int
+	for _, r := range a1.Recipes {
+		switch r.Method {
+		case domain.MethodCook:
+			cook++
+		case domain.MethodRefine:
+			refine++
+		}
+	}
+	if cook == 0 || refine == 0 {
+		t.Errorf("cook = %d, refine = %d; the fixture must exercise both", cook, refine)
+	}
+}
+
+// SPEC-0004 REQ "Recipe Graph Construction":
+// WHEN a recipe names its own output among its ingredients
+// THEN it is omitted from the artifact, and the provenance records the
+// omitted count.
+func TestSelfReferentialRecipesAreExcludedAndCounted(t *testing.T) {
+	g := buildGraph(t)
+
+	if g.SelfReferentialOmitted != 17 {
+		t.Errorf("omitted %d self-referential recipes, want the 17 the fixture defines",
+			g.SelfReferentialOmitted)
+	}
+	for _, r := range g.Recipes {
+		for _, in := range r.Inputs {
+			if in.Item == r.Output {
+				t.Errorf("recipe %q names its own output %q among its ingredients", r.ID, r.Output)
+			}
+		}
+	}
+	// The items involved survive by their other routes; exclusion trims a
+	// doubling strategy, it does not remove an item from the graph.
+	if _, ok := itemsByID(g)["CATALYST2"]; !ok {
+		t.Error("CATALYST2 disappeared with its self-referential recipes")
+	}
+}
+
+// SPEC-0004 REQ "Recipe Graph Construction":
+// Items with no recipe are emitted raw-obtainable with default method raw.
+func TestItemsWithoutRecipesAreRawTerminals(t *testing.T) {
+	g := buildGraph(t)
+
+	produced := map[string]bool{}
+	for _, r := range g.Recipes {
+		produced[r.Output] = true
+	}
+	var raws int
+	for _, it := range g.Items {
+		if produced[it.ID] {
+			if it.DefaultMethod == domain.MethodRaw && !it.RawObtainable {
+				t.Errorf("item %q defaults to raw but is not raw-obtainable", it.ID)
+			}
+			continue
+		}
+		raws++
+		if it.DefaultMethod != domain.MethodRaw {
+			t.Errorf("item %q has no recipe but defaults to %q", it.ID, it.DefaultMethod)
+		}
+		if !it.RawObtainable {
+			t.Errorf("item %q has no recipe but is not raw-obtainable", it.ID)
+		}
+	}
+	if raws == 0 {
+		t.Error("the fixture has no recipe-less items, so terminals are not exercised")
+	}
+}
+
+// SPEC-0004 REQ "Recipe Graph Construction":
+// WHEN a source table implies a method outside craft, refine, raw, cook
+// THEN generation fails naming the method found, rather than emitting it.
+func TestMethodVocabularyIsClosed(t *testing.T) {
+	g := buildGraph(t)
+
+	for _, r := range g.Recipes {
+		switch r.Method {
+		case domain.MethodCraft, domain.MethodRefine, domain.MethodCook:
+		case domain.MethodRaw:
+			t.Errorf("recipe %q declares method raw, which is terminal by definition", r.ID)
+		default:
+			t.Errorf("recipe %q declares method %q, outside the vocabulary", r.ID, r.Method)
+		}
+	}
+	// "buy" is deliberately absent from the vocabulary: this is a build
+	// planner, not a shopping list.
+	blob, err := normalize.Encode(graphArtifact(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(blob), `"buy"`) {
+		t.Error("a buy method reached the artifact")
+	}
+}
+
+// SPEC-0004 REQ "Excluded Content":
+// WHEN an item whose source record carries Description, Subtitle and Hint is
+// emitted THEN none of those fields appear anywhere in the artifact; and no
+// asset path appears either.
+func TestDescriptiveTextAndAssetPathsAreExcluded(t *testing.T) {
+	blob, err := normalize.Encode(graphArtifact(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(blob)
+
+	for _, banned := range []string{
+		"_DESC", "_SUB", "Subtitle", "Description", "Hint",
+		".DDS", ".MBIN", ".SCENE", "TEXTURES/", "MODELS/",
+	} {
+		if strings.Contains(out, banned) {
+			t.Errorf("artifact contains %q; only structure and quantities are taken", banned)
+		}
+	}
+
+	// The source really does carry them, so exclusion is a property of the
+	// normalizer rather than of the fixture.
+	src, err := os.ReadFile(filepath.Join(graphRoot, "products.MXML"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Description", "Subtitle", "Hint", ".DDS", "MODELS/"} {
+		if !strings.Contains(string(src), want) {
+			t.Errorf("the source fixture no longer carries %q, so exclusion is not being exercised", want)
+		}
+	}
+}
+
+// The acceptance case: the generated graph reproduces the shape of the
+// engine's hand-authored Stasis Device fixture for the nodes it covers.
+//
+// Compared as the craft closure rather than as a resolved tree, because the
+// hand fixture pins several nodes to raw that the real data reaches by
+// refining — a difference in default methods, not in structure.
+func TestStasisDeviceCraftClosureMatchesTheEngineFixture(t *testing.T) {
+	a1 := graphArtifact(t)
+
+	seen := map[string]bool{}
+	var walk func(string)
+	walk = func(id string) {
+		if seen[id] {
+			return
+		}
+		seen[id] = true
+		for _, r := range a1.RecipesFor(id, domain.MethodCraft) {
+			for _, in := range r.Inputs {
+				walk(in.Item)
+			}
+		}
+	}
+	walk("ULTRAPROD2")
+
+	if len(seen) != 34 {
+		t.Errorf("craft closure of ULTRAPROD2 = %d items, want the 34 the engine fixture carries", len(seen))
+	}
+
+	// And the top of the tree matches: three components, one of each.
+	top := a1.RecipesFor("ULTRAPROD2", domain.MethodCraft)
+	if len(top) != 1 {
+		t.Fatalf("ULTRAPROD2 craft recipes = %d, want 1", len(top))
+	}
+	if len(top[0].Inputs) != 3 {
+		t.Errorf("Stasis Device inputs = %d, want 3", len(top[0].Inputs))
+	}
+	for _, in := range top[0].Inputs {
+		if in.Quantity != 1 {
+			t.Errorf("Stasis Device consumes %d of %q, want 1", in.Quantity, in.Item)
+		}
+	}
+}
+
+// SPEC-0004 REQ "Structural Surprise Fails Loudly" — pointing the parser at
+// the wrong file is a named error, not an empty table.
+func TestWrongTemplateIsRefused(t *testing.T) {
+	src := graphSources(graphRoot)
+	src.Products = filepath.Join(graphRoot, "substances.MXML")
+
+	g, err := normalize.BuildGraph(src)
+	if !errors.Is(err, normalize.ErrStructureUnrecognized) {
+		t.Fatalf("error = %v, want ErrStructureUnrecognized", err)
+	}
+	if g != nil {
+		t.Error("a graph was returned alongside an error")
+	}
+	if !strings.Contains(err.Error(), "cGcProductTable") {
+		t.Errorf("error %q does not name the template it wanted", err)
+	}
+}
+
+// A missing source names the file rather than failing on a nil.
+func TestMissingSourceIsNamed(t *testing.T) {
+	src := graphSources(graphRoot)
+	src.Recipes = filepath.Join(graphRoot, "not_a_table.MXML")
+
+	g, err := normalize.BuildGraph(src)
+	if !errors.Is(err, normalize.ErrSourceMissing) {
+		t.Fatalf("error = %v, want ErrSourceMissing", err)
+	}
+	if g != nil {
+		t.Error("a graph was returned alongside an error")
+	}
+	if !strings.Contains(err.Error(), "not_a_table.MXML") {
+		t.Errorf("error %q does not name the missing file", err)
+	}
+}
+
+// A product declaring an alternative craft route would need a second recipe
+// id, which the id scheme does not provide. The game does not do this today
+// and the normalizer refuses to guess if it starts.
+func TestAlternativeCraftRouteIsRefused(t *testing.T) {
+	root := copyGraphTree(t)
+	p := filepath.Join(root, "products.MXML")
+	blob, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const empty = `<Property name="AltRequirements" />`
+	if !strings.Contains(string(blob), empty) {
+		t.Fatal("the fixture no longer carries an empty AltRequirements")
+	}
+	populated := `<Property name="AltRequirements">
+				<Property name="AltRequirements" value="GcTechnologyRequirement" _id="VENTGEM">
+					<Property name="ID" value="VENTGEM" />
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>`
+	edited := strings.Replace(string(blob), empty, populated, 1)
+	if err := os.WriteFile(p, []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := normalize.BuildGraph(graphSources(root))
+	if !errors.Is(err, normalize.ErrStructureUnrecognized) {
+		t.Fatalf("error = %v, want ErrStructureUnrecognized", err)
+	}
+	if g != nil {
+		t.Error("a graph was returned alongside an error")
+	}
+	if !strings.Contains(err.Error(), "AltRequirements") {
+		t.Errorf("error %q does not name the field", err)
+	}
+}
+
+// copyGraphTree copies the graph fixtures into a temp dir so a case can
+// break one.
+func copyGraphTree(t *testing.T) string {
+	t.Helper()
+	dst := t.TempDir()
+	entries, err := filepath.Glob(filepath.Join(graphRoot, "*.MXML"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("no fixtures under %s", graphRoot)
+	}
+	for _, p := range entries {
+		blob, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dst, filepath.Base(p)), blob, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dst
+}

--- a/internal/normalize/testdata/graph/gen.go
+++ b/internal/normalize/testdata/graph/gen.go
@@ -1,0 +1,355 @@
+//go:build ignore
+
+// Command gen builds the recipe-graph fixtures from a real decompiled
+// extraction.
+//
+// The rows are real: whole `<Property name="Table" ...>` blocks lifted
+// verbatim out of the decompiled tables, not an approximation of their
+// shape. Testing a parser against a hand-authored idea of the format tests
+// only that the parser agrees with its author, which is how this project
+// came to ship a PSARC reader for a format that is not PSARC.
+//
+// Usage, from a tree decompiled with MBINCompiler 6.45.0.1:
+//
+//	nmsextract extract NMSARC.Precache.pak $SRC metadata/reality/tables/
+//	nmsextract extract NMSARC.Precache.pak $SRC language/
+//	MBINCompiler <each .mbin>
+//	go run gen.go $SRC
+//
+// What is kept, and why:
+//
+//	products, substances  the craft closure of ULTRAPROD2 — the 34-node
+//	                      Stasis Device tree the engine fixture asserts —
+//	                      plus CATALYST2 and every ingredient of the
+//	                      recipes below, so the graph is closed. Two
+//	                      known-unnamed products are included so the
+//	                      allowlist is exercised rather than assumed.
+//	recipes               every recipe producing one of those items. That
+//	                      is 26 for CATALYST2 alone (ADR-0005's worked
+//	                      example), seven of them self-referential, and it
+//	                      includes yields other than one.
+//	localisation          only the Id and English properties of the keys
+//	                      the emitted items name. The real rows carry
+//	                      fifteen further translations that no code here
+//	                      reads; projecting them away keeps the fixture to
+//	                      what is under test.
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// The seeds. Each is here for a property the fixture has to exercise
+// against real rows rather than an invented approximation of them.
+var seeds = []string{
+	"ULTRAPROD2",     // the Stasis Device: a 34-item craft closure
+	"CATALYST2",      // Sodium Nitrate: 26 refine recipes, seven self-referential
+	"FOOD_P_STELLAR", // a cooked product, so the Cooking flag has both values
+	"AMMO",           // the one product in the table that crafts 25 at a time
+}
+
+// knownUnnamed products, included so the allowlist path is exercised. These
+// carry NameLower keys no English table defines.
+var unnamed = []string{"CHART_BUILDER", "WORLDSMB_SOUL"}
+
+type node struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+	ID    string `xml:"_id,attr"`
+	Props []node `xml:"Property"`
+}
+
+type doc struct {
+	Props []node `xml:"Property"`
+}
+
+func (n node) child(name string) (node, bool) {
+	for _, p := range n.Props {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return node{}, false
+}
+
+func (n node) children(name string) []node {
+	var out []node
+	for _, p := range n.Props {
+		if p.Name == name {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func (n node) str(name string) string {
+	c, _ := n.child(name)
+	return c.Value
+}
+
+// table is one parsed source file, keeping both the structure (for the
+// closure) and each row's original text (for the slice).
+type table struct {
+	path   string
+	header []string
+	rows   map[string]node
+	text   map[string]string
+	order  []string
+}
+
+func load(path, wrapper, rowValue string) (*table, error) {
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var d doc
+	if err := xml.Unmarshal(blob, &d); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+
+	t := &table{path: path, rows: map[string]node{}, text: map[string]string{}}
+	for _, p := range d.Props {
+		if p.Name != wrapper {
+			continue
+		}
+		for _, r := range p.children(wrapper) {
+			if r.Value != rowValue {
+				return nil, fmt.Errorf("%s: row %q has value %q, want %q", path, r.ID, r.Value, rowValue)
+			}
+			t.rows[r.ID] = r
+			t.order = append(t.order, r.ID)
+		}
+	}
+
+	// Rows sit at one indent level inside the wrapper and close on a line
+	// that is exactly that indent, which makes the slice a scan rather than
+	// a parse.
+	const open = `<Property name="Table" value="`
+	lines := strings.Split(string(blob), "\n")
+	for i := 0; i < len(lines); i++ {
+		l := lines[i]
+		if !strings.Contains(l, open) || !strings.Contains(l, `_id="`) {
+			continue
+		}
+		id := between(l, `_id="`, `"`)
+		indent := l[:len(l)-len(strings.TrimLeft(l, "\t"))]
+		row := []string{l}
+		for i++; i < len(lines); i++ {
+			row = append(row, lines[i])
+			if lines[i] == indent+"</Property>" {
+				break
+			}
+		}
+		t.text[id] = strings.Join(row, "\n")
+	}
+	for _, id := range t.order {
+		if _, ok := t.text[id]; !ok {
+			return nil, fmt.Errorf("%s: no text sliced for row %q", path, id)
+		}
+	}
+	return t, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run gen.go <decompiled-source-root>")
+		os.Exit(2)
+	}
+	src := os.Args[1]
+	tables := filepath.Join(src, "metadata/reality/tables")
+
+	products := must(load(filepath.Join(tables, "nms_reality_gcproducttable.MXML"), "Table", "GcProductData"))
+	substances := must(load(filepath.Join(tables, "nms_reality_gcsubstancetable.MXML"), "Table", "GcRealitySubstanceData"))
+	recipes := must(load(filepath.Join(tables, "nms_reality_gcrecipetable.MXML"), "Table", "GcRefinerRecipe"))
+
+	// Craft closure: a product's Requirements name the items it is built
+	// from, and those items' own requirements in turn.
+	core := map[string]bool{}
+	stack := append([]string(nil), seeds...)
+	for len(stack) > 0 {
+		id := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if core[id] {
+			continue
+		}
+		core[id] = true
+		r, ok := products.rows[id]
+		if !ok {
+			continue
+		}
+		reqs, ok := r.child("Requirements")
+		if !ok {
+			continue
+		}
+		for _, e := range reqs.children("Requirements") {
+			stack = append(stack, e.str("ID"))
+		}
+	}
+
+	// Every recipe producing a core item, and every ingredient it names.
+	items := map[string]bool{}
+	for id := range core {
+		items[id] = true
+	}
+	keptRecipes := map[string]bool{}
+	for _, rid := range recipes.order {
+		r := recipes.rows[rid]
+		result, ok := r.child("Result")
+		if !ok {
+			continue
+		}
+		if !core[result.str("Id")] {
+			continue
+		}
+		keptRecipes[rid] = true
+		ing, ok := r.child("Ingredients")
+		if !ok {
+			continue
+		}
+		for _, e := range ing.children("Ingredients") {
+			items[e.str("Id")] = true
+		}
+	}
+	for _, id := range unnamed {
+		items[id] = true
+	}
+
+	// Localisation keys: every emitted item's NameLower, minus the ones the
+	// allowlist expects to be absent.
+	keys := map[string]bool{}
+	skip := map[string]bool{}
+	for _, id := range unnamed {
+		skip[id] = true
+	}
+	for _, t := range []*table{products, substances} {
+		for id, r := range t.rows {
+			if items[id] && !skip[id] {
+				keys[r.str("NameLower")] = true
+			}
+		}
+	}
+
+	must0(emit("products.MXML", "cGcProductTable", products, items))
+	must0(emit("substances.MXML", "cGcSubstanceTable", substances, items))
+	must0(emit("recipes.MXML", "cGcRecipeTable", recipes, keptRecipes))
+	must0(emitLocalisation(filepath.Join(src, "language"), keys))
+
+	fmt.Printf("items %d (core %d), recipes %d, localisation keys %d\n",
+		len(items), len(core), len(keptRecipes), len(keys))
+}
+
+// emit writes the selected rows of a table, verbatim.
+func emit(dst, template string, t *table, keep map[string]bool) error {
+	out := []string{`<?xml version="1.0" encoding="utf-8"?>`,
+		`<!--File created using MBINCompiler version (6.45.0.1)-->`,
+		`<Data template="` + template + `">`,
+		"\t" + `<Property name="Table">`}
+	n := 0
+	for _, id := range t.order {
+		if !keep[id] {
+			continue
+		}
+		out = append(out, t.text[id])
+		n++
+	}
+	if n == 0 {
+		return fmt.Errorf("%s: no rows selected", dst)
+	}
+	out = append(out, "\t</Property>", "</Data>", "")
+	return os.WriteFile(dst, []byte(strings.Join(out, "\n")), 0o644)
+}
+
+// emitLocalisation projects each wanted key to its Id and English value.
+//
+// A key absent from every table is an error here rather than an omission:
+// the fixture exists to prove names resolve, and one that quietly lacks a
+// key would make the resolution test pass for the wrong reason.
+func emitLocalisation(dir string, keys map[string]bool) error {
+	files, err := filepath.Glob(filepath.Join(dir, "nms_*_english.MXML"))
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("%s: no english localisation tables", dir)
+	}
+	sort.Strings(files)
+
+	found := map[string]string{}
+	for _, f := range files {
+		t, err := load(f, "Table", "TkLocalisationEntry")
+		if err != nil {
+			return err
+		}
+		for id, r := range t.rows {
+			if keys[id] {
+				found[id] = r.str("English")
+			}
+		}
+	}
+	var missing []string
+	for k := range keys {
+		if _, ok := found[k]; !ok {
+			missing = append(missing, k)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("localisation keys not found in %v: %v", files, missing)
+	}
+
+	ids := make([]string, 0, len(found))
+	for k := range found {
+		ids = append(ids, k)
+	}
+	sort.Strings(ids)
+
+	out := []string{`<?xml version="1.0" encoding="utf-8"?>`,
+		`<!--File created using MBINCompiler version (6.45.0.1)-->`,
+		`<Data template="cTkLocalisationTable">`,
+		"\t" + `<Property name="Table">`}
+	for _, id := range ids {
+		out = append(out,
+			"\t\t"+`<Property name="Table" value="TkLocalisationEntry" _id="`+esc(id)+`">`,
+			"\t\t\t"+`<Property name="Id" value="`+esc(id)+`" />`,
+			"\t\t\t"+`<Property name="English" value="`+esc(found[id])+`" />`,
+			"\t\t"+`</Property>`)
+	}
+	out = append(out, "\t</Property>", "</Data>", "")
+	return os.WriteFile("localisation.MXML", []byte(strings.Join(out, "\n")), 0o644)
+}
+
+func esc(s string) string {
+	var b strings.Builder
+	xml.EscapeText(&b, []byte(s))
+	return b.String()
+}
+
+func between(s, open, close string) string {
+	i := strings.Index(s, open)
+	if i < 0 {
+		return ""
+	}
+	s = s[i+len(open):]
+	j := strings.Index(s, close)
+	if j < 0 {
+		return ""
+	}
+	return s[:j]
+}
+
+func must(t *table, err error) *table {
+	must0(err)
+	return t
+}
+
+func must0(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/internal/normalize/testdata/graph/localisation.MXML
+++ b/internal/normalize/testdata/graph/localisation.MXML
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--File created using MBINCompiler version (6.45.0.1)-->
+<Data template="cTkLocalisationTable">
+	<Property name="Table">
+		<Property name="Table" value="TkLocalisationEntry" _id="AMMO_PROD_NAME_L">
+			<Property name="Id" value="AMMO_PROD_NAME_L" />
+			<Property name="English" value="Projectile Ammunition" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="FOOD_MISC_STELLAR_NAME_L">
+			<Property name="Id" value="FOOD_MISC_STELLAR_NAME_L" />
+			<Property name="English" value="Silicon Egg" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="SUB_DEADDRONE_NAME_L">
+			<Property name="Id" value="SUB_DEADDRONE_NAME_L" />
+			<Property name="English" value="Pugneum" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_AIR1_NAME_L">
+			<Property name="Id" value="UI_AIR1_NAME_L" />
+			<Property name="English" value="Oxygen" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_ALLOY_COMPLEX_2_NAME_L">
+			<Property name="Id" value="UI_ALLOY_COMPLEX_2_NAME_L" />
+			<Property name="English" value="Iridesite" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_ALLOY_SIMPLE_1_NAME_L">
+			<Property name="Id" value="UI_ALLOY_SIMPLE_1_NAME_L" />
+			<Property name="English" value="Aronium" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_ALLOY_SIMPLE_5_NAME_L">
+			<Property name="Id" value="UI_ALLOY_SIMPLE_5_NAME_L" />
+			<Property name="English" value="Magno-Gold" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_ALLOY_SIMPLE_6_NAME_L">
+			<Property name="Id" value="UI_ALLOY_SIMPLE_6_NAME_L" />
+			<Property name="English" value="Grantine" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_ASTEROID1_NAME_L">
+			<Property name="Id" value="UI_ASTEROID1_NAME_L" />
+			<Property name="English" value="Silver" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_ASTEROID2_NAME_L">
+			<Property name="Id" value="UI_ASTEROID2_NAME_L" />
+			<Property name="English" value="Gold" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_ASTEROID3_NAME_L">
+			<Property name="Id" value="UI_ASTEROID3_NAME_L" />
+			<Property name="English" value="Platinum" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_CAVE1_NAME_L">
+			<Property name="Id" value="UI_CAVE1_NAME_L" />
+			<Property name="English" value="Cobalt" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_CAVE2_NAME_L">
+			<Property name="Id" value="UI_CAVE2_NAME_L" />
+			<Property name="English" value="Ionised Cobalt" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_COLD1_NAME_L">
+			<Property name="Id" value="UI_COLD1_NAME_L" />
+			<Property name="English" value="Dioxite" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_COMPOUND_2_NAME_L">
+			<Property name="Id" value="UI_COMPOUND_2_NAME_L" />
+			<Property name="English" value="Semiconductor" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_COMPOUND_3_NAME_L">
+			<Property name="Id" value="UI_COMPOUND_3_NAME_L" />
+			<Property name="English" value="Hot Ice" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_COMPOUND_5_NAME_L">
+			<Property name="Id" value="UI_COMPOUND_5_NAME_L" />
+			<Property name="English" value="Superconductor" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_COMPOUND_6_NAME_L">
+			<Property name="Id" value="UI_COMPOUND_6_NAME_L" />
+			<Property name="English" value="Cryo-Pump" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_DUSTY1_NAME_L">
+			<Property name="Id" value="UI_DUSTY1_NAME_L" />
+			<Property name="English" value="Pyrite" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_EX_PURPLE_NAME_L">
+			<Property name="Id" value="UI_EX_PURPLE_NAME_L" />
+			<Property name="English" value="Activated Quartzite" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_FARMPROD_2_NAME_L">
+			<Property name="Id" value="UI_FARMPROD_2_NAME_L" />
+			<Property name="English" value="Lubricant" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_FARMPROD_3_NAME_L">
+			<Property name="Id" value="UI_FARMPROD_3_NAME_L" />
+			<Property name="English" value="Glass" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_FARMPROD_4_NAME_L">
+			<Property name="Id" value="UI_FARMPROD_4_NAME_L" />
+			<Property name="English" value="Heat Capacitor" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_FARMPROD_5_NAME_L">
+			<Property name="Id" value="UI_FARMPROD_5_NAME_L" />
+			<Property name="English" value="Poly Fibre" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_FARMPROD_8_NAME_L">
+			<Property name="Id" value="UI_FARMPROD_8_NAME_L" />
+			<Property name="English" value="Living Glass" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_FARMPROD_9_NAME_L">
+			<Property name="Id" value="UI_FARMPROD_9_NAME_L" />
+			<Property name="English" value="Circuit Board" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_FUEL_1_NAME_L">
+			<Property name="Id" value="UI_FUEL_1_NAME_L" />
+			<Property name="English" value="Carbon" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_FUEL_2_NAME_L">
+			<Property name="Id" value="UI_FUEL_2_NAME_L" />
+			<Property name="English" value="Condensed Carbon" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_GASGIANT1_NAME_L">
+			<Property name="Id" value="UI_GASGIANT1_NAME_L" />
+			<Property name="English" value="Crystallised Helium" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_GAS_1_NAME_L">
+			<Property name="Id" value="UI_GAS_1_NAME_L" />
+			<Property name="English" value="Sulphurine" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_GAS_2_NAME_L">
+			<Property name="Id" value="UI_GAS_2_NAME_L" />
+			<Property name="English" value="Radon" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_GAS_3_NAME_L">
+			<Property name="Id" value="UI_GAS_3_NAME_L" />
+			<Property name="English" value="Nitrogen" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_GAS_4_NAME_L">
+			<Property name="Id" value="UI_GAS_4_NAME_L" />
+			<Property name="English" value="Methane" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_HOT1_NAME_L">
+			<Property name="Id" value="UI_HOT1_NAME_L" />
+			<Property name="English" value="Phosphorus" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_LAND1_NAME_L">
+			<Property name="Id" value="UI_LAND1_NAME_L" />
+			<Property name="English" value="Ferrite Dust" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_LAND2_NAME_L">
+			<Property name="Id" value="UI_LAND2_NAME_L" />
+			<Property name="English" value="Pure Ferrite" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_LAND3_NAME_L">
+			<Property name="Id" value="UI_LAND3_NAME_L" />
+			<Property name="English" value="Magnetised Ferrite" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_LAUNCHSUB_NAME_L">
+			<Property name="Id" value="UI_LAUNCHSUB_NAME_L" />
+			<Property name="English" value="Di-hydrogen" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_LUSH1_NAME_L">
+			<Property name="Id" value="UI_LUSH1_NAME_L" />
+			<Property name="English" value="Paraffinium" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_MAINTAIN_SUB3_NAME_L">
+			<Property name="Id" value="UI_MAINTAIN_SUB3_NAME_L" />
+			<Property name="English" value="Rusted Metal" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_MEGAPROD_2_NAME_L">
+			<Property name="Id" value="UI_MEGAPROD_2_NAME_L" />
+			<Property name="English" value="Quantum Processor" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_MEGAPROD_3_NAME_L">
+			<Property name="Id" value="UI_MEGAPROD_3_NAME_L" />
+			<Property name="English" value="Cryogenic Chamber" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_NEWCATA2_NAME_L">
+			<Property name="Id" value="UI_NEWCATA2_NAME_L" />
+			<Property name="English" value="Sodium Nitrate" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_NEWWATER2_NAME_L">
+			<Property name="Id" value="UI_NEWWATER2_NAME_L" />
+			<Property name="English" value="Chlorine" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_PLANTSUB_BARREN_NAME_L">
+			<Property name="Id" value="UI_PLANTSUB_BARREN_NAME_L" />
+			<Property name="English" value="Cactus Flesh" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_PLANTSUB_CAVE_NAME_L">
+			<Property name="Id" value="UI_PLANTSUB_CAVE_NAME_L" />
+			<Property name="English" value="Marrow Bulb" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_PLANTSUB_CREATUREPOOP_NAME_L">
+			<Property name="Id" value="UI_PLANTSUB_CREATUREPOOP_NAME_L" />
+			<Property name="English" value="Faecium" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_PLANTSUB_DEADCREATURE_NAME_L">
+			<Property name="Id" value="UI_PLANTSUB_DEADCREATURE_NAME_L" />
+			<Property name="English" value="Mordite" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_PLANTSUB_LUSH_NAME_L">
+			<Property name="Id" value="UI_PLANTSUB_LUSH_NAME_L" />
+			<Property name="English" value="Star Bulb" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_PLANTSUB_RADIO_NAME_L">
+			<Property name="Id" value="UI_PLANTSUB_RADIO_NAME_L" />
+			<Property name="English" value="Gamma Root" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_PLANTSUB_SCORCHED_NAME_L">
+			<Property name="Id" value="UI_PLANTSUB_SCORCHED_NAME_L" />
+			<Property name="English" value="Solanium" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_PLANTSUB_SNOW_NAME_L">
+			<Property name="Id" value="UI_PLANTSUB_SNOW_NAME_L" />
+			<Property name="English" value="Frost Crystal" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_PLANTSUB_WATER_NAME_L">
+			<Property name="Id" value="UI_PLANTSUB_WATER_NAME_L" />
+			<Property name="English" value="Kelp Sac" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_RADIO1_NAME_L">
+			<Property name="Id" value="UI_RADIO1_NAME_L" />
+			<Property name="English" value="Uranium" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_REACTION_1_NAME_L">
+			<Property name="Id" value="UI_REACTION_1_NAME_L" />
+			<Property name="English" value="Thermic Condensate" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_REACTION_2_NAME_L">
+			<Property name="Id" value="UI_REACTION_2_NAME_L" />
+			<Property name="English" value="Enriched Carbon" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_REACTION_3_NAME_L">
+			<Property name="Id" value="UI_REACTION_3_NAME_L" />
+			<Property name="English" value="Nitrogen Salt" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_ROCKETFUEL_NAME_L">
+			<Property name="Id" value="UI_ROCKETFUEL_NAME_L" />
+			<Property name="English" value="Tritium" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_SAND1_NAME_L">
+			<Property name="Id" value="UI_SAND1_NAME_L" />
+			<Property name="English" value="Silicate Powder" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_STELLAR2_NAME_L">
+			<Property name="Id" value="UI_STELLAR2_NAME_L" />
+			<Property name="English" value="Chromatic Metal" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_TOXIC1_NAME_L">
+			<Property name="Id" value="UI_TOXIC1_NAME_L" />
+			<Property name="English" value="Ammonia" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_ULTRAPROD_2_NAME_L">
+			<Property name="Id" value="UI_ULTRAPROD_2_NAME_L" />
+			<Property name="English" value="Stasis Device" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_VENTGEM_NAME_L">
+			<Property name="Id" value="UI_VENTGEM_NAME_L" />
+			<Property name="English" value="Crystal Sulphide" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_WATER1_NAME_L">
+			<Property name="Id" value="UI_WATER1_NAME_L" />
+			<Property name="English" value="Salt" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_WATER2_NAME_L">
+			<Property name="Id" value="UI_WATER2_NAME_L" />
+			<Property name="English" value="Sodium" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_WATERPLANT_NAME_L">
+			<Property name="Id" value="UI_WATERPLANT_NAME_L" />
+			<Property name="English" value="Cyto-Phosphate" />
+		</Property>
+		<Property name="Table" value="TkLocalisationEntry" _id="UI_WATERWORLD1_NAME_L">
+			<Property name="Id" value="UI_WATERWORLD1_NAME_L" />
+			<Property name="English" value="Lithium" />
+		</Property>
+	</Property>
+</Data>

--- a/internal/normalize/testdata/graph/products.MXML
+++ b/internal/normalize/testdata/graph/products.MXML
@@ -1,0 +1,2646 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--File created using MBINCompiler version (6.45.0.1)-->
+<Data template="cGcProductTable">
+	<Property name="Table">
+		<Property name="Table" value="GcProductData" _id="AMMO">
+			<Property name="ID" value="AMMO" />
+			<Property name="Name" value="AMMO_PROD_NAME" />
+			<Property name="NameLower" value="AMMO_PROD_NAME_L" />
+			<Property name="Subtitle" value="AMMO_PROD_SUB" />
+			<Property name="Description" value="AMMO_PROD_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="1" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4PRODUCTS/PRODUCT.AMMO.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.101960786" />
+				<Property name="G" value="0.152941182" />
+				<Property name="B" value="0.200000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Consumable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="true" />
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1000" />
+			<Property name="DefaultCraftAmount" value="25" />
+			<Property name="CraftAmountStepSize" value="25" />
+			<Property name="CraftAmountMultiplier" value="50" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="LAND1">
+					<Property name="ID" value="LAND1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.000000" />
+			<Property name="NormalisedValueOffWorld" value="0.000000" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_BUY_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_AMMO_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="false" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="VENTGEM">
+			<Property name="ID" value="VENTGEM" />
+			<Property name="Name" value="UI_VENTGEM_NAME" />
+			<Property name="NameLower" value="UI_VENTGEM_NAME_L" />
+			<Property name="Subtitle" value="UI_VENTGEM_SUB" />
+			<Property name="Description" value="UI_VENTGEM_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="7800" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4PRODUCTS/PRODUCT.VENTGEM.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Exotic" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements" />
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="0.000000" />
+				<Property name="HighPriceMod" value="-0.100000" />
+				<Property name="BuyBaseMarkup" value="0.100000" />
+				<Property name="BuyMarkupMod" value="0.200000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.000474935921" />
+			<Property name="NormalisedValueOffWorld" value="0.000474935921" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Curio" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="false" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.100000" />
+			<Property name="PinObjective" value="UI_PIN_VENTGEM_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_VENTGEM_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Mineral" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="true" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="true" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="ALLOY1">
+			<Property name="ID" value="ALLOY1" />
+			<Property name="Name" value="UI_ALLOY_SIMPLE_1_NAME" />
+			<Property name="NameLower" value="UI_ALLOY_SIMPLE_1_NAME_L" />
+			<Property name="Subtitle" value="UI_ALLOY_SIMPLE_SUBTITLE" />
+			<Property name="Description" value="UI_ALLOY_SIMPLE_1_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="25000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/PRODUCTS/PRODUCT.METALLIC.1.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.952941179" />
+				<Property name="G" value="0.662745118" />
+				<Property name="B" value="0.137254909" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Stellar" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="LUSH1">
+					<Property name="ID" value="LUSH1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="50" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="CAVE2">
+					<Property name="ID" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="50" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.500000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.0016025001" />
+			<Property name="NormalisedValueOffWorld" value="0.0016025001" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_ALLOY1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="true" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="ALLOY5">
+			<Property name="ID" value="ALLOY5" />
+			<Property name="Name" value="UI_ALLOY_SIMPLE_5_NAME" />
+			<Property name="NameLower" value="UI_ALLOY_SIMPLE_5_NAME_L" />
+			<Property name="Subtitle" value="UI_ALLOY_SIMPLE_SUBTITLE" />
+			<Property name="Description" value="UI_ALLOY_SIMPLE_5_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="25000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/PRODUCTS/PRODUCT.METALLIC.5.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.952941179" />
+				<Property name="G" value="0.662745118" />
+				<Property name="B" value="0.137254909" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Stellar" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="HOT1">
+					<Property name="ID" value="HOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="50" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="CAVE2">
+					<Property name="ID" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="50" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.500000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.0016025001" />
+			<Property name="NormalisedValueOffWorld" value="0.0016025001" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_ALLOY5_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="true" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="ALLOY6">
+			<Property name="ID" value="ALLOY6" />
+			<Property name="Name" value="UI_ALLOY_SIMPLE_6_NAME" />
+			<Property name="NameLower" value="UI_ALLOY_SIMPLE_6_NAME_L" />
+			<Property name="Subtitle" value="UI_ALLOY_SIMPLE_SUBTITLE" />
+			<Property name="Description" value="UI_ALLOY_SIMPLE_6_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="25000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/PRODUCTS/PRODUCT.METALLIC.6.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.952941179" />
+				<Property name="G" value="0.662745118" />
+				<Property name="B" value="0.137254909" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Stellar" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="COLD1">
+					<Property name="ID" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="50" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="CAVE2">
+					<Property name="ID" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="50" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.500000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.0016025001" />
+			<Property name="NormalisedValueOffWorld" value="0.0016025001" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_ALLOY6_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="true" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="ALLOY8">
+			<Property name="ID" value="ALLOY8" />
+			<Property name="Name" value="UI_ALLOY_COMPLEX_2_NAME" />
+			<Property name="NameLower" value="UI_ALLOY_COMPLEX_2_NAME_L" />
+			<Property name="Subtitle" value="UI_ALLOY_COMPLEX_SUBTITLE" />
+			<Property name="Description" value="UI_ALLOY_COMPLEX_2_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="150000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4PRODUCTS/PRODUCT.IRIDISITE.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.952941179" />
+				<Property name="G" value="0.662745118" />
+				<Property name="B" value="0.137254909" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Stellar" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="ALLOY1">
+					<Property name="ID" value="ALLOY1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="ALLOY5">
+					<Property name="ID" value="ALLOY5" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="ALLOY6">
+					<Property name="ID" value="ALLOY6" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.00961532071" />
+			<Property name="NormalisedValueOffWorld" value="0.00961532071" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_ALLOY8_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="true" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="true" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="CHART_BUILDER">
+			<Property name="ID" value="CHART_BUILDER" />
+			<Property name="Name" value="UI_STARCHART_BUILDER_NAME" />
+			<Property name="NameLower" value="UI_STARCHART_BUILDER_NAME_L" />
+			<Property name="Subtitle" value="UI_STARCHART_BUILDER_SUB" />
+			<Property name="Description" value="UI_STARCHART_BUILDER_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="3200" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4PRODUCTS/PRODUCT.STARCHART.BUILDER.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.101960786" />
+				<Property name="G" value="0.152941182" />
+				<Property name="B" value="0.200000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Curiosity" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="true" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="4" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements" />
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="0.000000" />
+				<Property name="HighPriceMod" value="0.000000" />
+				<Property name="BuyBaseMarkup" value="0.000000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.00827852823" />
+			<Property name="NormalisedValueOffWorld" value="0.00827852823" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Curio" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="false" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.000000" />
+			<Property name="PinObjective" value="UI_FIND_OBJ" />
+			<Property name="PinObjectiveTip" value="" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="false" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="FARMPROD2">
+			<Property name="ID" value="FARMPROD2" />
+			<Property name="Name" value="UI_FARMPROD_2_NAME" />
+			<Property name="NameLower" value="UI_FARMPROD_2_NAME_L" />
+			<Property name="Subtitle" value="UI_FARMPROD_SUBTITLE" />
+			<Property name="Description" value="UI_FARMPROD_2_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="110000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/FARMPROD.2.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="4" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="PLANT_POOP">
+					<Property name="ID" value="PLANT_POOP" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="50" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="PLANT_RADIO">
+					<Property name="ID" value="PLANT_RADIO" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="400" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.0070512183" />
+			<Property name="NormalisedValueOffWorld" value="0.0070512183" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_FARMPROD2_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="true" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="FARMPROD3">
+			<Property name="ID" value="FARMPROD3" />
+			<Property name="Name" value="UI_FARMPROD_3_NAME" />
+			<Property name="NameLower" value="UI_FARMPROD_3_NAME_L" />
+			<Property name="Subtitle" value="UI_FARMPROD_SUBTITLE" />
+			<Property name="Description" value="UI_FARMPROD_3_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="200" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/FARMPROD.3.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="5" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="PLANT_SNOW">
+					<Property name="ID" value="PLANT_SNOW" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="40" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="1.27564108E-05" />
+			<Property name="NormalisedValueOffWorld" value="1.27564108E-05" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_FARMPROD3_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_FARMPROD3_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="true" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="false" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="FARMPROD4">
+			<Property name="ID" value="FARMPROD4" />
+			<Property name="Name" value="UI_FARMPROD_4_NAME" />
+			<Property name="NameLower" value="UI_FARMPROD_4_NAME_L" />
+			<Property name="Subtitle" value="UI_FARMPROD_SUBTITLE" />
+			<Property name="Description" value="UI_FARMPROD_4_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="180000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/FARMPROD.4.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="PLANT_SNOW">
+					<Property name="ID" value="PLANT_SNOW" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="100" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="PLANT_HOT">
+					<Property name="ID" value="PLANT_HOT" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="200" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.0115383985" />
+			<Property name="NormalisedValueOffWorld" value="0.0115383985" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_FARMPROD4_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="false" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="FARMPROD5">
+			<Property name="ID" value="FARMPROD5" />
+			<Property name="Name" value="UI_FARMPROD_5_NAME" />
+			<Property name="NameLower" value="UI_FARMPROD_5_NAME_L" />
+			<Property name="Subtitle" value="UI_FARMPROD_SUBTITLE" />
+			<Property name="Description" value="UI_FARMPROD_5_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="130000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/FARMPROD.5.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="PLANT_DUST">
+					<Property name="ID" value="PLANT_DUST" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="100" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="PLANT_LUSH">
+					<Property name="ID" value="PLANT_LUSH" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="200" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.02240224" />
+			<Property name="NormalisedValueOffWorld" value="0.02240224" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_FARMPROD5_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="false" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="FARMPROD8">
+			<Property name="ID" value="FARMPROD8" />
+			<Property name="Name" value="UI_FARMPROD_8_NAME" />
+			<Property name="NameLower" value="UI_FARMPROD_8_NAME_L" />
+			<Property name="Subtitle" value="UI_FARMPROD_SUBTITLE" />
+			<Property name="Description" value="UI_FARMPROD_8_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="566000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/FARMPROD.8.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="FARMPROD2">
+					<Property name="ID" value="FARMPROD2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="FARMPROD3">
+					<Property name="ID" value="FARMPROD3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="5" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.02240224" />
+			<Property name="NormalisedValueOffWorld" value="0.02240224" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_FARMPROD8_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="true" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="false" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="FARMPROD9">
+			<Property name="ID" value="FARMPROD9" />
+			<Property name="Name" value="UI_FARMPROD_9_NAME" />
+			<Property name="NameLower" value="UI_FARMPROD_9_NAME_L" />
+			<Property name="Subtitle" value="UI_FARMPROD_SUBTITLE" />
+			<Property name="Description" value="UI_FARMPROD_9_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="916250" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/FARMPROD.9.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="FARMPROD4">
+					<Property name="ID" value="FARMPROD4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="FARMPROD5">
+					<Property name="ID" value="FARMPROD5" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.02240224" />
+			<Property name="NormalisedValueOffWorld" value="0.02240224" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_FARMPROD9_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="true" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="false" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="REACTION1">
+			<Property name="ID" value="REACTION1" />
+			<Property name="Name" value="UI_REACTION_1_NAME" />
+			<Property name="NameLower" value="UI_REACTION_1_NAME_L" />
+			<Property name="Subtitle" value="UI_REACTION_SUBTITLE" />
+			<Property name="Description" value="UI_REACTION_1_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="50000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/REACTION.1.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="GAS1">
+					<Property name="ID" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="250" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="FUEL2">
+					<Property name="ID" value="FUEL2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="50" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.00320506422" />
+			<Property name="NormalisedValueOffWorld" value="0.00320506422" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_REACTION1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="true" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="true" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="REACTION2">
+			<Property name="ID" value="REACTION2" />
+			<Property name="Name" value="UI_REACTION_2_NAME" />
+			<Property name="NameLower" value="UI_REACTION_2_NAME_L" />
+			<Property name="Subtitle" value="UI_REACTION_SUBTITLE" />
+			<Property name="Description" value="UI_REACTION_2_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="50000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/REACTION.2.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="GAS2">
+					<Property name="ID" value="GAS2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="250" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="FUEL2">
+					<Property name="ID" value="FUEL2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="50" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.00320506422" />
+			<Property name="NormalisedValueOffWorld" value="0.00320506422" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_REACTION2_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="true" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="true" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="REACTION3">
+			<Property name="ID" value="REACTION3" />
+			<Property name="Name" value="UI_REACTION_3_NAME" />
+			<Property name="NameLower" value="UI_REACTION_3_NAME_L" />
+			<Property name="Subtitle" value="UI_REACTION_SUBTITLE" />
+			<Property name="Description" value="UI_REACTION_3_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="50000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/REACTION.3.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="GAS3">
+					<Property name="ID" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="250" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="FUEL2">
+					<Property name="ID" value="FUEL2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="50" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.00320506422" />
+			<Property name="NormalisedValueOffWorld" value="0.00320506422" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_REACTION3_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="true" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="true" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="COMPOUND2">
+			<Property name="ID" value="COMPOUND2" />
+			<Property name="Name" value="UI_COMPOUND_2_NAME" />
+			<Property name="NameLower" value="UI_COMPOUND_2_NAME_L" />
+			<Property name="Subtitle" value="UI_COMPOUND_SUBTITLE" />
+			<Property name="Description" value="UI_COMPOUND_2_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="320000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/COMPOUND.2.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="REACTION1">
+					<Property name="ID" value="REACTION1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="REACTION3">
+					<Property name="ID" value="REACTION3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.0205127578" />
+			<Property name="NormalisedValueOffWorld" value="0.0205127578" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_COMPOUND2_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="true" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="true" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="COMPOUND3">
+			<Property name="ID" value="COMPOUND3" />
+			<Property name="Name" value="UI_COMPOUND_3_NAME" />
+			<Property name="NameLower" value="UI_COMPOUND_3_NAME_L" />
+			<Property name="Subtitle" value="UI_COMPOUND_SUBTITLE" />
+			<Property name="Description" value="UI_COMPOUND_3_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="320000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/COMPOUND.3.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="REACTION2">
+					<Property name="ID" value="REACTION2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="REACTION3">
+					<Property name="ID" value="REACTION3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.0205127578" />
+			<Property name="NormalisedValueOffWorld" value="0.0205127578" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_COMPOUND3_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="true" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="true" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="COMPOUND5">
+			<Property name="ID" value="COMPOUND5" />
+			<Property name="Name" value="UI_COMPOUND_5_NAME" />
+			<Property name="NameLower" value="UI_COMPOUND_5_NAME_L" />
+			<Property name="Subtitle" value="UI_COMPOUND_SUBTITLE" />
+			<Property name="Description" value="UI_COMPOUND_5_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="1500000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/COMPOUND.5.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="COMPOUND2">
+					<Property name="ID" value="COMPOUND2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="REACTION2">
+					<Property name="ID" value="REACTION2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.0961537883" />
+			<Property name="NormalisedValueOffWorld" value="0.0961537883" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_COMPOUND5_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="false" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="COMPOUND6">
+			<Property name="ID" value="COMPOUND6" />
+			<Property name="Name" value="UI_COMPOUND_6_NAME" />
+			<Property name="NameLower" value="UI_COMPOUND_6_NAME_L" />
+			<Property name="Subtitle" value="UI_COMPOUND_SUBTITLE" />
+			<Property name="Description" value="UI_COMPOUND_6_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="1500000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/COMPOUND.6.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="COMPOUND3">
+					<Property name="ID" value="COMPOUND3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="REACTION1">
+					<Property name="ID" value="REACTION1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.0961537883" />
+			<Property name="NormalisedValueOffWorld" value="0.0961537883" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_COMPOUND6_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="false" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="MEGAPROD2">
+			<Property name="ID" value="MEGAPROD2" />
+			<Property name="Name" value="UI_MEGAPROD_2_NAME" />
+			<Property name="NameLower" value="UI_MEGAPROD_2_NAME_L" />
+			<Property name="Subtitle" value="UI_MEGAPROD_SUBTITLE" />
+			<Property name="Description" value="UI_MEGAPROD_2_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="4400000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/MEGAPROD.2.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="FARMPROD9">
+					<Property name="ID" value="FARMPROD9" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="COMPOUND5">
+					<Property name="ID" value="COMPOUND5" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.282051235" />
+			<Property name="NormalisedValueOffWorld" value="0.282051235" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_MEGAPROD2_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="false" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="MEGAPROD3">
+			<Property name="ID" value="MEGAPROD3" />
+			<Property name="Name" value="UI_MEGAPROD_3_NAME" />
+			<Property name="NameLower" value="UI_MEGAPROD_3_NAME_L" />
+			<Property name="Subtitle" value="UI_MEGAPROD_SUBTITLE" />
+			<Property name="Description" value="UI_MEGAPROD_3_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="3800000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4PRODUCTS/PRODUCT.CRYOCHAMBER.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="FARMPROD8">
+					<Property name="ID" value="FARMPROD8" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="COMPOUND6">
+					<Property name="ID" value="COMPOUND6" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="0.243589699" />
+			<Property name="NormalisedValueOffWorld" value="0.243589699" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_MEGAPROD3_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="false" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="ULTRAPROD2">
+			<Property name="ID" value="ULTRAPROD2" />
+			<Property name="Name" value="UI_ULTRAPROD_2_NAME" />
+			<Property name="NameLower" value="UI_ULTRAPROD_2_NAME_L" />
+			<Property name="Subtitle" value="UI_ULTRAPROD_SUBTITLE" />
+			<Property name="Description" value="UI_ULTRAPROD_2_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="15600000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/ULTRAPROD.2.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.800000" />
+				<Property name="G" value="0.800000" />
+				<Property name="B" value="0.800000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Tradeable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="false" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements">
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="MEGAPROD2">
+					<Property name="ID" value="MEGAPROD2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="MEGAPROD3">
+					<Property name="ID" value="MEGAPROD3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Requirements" value="GcTechnologyRequirement" _id="ALLOY8">
+					<Property name="ID" value="ALLOY8" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="1.000000" />
+			<Property name="NormalisedValueOffWorld" value="1.000000" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Crafting" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_ULTRAPROD2_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="false" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="WORLDSMB_SOUL">
+			<Property name="ID" value="WORLDSMB_SOUL" />
+			<Property name="Name" value="UI_WORLDSMB_SOUL_NAME" />
+			<Property name="NameLower" value="UI_WORLDSMB_SOUL_NAME_L" />
+			<Property name="Subtitle" value="UI_WORLDSMB_SOUL_SUB" />
+			<Property name="Description" value="UI_WORLDSMB_SOUL_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="1000" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4PRODUCTS/PRODUCT.WORLDSMB.SOULSEED.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.101960786" />
+				<Property name="G" value="0.152941182" />
+				<Property name="B" value="0.200000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Stellar" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Curiosity" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="true" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements" />
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.500000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="6.40384678E-05" />
+			<Property name="NormalisedValueOffWorld" value="9.60897523E-05" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="NotEnabled" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="true" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_CRAFT_OBJ" />
+			<Property name="PinObjectiveTip" value="" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="CookingValue" value="0.000000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Unspecified" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="false" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+		<Property name="Table" value="GcProductData" _id="FOOD_P_STELLAR">
+			<Property name="ID" value="FOOD_P_STELLAR" />
+			<Property name="Name" value="FOOD_MISC_STELLAR_NAME" />
+			<Property name="NameLower" value="FOOD_MISC_STELLAR_NAME_L" />
+			<Property name="Subtitle" value="FOOD_INGREDIENT_SUB" />
+			<Property name="Description" value="FOOD_REFINED_DESC" />
+			<Property name="AltDescription" value="" />
+			<Property name="Hint" value="" />
+			<Property name="BuildableShipTechID" value="" />
+			<Property name="GroupID" value="" />
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="BaseValue" value="500" />
+			<Property name="Level" value="0" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/COOKINGPRODUCTS/PRODUCT.PLANT.STELLARWILD.DDS" />
+			</Property>
+			<Property name="HeroIcon" value="TkTextureResource">
+				<Property name="Filename" value="" />
+			</Property>
+			<Property name="Colour">
+				<Property name="R" value="0.0352941193" />
+				<Property name="G" value="0.360784322" />
+				<Property name="B" value="0.466666669" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Exotic" />
+			</Property>
+			<Property name="Type" value="GcProductCategory">
+				<Property name="ProductCategory" value="Consumable" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Common" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="Consumable" value="true" />
+			<Property name="ChargeValue" value="0" />
+			<Property name="StackMultiplier" value="10" />
+			<Property name="DefaultCraftAmount" value="1" />
+			<Property name="CraftAmountStepSize" value="1" />
+			<Property name="CraftAmountMultiplier" value="1" />
+			<Property name="Requirements" />
+			<Property name="AltRequirements" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.200000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="RecipeCost" value="1" />
+			<Property name="SpecificChargeOnly" value="false" />
+			<Property name="NormalisedValueOnWorld" value="3.19871833E-05" />
+			<Property name="NormalisedValueOffWorld" value="3.19871833E-05" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiCategory" value="Cooking" />
+			<Property name="FossilCategory" value="GcFossilCategory">
+				<Property name="FossilCategory" value="None" />
+			</Property>
+			<Property name="CorvettePartCategory" value="GcCorvettePartCategory">
+				<Property name="CorvettePartCategory" value="None" />
+			</Property>
+			<Property name="CorvetteRewardFrequency" value="0.000000" />
+			<Property name="IsCraftable" value="false" />
+			<Property name="DeploysInto" value="" />
+			<Property name="EconomyInfluenceMultiplier" value="0.330000" />
+			<Property name="PinObjective" value="" />
+			<Property name="PinObjectiveTip" value="" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="PinObjectiveEasyToRefine" value="false" />
+			<Property name="NeverPinnable" value="false" />
+			<Property name="CookingIngredient" value="true" />
+			<Property name="CookingValue" value="0.400000" />
+			<Property name="FoodBonusStat" value="GcStatsTypes">
+				<Property name="StatsType" value="Suit_Protection" />
+			</Property>
+			<Property name="FoodBonusStatAmount" value="0.000000" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="GiveRewardOnSpecialPurchase" value="" />
+			<Property name="EggModifierIngredient" value="true" />
+			<Property name="IsTechbox" value="false" />
+			<Property name="CanSendToOtherPlayers" value="true" />
+		</Property>
+	</Property>
+</Data>

--- a/internal/normalize/testdata/graph/recipes.MXML
+++ b/internal/normalize/testdata/graph/recipes.MXML
@@ -1,0 +1,4498 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--File created using MBINCompiler version (6.45.0.1)-->
+<Data template="cGcRecipeTable">
+	<Property name="Table">
+		<Property name="Table" value="GcRefinerRecipe" _id="RECIPE_2">
+			<Property name="Id" value="RECIPE_2" />
+			<Property name="RecipeType" value="UI_EGG_PROCESS" />
+			<Property name="RecipeName" value="UI_EGG_PROCESS_R" />
+			<Property name="TimeToMake" value="5.000000" />
+			<Property name="Cooking" value="true" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="FOOD_P_STELLAR" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="STELLAR2">
+					<Property name="Id" value="STELLAR2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_5">
+			<Property name="Id" value="REFINERECIPE_5" />
+			<Property name="RecipeType" value="RECIPE_VENTGEM" />
+			<Property name="RecipeName" value="R_NAME_VENTGEM" />
+			<Property name="TimeToMake" value="60.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="50" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="VENTGEM">
+					<Property name="Id" value="VENTGEM" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Product" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_7">
+			<Property name="Id" value="REFINERECIPE_7" />
+			<Property name="RecipeType" value="RECIPE_WATERPLANT" />
+			<Property name="RecipeName" value="R_NAME_WATERPLANT" />
+			<Property name="TimeToMake" value="60.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="FUEL2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATERPLANT">
+					<Property name="Id" value="WATERPLANT" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_9">
+			<Property name="Id" value="REFINERECIPE_9" />
+			<Property name="RecipeType" value="RECIPE_ASTEROID1" />
+			<Property name="RecipeName" value="R_NAME_ASTEROID1" />
+			<Property name="TimeToMake" value="60.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="FARMPROD3" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_SNOW">
+					<Property name="Id" value="PLANT_SNOW" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="40" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_13">
+			<Property name="Id" value="REFINERECIPE_13" />
+			<Property name="RecipeType" value="RECIPE_CREATURE1" />
+			<Property name="RecipeName" value="R_NAME_CREATURE1_POOP" />
+			<Property name="TimeToMake" value="60.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_POOP" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CREATURE1">
+					<Property name="Id" value="CREATURE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="3" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_23">
+			<Property name="Id" value="REFINERECIPE_23" />
+			<Property name="RecipeType" value="RECIPE_CAVE1" />
+			<Property name="RecipeName" value="R_NAME_CAVE1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CAVE2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_26">
+			<Property name="Id" value="REFINERECIPE_26" />
+			<Property name="RecipeType" value="RECIPE_FUEL1" />
+			<Property name="RecipeName" value="R_NAME_FUEL1" />
+			<Property name="TimeToMake" value="45.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="FUEL2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL1">
+					<Property name="Id" value="FUEL1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_27">
+			<Property name="Id" value="REFINERECIPE_27" />
+			<Property name="RecipeType" value="RECIPE_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_CATALYST1" />
+			<Property name="TimeToMake" value="100.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST1">
+					<Property name="Id" value="CATALYST1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_40">
+			<Property name="Id" value="REFINERECIPE_40" />
+			<Property name="RecipeType" value="RECIPE_LUSH1" />
+			<Property name="RecipeName" value="R_NAME_LUSH1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LAND1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LUSH1">
+					<Property name="Id" value="LUSH1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_41">
+			<Property name="Id" value="REFINERECIPE_41" />
+			<Property name="RecipeType" value="RECIPE_DUSTY1" />
+			<Property name="RecipeName" value="R_NAME_DUSTY1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LAND1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="DUSTY1">
+					<Property name="Id" value="DUSTY1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_42">
+			<Property name="Id" value="REFINERECIPE_42" />
+			<Property name="RecipeType" value="RECIPE_TOXIC1" />
+			<Property name="RecipeName" value="R_NAME_TOXIC1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LAND1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="TOXIC1">
+					<Property name="Id" value="TOXIC1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_43">
+			<Property name="Id" value="REFINERECIPE_43" />
+			<Property name="RecipeType" value="RECIPE_RADIO1" />
+			<Property name="RecipeName" value="R_NAME_RADIO1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LAND1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="RADIO1">
+					<Property name="Id" value="RADIO1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_44">
+			<Property name="Id" value="REFINERECIPE_44" />
+			<Property name="RecipeType" value="RECIPE_COLD1" />
+			<Property name="RecipeName" value="R_NAME_COLD1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LAND1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_45">
+			<Property name="Id" value="REFINERECIPE_45" />
+			<Property name="RecipeType" value="RECIPE_HOT1" />
+			<Property name="RecipeName" value="R_NAME_HOT1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LAND1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="HOT1">
+					<Property name="Id" value="HOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_48">
+			<Property name="Id" value="REFINERECIPE_48" />
+			<Property name="RecipeType" value="RECIPE_GAS1" />
+			<Property name="RecipeName" value="R_NAME_GAS1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="GAS2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS1">
+					<Property name="Id" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="3" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_49">
+			<Property name="Id" value="REFINERECIPE_49" />
+			<Property name="RecipeType" value="RECIPE_GAS2" />
+			<Property name="RecipeName" value="R_NAME_GAS2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="GAS3" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS2">
+					<Property name="Id" value="GAS2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="3" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_50">
+			<Property name="Id" value="REFINERECIPE_50" />
+			<Property name="RecipeType" value="RECIPE_GAS3" />
+			<Property name="RecipeName" value="R_NAME_GAS3" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="GAS1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS3">
+					<Property name="Id" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="3" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_53">
+			<Property name="Id" value="REFINERECIPE_53" />
+			<Property name="RecipeType" value="RECIPE_SPACEGUNK3" />
+			<Property name="RecipeName" value="R_NAME_SPACEGUNK3" />
+			<Property name="TimeToMake" value="160.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LAND1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="SPACEGUNK3">
+					<Property name="Id" value="SPACEGUNK3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_76">
+			<Property name="Id" value="REFINERECIPE_76" />
+			<Property name="RecipeType" value="RECIPE_SALT_GLASS" />
+			<Property name="RecipeName" value="R_NAME_SALT_GLASS" />
+			<Property name="TimeToMake" value="20.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="FARMPROD3" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATERPLANT">
+					<Property name="Id" value="WATERPLANT" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="50" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER1">
+					<Property name="Id" value="WATER1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="50" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_81">
+			<Property name="Id" value="REFINERECIPE_81" />
+			<Property name="RecipeType" value="RECIPE_LAUNCHSUB_RADIO" />
+			<Property name="RecipeName" value="R_NAME_LAUNCHSUB_RADIO" />
+			<Property name="TimeToMake" value="10.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="FUEL2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="RADIO1">
+					<Property name="Id" value="RADIO1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAUNCHSUB">
+					<Property name="Id" value="LAUNCHSUB" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_82">
+			<Property name="Id" value="REFINERECIPE_82" />
+			<Property name="RecipeType" value="RECIPE_LAUNCHSUB_GAS1" />
+			<Property name="RecipeName" value="R_NAME_LAUNCHSUB_GAS1" />
+			<Property name="TimeToMake" value="40.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_HOT" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS1">
+					<Property name="Id" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAUNCHSUB">
+					<Property name="Id" value="LAUNCHSUB" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_86">
+			<Property name="Id" value="REFINERECIPE_86" />
+			<Property name="RecipeType" value="RECIPE_CREATURE1" />
+			<Property name="RecipeName" value="R_NAME_CREATURE1" />
+			<Property name="TimeToMake" value="20.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_POOP" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAUNCHSUB">
+					<Property name="Id" value="LAUNCHSUB" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL1">
+					<Property name="Id" value="FUEL1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_95">
+			<Property name="Id" value="REFINERECIPE_95" />
+			<Property name="RecipeType" value="RECIPE_FUEL1_OXYGEN" />
+			<Property name="RecipeName" value="R_NAME_FUEL1_OXYGEN" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="FUEL2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="5" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL1">
+					<Property name="Id" value="FUEL1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_96">
+			<Property name="Id" value="REFINERECIPE_96" />
+			<Property name="RecipeType" value="RECIPE_FUEL2_OXYGEN" />
+			<Property name="RecipeName" value="R_NAME_FUEL2_OXYGEN" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="FUEL2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="6" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL2">
+					<Property name="Id" value="FUEL2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_97">
+			<Property name="Id" value="REFINERECIPE_97" />
+			<Property name="RecipeType" value="RECIPE_CATALYST1_OXYGEN" />
+			<Property name="RecipeName" value="R_NAME_CATALYST1_OXYGEN" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST1">
+					<Property name="Id" value="CATALYST1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_98">
+			<Property name="Id" value="REFINERECIPE_98" />
+			<Property name="RecipeType" value="RECIPE_CATALYST2_OXYGEN" />
+			<Property name="RecipeName" value="R_NAME_CATALYST2_OXYGEN" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST2">
+					<Property name="Id" value="CATALYST2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_99">
+			<Property name="Id" value="REFINERECIPE_99" />
+			<Property name="RecipeType" value="RECIPE_FUEL1_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_FUEL1_CATALYST1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL1">
+					<Property name="Id" value="FUEL1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST1">
+					<Property name="Id" value="CATALYST1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_100">
+			<Property name="Id" value="REFINERECIPE_100" />
+			<Property name="RecipeType" value="RECIPE_FUEL2_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_FUEL2_CATALYST1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL2">
+					<Property name="Id" value="FUEL2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST1">
+					<Property name="Id" value="CATALYST1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_101">
+			<Property name="Id" value="REFINERECIPE_101" />
+			<Property name="RecipeType" value="RECIPE_FUEL1_CATALYST2" />
+			<Property name="RecipeName" value="R_NAME_FUEL1_CATALYST2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="COLD1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL1">
+					<Property name="Id" value="FUEL1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST2">
+					<Property name="Id" value="CATALYST2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_102">
+			<Property name="Id" value="REFINERECIPE_102" />
+			<Property name="RecipeType" value="RECIPE_FUEL2_CATALYST2" />
+			<Property name="RecipeName" value="R_NAME_FUEL2_CATALYST2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="COLD1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL2">
+					<Property name="Id" value="FUEL2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST2">
+					<Property name="Id" value="CATALYST2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_105">
+			<Property name="Id" value="REFINERECIPE_105" />
+			<Property name="RecipeType" value="RECIPE_CATALYST1_ROBOT1" />
+			<Property name="RecipeName" value="R_NAME_CATALYST1_ROBOT1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST1">
+					<Property name="Id" value="CATALYST1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ROBOT1">
+					<Property name="Id" value="ROBOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_106">
+			<Property name="Id" value="REFINERECIPE_106" />
+			<Property name="RecipeType" value="RECIPE_CATALYST2_ROBOT1" />
+			<Property name="RecipeName" value="R_NAME_CATALYST2_ROBOT1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="3" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST2">
+					<Property name="Id" value="CATALYST2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ROBOT1">
+					<Property name="Id" value="ROBOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_107">
+			<Property name="Id" value="REFINERECIPE_107" />
+			<Property name="RecipeType" value="RECIPE_FUEL1_CREATURE1" />
+			<Property name="RecipeName" value="R_NAME_FUEL1_CREATURE1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_POOP" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="3" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL1">
+					<Property name="Id" value="FUEL1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CREATURE1">
+					<Property name="Id" value="CREATURE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_108">
+			<Property name="Id" value="REFINERECIPE_108" />
+			<Property name="RecipeType" value="RECIPE_FUEL2_CREATURE1" />
+			<Property name="RecipeName" value="R_NAME_FUEL2_CREATURE1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_POOP" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="4" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL2">
+					<Property name="Id" value="FUEL2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CREATURE1">
+					<Property name="Id" value="CREATURE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_118">
+			<Property name="Id" value="REFINERECIPE_118" />
+			<Property name="RecipeType" value="RECIPE_LUSH1_PLANT_LUSH" />
+			<Property name="RecipeName" value="R_NAME_LUSH1_PLANT_LUSH" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_LUSH" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LUSH1">
+					<Property name="Id" value="LUSH1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_LUSH">
+					<Property name="Id" value="PLANT_LUSH" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_119">
+			<Property name="Id" value="REFINERECIPE_119" />
+			<Property name="RecipeType" value="RECIPE_DUSTY1_PLANT_DUST" />
+			<Property name="RecipeName" value="R_NAME_DUSTY1_PLANT_DUST" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_DUST" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="DUSTY1">
+					<Property name="Id" value="DUSTY1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_DUST">
+					<Property name="Id" value="PLANT_DUST" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_121">
+			<Property name="Id" value="REFINERECIPE_121" />
+			<Property name="RecipeType" value="RECIPE_RADIO1_PLANT_RADIO" />
+			<Property name="RecipeName" value="R_NAME_RADIO1_PLANT_RADIO" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_RADIO" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="RADIO1">
+					<Property name="Id" value="RADIO1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_RADIO">
+					<Property name="Id" value="PLANT_RADIO" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_122">
+			<Property name="Id" value="REFINERECIPE_122" />
+			<Property name="RecipeType" value="RECIPE_COLD1_PLANT_SNOW" />
+			<Property name="RecipeName" value="R_NAME_COLD1_PLANT_SNOW" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_SNOW" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_SNOW">
+					<Property name="Id" value="PLANT_SNOW" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_123">
+			<Property name="Id" value="REFINERECIPE_123" />
+			<Property name="RecipeType" value="RECIPE_HOT1_PLANT_HOT" />
+			<Property name="RecipeName" value="R_NAME_HOT1_PLANT_HOT" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_HOT" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="HOT1">
+					<Property name="Id" value="HOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_HOT">
+					<Property name="Id" value="PLANT_HOT" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_126">
+			<Property name="Id" value="REFINERECIPE_126" />
+			<Property name="RecipeType" value="RECIPE_CAVE1_OXYGEN" />
+			<Property name="RecipeName" value="R_NAME_CAVE1_OXYGEN" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CAVE2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="5" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_127">
+			<Property name="Id" value="REFINERECIPE_127" />
+			<Property name="RecipeType" value="RECIPE_CAVE2_OXYGEN" />
+			<Property name="RecipeName" value="R_NAME_CAVE2_OXYGEN" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CAVE2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="6" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_129">
+			<Property name="Id" value="REFINERECIPE_129" />
+			<Property name="RecipeType" value="RECIPE_ASTEROID1_OXYGEN" />
+			<Property name="RecipeName" value="R_NAME_ASTEROID1_OXYGEN" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LUSH1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID1">
+					<Property name="Id" value="ASTEROID1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_132">
+			<Property name="Id" value="REFINERECIPE_132" />
+			<Property name="RecipeType" value="RECIPE_GAS1_OXYGEN" />
+			<Property name="RecipeName" value="R_NAME_GAS1_OXYGEN" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="GAS2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS1">
+					<Property name="Id" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_133">
+			<Property name="Id" value="REFINERECIPE_133" />
+			<Property name="RecipeType" value="RECIPE_GAS2_OXYGEN" />
+			<Property name="RecipeName" value="R_NAME_GAS2_OXYGEN" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="GAS3" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS2">
+					<Property name="Id" value="GAS2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_134">
+			<Property name="Id" value="REFINERECIPE_134" />
+			<Property name="RecipeType" value="RECIPE_GAS3_OXYGEN" />
+			<Property name="RecipeName" value="R_NAME_GAS3_OXYGEN" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="GAS1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS3">
+					<Property name="Id" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_135">
+			<Property name="Id" value="REFINERECIPE_135" />
+			<Property name="RecipeType" value="RECIPE_GAS1_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_GAS3_LAND1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="GAS2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS1">
+					<Property name="Id" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="STELLAR2">
+					<Property name="Id" value="STELLAR2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_136">
+			<Property name="Id" value="REFINERECIPE_136" />
+			<Property name="RecipeType" value="RECIPE_GAS2_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_GAS3_LAND1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="GAS3" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS2">
+					<Property name="Id" value="GAS2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="STELLAR2">
+					<Property name="Id" value="STELLAR2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_137">
+			<Property name="Id" value="REFINERECIPE_137" />
+			<Property name="RecipeType" value="RECIPE_GAS3_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_GAS3_LAND1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="GAS1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS3">
+					<Property name="Id" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="STELLAR2">
+					<Property name="Id" value="STELLAR2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_138">
+			<Property name="Id" value="REFINERECIPE_138" />
+			<Property name="RecipeType" value="RECIPE_GAS2_CATALYST2" />
+			<Property name="RecipeName" value="R_NAME_GAS3_LAND1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS3">
+					<Property name="Id" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST1">
+					<Property name="Id" value="CATALYST1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_139">
+			<Property name="Id" value="REFINERECIPE_139" />
+			<Property name="RecipeType" value="RECIPE_GAS3_CATALYST2" />
+			<Property name="RecipeName" value="R_NAME_GAS3_LAND1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS3">
+					<Property name="Id" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST2">
+					<Property name="Id" value="CATALYST2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_140">
+			<Property name="Id" value="REFINERECIPE_140" />
+			<Property name="RecipeType" value="RECIPE_PLANT_CAVE_OXYGEN" />
+			<Property name="RecipeName" value="R_NAME_PLANT_CAVE_OXYGEN" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CAVE2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_CAVE">
+					<Property name="Id" value="PLANT_CAVE" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_142">
+			<Property name="Id" value="REFINERECIPE_142" />
+			<Property name="RecipeType" value="RECIPE_PLANT_POOP_OXYGEN" />
+			<Property name="RecipeName" value="R_NAME_PLANT_POOP_OXYGEN" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_POOP" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="3" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_POOP">
+					<Property name="Id" value="PLANT_POOP" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_143">
+			<Property name="Id" value="REFINERECIPE_143" />
+			<Property name="RecipeType" value="RECIPE_PLANT_CAVE_ROBOT1" />
+			<Property name="RecipeName" value="R_NAME_PLANT_CAVE_ROBOT1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CAVE2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_CAVE">
+					<Property name="Id" value="PLANT_CAVE" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ROBOT1">
+					<Property name="Id" value="ROBOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_147">
+			<Property name="Id" value="REFINERECIPE_147" />
+			<Property name="RecipeType" value="RECIPE_PLANT_POOP_FUEL1" />
+			<Property name="RecipeName" value="R_NAME_PLANT_POOP_FUEL1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="FUEL2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_POOP">
+					<Property name="Id" value="PLANT_POOP" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL1">
+					<Property name="Id" value="FUEL1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_148">
+			<Property name="Id" value="REFINERECIPE_148" />
+			<Property name="RecipeType" value="RECIPE_PLANT_CAVE_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_PLANT_CAVE_CATALYST1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_CAVE">
+					<Property name="Id" value="PLANT_CAVE" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST1">
+					<Property name="Id" value="CATALYST1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_149">
+			<Property name="Id" value="REFINERECIPE_149" />
+			<Property name="RecipeType" value="RECIPE_PLANT_WATER_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_PLANT_WATER_CATALYST1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_WATER">
+					<Property name="Id" value="PLANT_WATER" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST1">
+					<Property name="Id" value="CATALYST1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_150">
+			<Property name="Id" value="REFINERECIPE_150" />
+			<Property name="RecipeType" value="RECIPE_PLANT_POOP_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_PLANT_POOP_CATALYST1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_POOP">
+					<Property name="Id" value="PLANT_POOP" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST1">
+					<Property name="Id" value="CATALYST1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_153">
+			<Property name="Id" value="REFINERECIPE_153" />
+			<Property name="RecipeType" value="RECIPE_PLANT_POOP_FUEL2" />
+			<Property name="RecipeName" value="R_NAME_PLANT_POOP_FUEL2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="FUEL2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="3" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_POOP">
+					<Property name="Id" value="PLANT_POOP" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL2">
+					<Property name="Id" value="FUEL2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_154">
+			<Property name="Id" value="REFINERECIPE_154" />
+			<Property name="RecipeType" value="RECIPE_PLANT_CAVE_CATALYST2" />
+			<Property name="RecipeName" value="R_NAME_PLANT_CAVE_CATALYST2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_CAVE">
+					<Property name="Id" value="PLANT_CAVE" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST2">
+					<Property name="Id" value="CATALYST2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_155">
+			<Property name="Id" value="REFINERECIPE_155" />
+			<Property name="RecipeType" value="RECIPE_PLANT_WATER_CATALYST2" />
+			<Property name="RecipeName" value="R_NAME_PLANT_WATER_CATALYST2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_WATER">
+					<Property name="Id" value="PLANT_WATER" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST2">
+					<Property name="Id" value="CATALYST2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_156">
+			<Property name="Id" value="REFINERECIPE_156" />
+			<Property name="RecipeType" value="RECIPE_PLANT_POOP_CATALYST2" />
+			<Property name="RecipeName" value="R_NAME_PLANT_POOP_CATALYST2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_POOP">
+					<Property name="Id" value="PLANT_POOP" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST2">
+					<Property name="Id" value="CATALYST2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_157">
+			<Property name="Id" value="REFINERECIPE_157" />
+			<Property name="RecipeType" value="RECIPE_PLANT_CAVE_CAVE1" />
+			<Property name="RecipeName" value="R_NAME_PLANT_CAVE_CAVE1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CAVE2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_CAVE">
+					<Property name="Id" value="PLANT_CAVE" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_159">
+			<Property name="Id" value="REFINERECIPE_159" />
+			<Property name="RecipeType" value="RECIPE_PLANT_CAVE_CAVE2" />
+			<Property name="RecipeName" value="R_NAME_PLANT_CAVE_CAVE2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CAVE2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_CAVE">
+					<Property name="Id" value="PLANT_CAVE" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_162">
+			<Property name="Id" value="REFINERECIPE_162" />
+			<Property name="RecipeType" value="RECIPE_PLANT_POOP_CREATURE1" />
+			<Property name="RecipeName" value="R_NAME_PLANT_POOP_CREATURE1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="FUEL2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_POOP">
+					<Property name="Id" value="PLANT_POOP" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CREATURE1">
+					<Property name="Id" value="CREATURE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_179">
+			<Property name="Id" value="REFINERECIPE_179" />
+			<Property name="RecipeType" value="RECIPE_GROW_PLANT" />
+			<Property name="RecipeName" value="R_NAME_GROW_PLANT_OXY_LUSH" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_LUSH" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LUSH1">
+					<Property name="Id" value="LUSH1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_180">
+			<Property name="Id" value="REFINERECIPE_180" />
+			<Property name="RecipeType" value="RECIPE_GROW_PLANT" />
+			<Property name="RecipeName" value="R_NAME_GROW_PLANT_OXY_DUST" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_DUST" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="DUSTY1">
+					<Property name="Id" value="DUSTY1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_182">
+			<Property name="Id" value="REFINERECIPE_182" />
+			<Property name="RecipeType" value="RECIPE_GROW_PLANT" />
+			<Property name="RecipeName" value="R_NAME_GROW_PLANT_OXY_RADIO" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_RADIO" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="RADIO1">
+					<Property name="Id" value="RADIO1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_183">
+			<Property name="Id" value="REFINERECIPE_183" />
+			<Property name="RecipeType" value="RECIPE_GROW_PLANT" />
+			<Property name="RecipeName" value="R_NAME_GROW_PLANT_OXY_SNOW" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_SNOW" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_184">
+			<Property name="Id" value="REFINERECIPE_184" />
+			<Property name="RecipeType" value="RECIPE_GROW_PLANT" />
+			<Property name="RecipeName" value="R_NAME_GROW_PLANT_OXY_HOT" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_HOT" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="HOT1">
+					<Property name="Id" value="HOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_186">
+			<Property name="Id" value="REFINERECIPE_186" />
+			<Property name="RecipeType" value="RECIPE_DUSTY1_LAND1" />
+			<Property name="RecipeName" value="R_NAME_DUSTY1_LAND1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LUSH1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="DUSTY1">
+					<Property name="Id" value="DUSTY1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND1">
+					<Property name="Id" value="LAND1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_187">
+			<Property name="Id" value="REFINERECIPE_187" />
+			<Property name="RecipeType" value="RECIPE_TOXIC1_LAND1" />
+			<Property name="RecipeName" value="R_NAME_TOXIC1_LAND1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="COLD1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="TOXIC1">
+					<Property name="Id" value="TOXIC1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND1">
+					<Property name="Id" value="LAND1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_189">
+			<Property name="Id" value="REFINERECIPE_189" />
+			<Property name="RecipeType" value="RECIPE_COLD1_LAND1" />
+			<Property name="RecipeName" value="R_NAME_COLD1_LAND1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="HOT1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND1">
+					<Property name="Id" value="LAND1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_192">
+			<Property name="Id" value="REFINERECIPE_192" />
+			<Property name="RecipeType" value="RECIPE_DUSTY1_LAND1" />
+			<Property name="RecipeName" value="R_NAME_DUSTY1_LAND2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LUSH1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="DUSTY1">
+					<Property name="Id" value="DUSTY1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND2">
+					<Property name="Id" value="LAND2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_193">
+			<Property name="Id" value="REFINERECIPE_193" />
+			<Property name="RecipeType" value="RECIPE_TOXIC1_LAND1" />
+			<Property name="RecipeName" value="R_NAME_TOXIC1_LAND2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="COLD1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="TOXIC1">
+					<Property name="Id" value="TOXIC1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND2">
+					<Property name="Id" value="LAND2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_195">
+			<Property name="Id" value="REFINERECIPE_195" />
+			<Property name="RecipeType" value="RECIPE_COLD1_LAND1" />
+			<Property name="RecipeName" value="R_NAME_COLD1_LAND2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="HOT1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND2">
+					<Property name="Id" value="LAND2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_198">
+			<Property name="Id" value="REFINERECIPE_198" />
+			<Property name="RecipeType" value="RECIPE_PLANT_SNOW_WATER1" />
+			<Property name="RecipeName" value="R_NAME_PLANT_SNOW_WATER1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="COLD1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_SNOW">
+					<Property name="Id" value="PLANT_SNOW" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER1">
+					<Property name="Id" value="WATER1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_201">
+			<Property name="Id" value="REFINERECIPE_201" />
+			<Property name="RecipeType" value="RECIPE_PLANT_HOT_WATER1" />
+			<Property name="RecipeName" value="R_NAME_PLANT_HOT_WATER1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="HOT1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_HOT">
+					<Property name="Id" value="PLANT_HOT" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER1">
+					<Property name="Id" value="WATER1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_202">
+			<Property name="Id" value="REFINERECIPE_202" />
+			<Property name="RecipeType" value="RECIPE_PLANT_LUSH_WATER1" />
+			<Property name="RecipeName" value="R_NAME_PLANT_LUSH_WATER1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LUSH1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="PLANT_LUSH">
+					<Property name="Id" value="PLANT_LUSH" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="2" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER1">
+					<Property name="Id" value="WATER1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_209">
+			<Property name="Id" value="REFINERECIPE_209" />
+			<Property name="RecipeType" value="RECIPE_GAS1_LAND" />
+			<Property name="RecipeName" value="R_NAME_GAS1_LAND1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LUSH1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS1">
+					<Property name="Id" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND1">
+					<Property name="Id" value="LAND1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_211">
+			<Property name="Id" value="REFINERECIPE_211" />
+			<Property name="RecipeType" value="RECIPE_GAS1_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_GAS3_LAND1" />
+			<Property name="TimeToMake" value="120.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS3">
+					<Property name="Id" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND1">
+					<Property name="Id" value="LAND1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_212">
+			<Property name="Id" value="REFINERECIPE_212" />
+			<Property name="RecipeType" value="RECIPE_GAS1_LAND" />
+			<Property name="RecipeName" value="R_NAME_GAS1_LAND2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LUSH1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS1">
+					<Property name="Id" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND2">
+					<Property name="Id" value="LAND2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_214">
+			<Property name="Id" value="REFINERECIPE_214" />
+			<Property name="RecipeType" value="RECIPE_GAS1_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_GAS3_LAND2" />
+			<Property name="TimeToMake" value="120.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS3">
+					<Property name="Id" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND2">
+					<Property name="Id" value="LAND2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_215">
+			<Property name="Id" value="REFINERECIPE_215" />
+			<Property name="RecipeType" value="RECIPE_GAS1_LAND" />
+			<Property name="RecipeName" value="R_NAME_GAS1_LAND3" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LUSH1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="3" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS1">
+					<Property name="Id" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND3">
+					<Property name="Id" value="LAND3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_217">
+			<Property name="Id" value="REFINERECIPE_217" />
+			<Property name="RecipeType" value="RECIPE_GAS3_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_GAS3_LAND3" />
+			<Property name="TimeToMake" value="120.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="3" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS3">
+					<Property name="Id" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND3">
+					<Property name="Id" value="LAND3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_219">
+			<Property name="Id" value="REFINERECIPE_219" />
+			<Property name="RecipeType" value="RECIPE_GROW_PLANT" />
+			<Property name="RecipeName" value="R_NAME_GROW_PLANT_SNOW" />
+			<Property name="TimeToMake" value="60.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_SNOW" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS2">
+					<Property name="Id" value="GAS2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_220">
+			<Property name="Id" value="REFINERECIPE_220" />
+			<Property name="RecipeType" value="RECIPE_GROW_PLANT" />
+			<Property name="RecipeName" value="R_NAME_GROW_PLANT_RADIO" />
+			<Property name="TimeToMake" value="60.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_RADIO" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="RADIO1">
+					<Property name="Id" value="RADIO1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS2">
+					<Property name="Id" value="GAS2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_221">
+			<Property name="Id" value="REFINERECIPE_221" />
+			<Property name="RecipeType" value="RECIPE_GROW_PLANT" />
+			<Property name="RecipeName" value="R_NAME_GROW_PLANT_DUST" />
+			<Property name="TimeToMake" value="60.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_DUST" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="DUSTY1">
+					<Property name="Id" value="DUSTY1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS1">
+					<Property name="Id" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_222">
+			<Property name="Id" value="REFINERECIPE_222" />
+			<Property name="RecipeType" value="RECIPE_GROW_PLANT" />
+			<Property name="RecipeName" value="R_NAME_GROW_PLANT_HOT" />
+			<Property name="TimeToMake" value="60.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_HOT" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="HOT1">
+					<Property name="Id" value="HOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS1">
+					<Property name="Id" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_223">
+			<Property name="Id" value="REFINERECIPE_223" />
+			<Property name="RecipeType" value="RECIPE_GROW_PLANT" />
+			<Property name="RecipeName" value="R_NAME_GROW_PLANT_LUSH" />
+			<Property name="TimeToMake" value="60.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_LUSH" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LUSH1">
+					<Property name="Id" value="LUSH1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS3">
+					<Property name="Id" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_226">
+			<Property name="Id" value="REFINERECIPE_226" />
+			<Property name="RecipeType" value="RECIPE_GROW_PLANT" />
+			<Property name="RecipeName" value="R_NAME_GROW_PLANT_LUSH" />
+			<Property name="TimeToMake" value="60.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_POOP" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS1">
+					<Property name="Id" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS3">
+					<Property name="Id" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_263">
+			<Property name="Id" value="REFINERECIPE_263" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_1_1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LUSH1">
+					<Property name="Id" value="LUSH1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="60" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ROCKETSUB">
+					<Property name="Id" value="ROCKETSUB" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_264">
+			<Property name="Id" value="REFINERECIPE_264" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_1_2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LUSH1">
+					<Property name="Id" value="LUSH1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ROCKETSUB">
+					<Property name="Id" value="ROCKETSUB" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_265">
+			<Property name="Id" value="REFINERECIPE_265" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_1_3" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LUSH1">
+					<Property name="Id" value="LUSH1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="60" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID1">
+					<Property name="Id" value="ASTEROID1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_266">
+			<Property name="Id" value="REFINERECIPE_266" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_1_4" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LUSH1">
+					<Property name="Id" value="LUSH1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID1">
+					<Property name="Id" value="ASTEROID1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_267">
+			<Property name="Id" value="REFINERECIPE_267" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_1_5" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LUSH1">
+					<Property name="Id" value="LUSH1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="60" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID2">
+					<Property name="Id" value="ASTEROID2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_268">
+			<Property name="Id" value="REFINERECIPE_268" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_1_6" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LUSH1">
+					<Property name="Id" value="LUSH1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID2">
+					<Property name="Id" value="ASTEROID2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_269">
+			<Property name="Id" value="REFINERECIPE_269" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_1_7" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LUSH1">
+					<Property name="Id" value="LUSH1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="60" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID3">
+					<Property name="Id" value="ASTEROID3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="5" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_270">
+			<Property name="Id" value="REFINERECIPE_270" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_1_8" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LUSH1">
+					<Property name="Id" value="LUSH1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID3">
+					<Property name="Id" value="ASTEROID3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="5" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_295">
+			<Property name="Id" value="REFINERECIPE_295" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_5_1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY5" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="HOT1">
+					<Property name="Id" value="HOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="60" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ROCKETSUB">
+					<Property name="Id" value="ROCKETSUB" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_296">
+			<Property name="Id" value="REFINERECIPE_296" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_5_2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY5" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="HOT1">
+					<Property name="Id" value="HOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ROCKETSUB">
+					<Property name="Id" value="ROCKETSUB" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_297">
+			<Property name="Id" value="REFINERECIPE_297" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_5_3" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY5" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="HOT1">
+					<Property name="Id" value="HOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="60" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID1">
+					<Property name="Id" value="ASTEROID1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_298">
+			<Property name="Id" value="REFINERECIPE_298" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_5_4" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY5" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="HOT1">
+					<Property name="Id" value="HOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID1">
+					<Property name="Id" value="ASTEROID1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_299">
+			<Property name="Id" value="REFINERECIPE_299" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_5_5" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY5" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="HOT1">
+					<Property name="Id" value="HOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="60" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID2">
+					<Property name="Id" value="ASTEROID2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_300">
+			<Property name="Id" value="REFINERECIPE_300" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_5_6" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY5" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="HOT1">
+					<Property name="Id" value="HOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID2">
+					<Property name="Id" value="ASTEROID2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_301">
+			<Property name="Id" value="REFINERECIPE_301" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_5_7" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY5" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="HOT1">
+					<Property name="Id" value="HOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="60" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID3">
+					<Property name="Id" value="ASTEROID3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="5" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_302">
+			<Property name="Id" value="REFINERECIPE_302" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_5_8" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY5" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="HOT1">
+					<Property name="Id" value="HOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID3">
+					<Property name="Id" value="ASTEROID3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="5" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_303">
+			<Property name="Id" value="REFINERECIPE_303" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_6_1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY6" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="60" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ROCKETSUB">
+					<Property name="Id" value="ROCKETSUB" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_304">
+			<Property name="Id" value="REFINERECIPE_304" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_6_2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY6" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ROCKETSUB">
+					<Property name="Id" value="ROCKETSUB" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_305">
+			<Property name="Id" value="REFINERECIPE_305" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_6_3" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY6" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="60" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID1">
+					<Property name="Id" value="ASTEROID1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_306">
+			<Property name="Id" value="REFINERECIPE_306" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_6_4" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY6" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID1">
+					<Property name="Id" value="ASTEROID1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_307">
+			<Property name="Id" value="REFINERECIPE_307" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_6_5" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY6" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="60" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID2">
+					<Property name="Id" value="ASTEROID2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_308">
+			<Property name="Id" value="REFINERECIPE_308" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_6_6" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY6" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID2">
+					<Property name="Id" value="ASTEROID2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_309">
+			<Property name="Id" value="REFINERECIPE_309" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_6_7" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY6" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE1">
+					<Property name="Id" value="CAVE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="60" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID3">
+					<Property name="Id" value="ASTEROID3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="5" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_310">
+			<Property name="Id" value="REFINERECIPE_310" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_ALLOY" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_ALLOY_6_8" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="ALLOY6" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="30" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="ASTEROID3">
+					<Property name="Id" value="ASTEROID3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="5" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_311">
+			<Property name="Id" value="REFINERECIPE_311" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_REACTION1_1" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_REACTION1_1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="REACTION1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS1">
+					<Property name="Id" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="100" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL1">
+					<Property name="Id" value="FUEL1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER1">
+					<Property name="Id" value="WATER1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_312">
+			<Property name="Id" value="REFINERECIPE_312" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_REACTION2_1" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_REACTION2_1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="REACTION2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS2">
+					<Property name="Id" value="GAS2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="100" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL1">
+					<Property name="Id" value="FUEL1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER1">
+					<Property name="Id" value="WATER1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_313">
+			<Property name="Id" value="REFINERECIPE_313" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_REACTION3_1" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_REACTION3_1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="REACTION3" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS3">
+					<Property name="Id" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="100" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL1">
+					<Property name="Id" value="FUEL1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER1">
+					<Property name="Id" value="WATER1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_314">
+			<Property name="Id" value="REFINERECIPE_314" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_REACTION1_2" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_REACTION1_2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="REACTION1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS1">
+					<Property name="Id" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="100" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL2">
+					<Property name="Id" value="FUEL2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER1">
+					<Property name="Id" value="WATER1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_315">
+			<Property name="Id" value="REFINERECIPE_315" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_REACTION2_2" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_REACTION2_2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="REACTION2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS2">
+					<Property name="Id" value="GAS2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="100" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL2">
+					<Property name="Id" value="FUEL2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER1">
+					<Property name="Id" value="WATER1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_316">
+			<Property name="Id" value="REFINERECIPE_316" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_REACTION3_2" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_REACTION3_2" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="REACTION3" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS3">
+					<Property name="Id" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="100" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL2">
+					<Property name="Id" value="FUEL2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER1">
+					<Property name="Id" value="WATER1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_317">
+			<Property name="Id" value="REFINERECIPE_317" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_REACTION1_3" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_REACTION1_3" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="REACTION1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS1">
+					<Property name="Id" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="100" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL1">
+					<Property name="Id" value="FUEL1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER2">
+					<Property name="Id" value="WATER2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="5" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_318">
+			<Property name="Id" value="REFINERECIPE_318" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_REACTION2_3" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_REACTION2_3" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="REACTION2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS2">
+					<Property name="Id" value="GAS2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="100" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL1">
+					<Property name="Id" value="FUEL1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER2">
+					<Property name="Id" value="WATER2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="5" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_319">
+			<Property name="Id" value="REFINERECIPE_319" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_REACTION3_3" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_REACTION3_3" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="REACTION3" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS3">
+					<Property name="Id" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="100" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL1">
+					<Property name="Id" value="FUEL1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="20" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER2">
+					<Property name="Id" value="WATER2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="5" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_320">
+			<Property name="Id" value="REFINERECIPE_320" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_REACTION1_4" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_REACTION1_4" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="REACTION1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS1">
+					<Property name="Id" value="GAS1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="100" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL2">
+					<Property name="Id" value="FUEL2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER2">
+					<Property name="Id" value="WATER2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="5" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_321">
+			<Property name="Id" value="REFINERECIPE_321" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_REACTION2_4" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_REACTION2_4" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="REACTION2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS2">
+					<Property name="Id" value="GAS2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="100" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL2">
+					<Property name="Id" value="FUEL2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER2">
+					<Property name="Id" value="WATER2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="5" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_322">
+			<Property name="Id" value="REFINERECIPE_322" />
+			<Property name="RecipeType" value="RECIPE_3INPUT_REACTION3_4" />
+			<Property name="RecipeName" value="R_NAME_3INPUT_REACTION3_4" />
+			<Property name="TimeToMake" value="20.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="REACTION3" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS3">
+					<Property name="Id" value="GAS3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="100" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="FUEL2">
+					<Property name="Id" value="FUEL2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="10" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATER2">
+					<Property name="Id" value="WATER2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="5" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_323">
+			<Property name="Id" value="REFINERECIPE_323" />
+			<Property name="RecipeType" value="RECIPE_SILICATE" />
+			<Property name="RecipeName" value="R_NAME_SILICATE" />
+			<Property name="TimeToMake" value="10.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="FARMPROD3" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Product" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="SAND1">
+					<Property name="Id" value="SAND1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="40" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_345">
+			<Property name="Id" value="REFINERECIPE_345" />
+			<Property name="RecipeType" value="RECIPE_LUSH1" />
+			<Property name="RecipeName" value="R_NAME_LUSH1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LAND1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GASGIANT1">
+					<Property name="Id" value="GASGIANT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_358">
+			<Property name="Id" value="REFINERECIPE_358" />
+			<Property name="RecipeType" value="RECIPE_GAS1_LAND" />
+			<Property name="RecipeName" value="R_NAME_GAS1_LAND1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="EX_PURPLE">
+					<Property name="Id" value="EX_PURPLE" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GASGIANT1">
+					<Property name="Id" value="GASGIANT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_361">
+			<Property name="Id" value="REFINERECIPE_361" />
+			<Property name="RecipeType" value="RECIPE_LUSH1" />
+			<Property name="RecipeName" value="R_NAME_LUSH1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="LAND1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATERWORLD1">
+					<Property name="Id" value="WATERWORLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_374">
+			<Property name="Id" value="REFINERECIPE_374" />
+			<Property name="RecipeType" value="RECIPE_GAS1_LAND" />
+			<Property name="RecipeName" value="R_NAME_GAS1_LAND1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="EX_PURPLE">
+					<Property name="Id" value="EX_PURPLE" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="WATERWORLD1">
+					<Property name="Id" value="WATERWORLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_378">
+			<Property name="Id" value="REFINERECIPE_378" />
+			<Property name="RecipeType" value="RECIPE_GAS3" />
+			<Property name="RecipeName" value="R_NAME_GAS3" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="GAS3" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="3" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_379">
+			<Property name="Id" value="REFINERECIPE_379" />
+			<Property name="RecipeType" value="RECIPE_LAUNCHSUB_GAS3" />
+			<Property name="RecipeName" value="R_NAME_LAUNCHSUB_GAS3" />
+			<Property name="TimeToMake" value="40.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="HOT1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAUNCHSUB">
+					<Property name="Id" value="LAUNCHSUB" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_380">
+			<Property name="Id" value="REFINERECIPE_380" />
+			<Property name="RecipeType" value="RECIPE_GAS3_OXYGEN" />
+			<Property name="RecipeName" value="R_NAME_GAS3_OXYGEN" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="GAS3" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="OXYGEN">
+					<Property name="Id" value="OXYGEN" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_381">
+			<Property name="Id" value="REFINERECIPE_381" />
+			<Property name="RecipeType" value="RECIPE_GAS3_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_GAS3_LAND1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="GAS3" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="STELLAR2">
+					<Property name="Id" value="STELLAR2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_382">
+			<Property name="Id" value="REFINERECIPE_382" />
+			<Property name="RecipeType" value="RECIPE_GAS2_CATALYST2" />
+			<Property name="RecipeName" value="R_NAME_GAS3_LAND1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST1">
+					<Property name="Id" value="CATALYST1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_383">
+			<Property name="Id" value="REFINERECIPE_383" />
+			<Property name="RecipeType" value="RECIPE_GAS3_CATALYST2" />
+			<Property name="RecipeName" value="R_NAME_GAS3_LAND1" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CATALYST2">
+					<Property name="Id" value="CATALYST2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_384">
+			<Property name="Id" value="REFINERECIPE_384" />
+			<Property name="RecipeType" value="RECIPE_GAS1_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_GAS3_LAND1" />
+			<Property name="TimeToMake" value="120.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND1">
+					<Property name="Id" value="LAND1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_385">
+			<Property name="Id" value="REFINERECIPE_385" />
+			<Property name="RecipeType" value="RECIPE_GAS1_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_GAS3_LAND2" />
+			<Property name="TimeToMake" value="120.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND2">
+					<Property name="Id" value="LAND2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_386">
+			<Property name="Id" value="REFINERECIPE_386" />
+			<Property name="RecipeType" value="RECIPE_GAS3_CATALYST1" />
+			<Property name="RecipeName" value="R_NAME_GAS3_LAND3" />
+			<Property name="TimeToMake" value="120.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CATALYST2" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="3" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LAND3">
+					<Property name="Id" value="LAND3" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_389">
+			<Property name="Id" value="REFINERECIPE_389" />
+			<Property name="RecipeType" value="RECIPE_LUSH1_PLANT_LUSH" />
+			<Property name="RecipeName" value="R_NAME_LUSH1_PLANT_LUSH" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_SNOW" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="COLD1">
+					<Property name="Id" value="COLD1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_390">
+			<Property name="Id" value="REFINERECIPE_390" />
+			<Property name="RecipeType" value="RECIPE_LUSH1_PLANT_LUSH" />
+			<Property name="RecipeName" value="R_NAME_LUSH1_PLANT_LUSH" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_RADIO" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="RADIO1">
+					<Property name="Id" value="RADIO1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_391">
+			<Property name="Id" value="REFINERECIPE_391" />
+			<Property name="RecipeType" value="RECIPE_LUSH1_PLANT_LUSH" />
+			<Property name="RecipeName" value="R_NAME_LUSH1_PLANT_LUSH" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_DUST" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="DUSTY1">
+					<Property name="Id" value="DUSTY1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_392">
+			<Property name="Id" value="REFINERECIPE_392" />
+			<Property name="RecipeType" value="RECIPE_LUSH1_PLANT_LUSH" />
+			<Property name="RecipeName" value="R_NAME_LUSH1_PLANT_LUSH" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_HOT" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="HOT1">
+					<Property name="Id" value="HOT1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_393">
+			<Property name="Id" value="REFINERECIPE_393" />
+			<Property name="RecipeType" value="RECIPE_LUSH1_PLANT_LUSH" />
+			<Property name="RecipeName" value="R_NAME_LUSH1_PLANT_LUSH" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_LUSH" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="LUSH1">
+					<Property name="Id" value="LUSH1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_396">
+			<Property name="Id" value="REFINERECIPE_396" />
+			<Property name="RecipeType" value="RECIPE_LUSH1_PLANT_LUSH" />
+			<Property name="RecipeName" value="R_NAME_LUSH1_PLANT_LUSH" />
+			<Property name="TimeToMake" value="90.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="PLANT_POOP" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="1" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="GAS4">
+					<Property name="Id" value="GAS4" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CREATURE1">
+					<Property name="Id" value="CREATURE1" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
+	</Property>
+</Data>

--- a/internal/normalize/testdata/graph/substances.MXML
+++ b/internal/normalize/testdata/graph/substances.MXML
@@ -1,0 +1,2866 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--File created using MBINCompiler version (6.45.0.1)-->
+<Data template="cGcSubstanceTable">
+	<Property name="Table">
+		<Property name="Table" value="GcRealitySubstanceData" _id="FUEL1">
+			<Property name="Name" value="UI_FUEL_1_NAME" />
+			<Property name="NameLower" value="UI_FUEL_1_NAME_L" />
+			<Property name="ID" value="FUEL1" />
+			<Property name="Symbol" value="UI_FUEL1_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.FUEL.1.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/RESOURCEDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_FUEL1_SUB" />
+			<Property name="Description" value="UI_FUEL_1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.733333349" />
+				<Property name="G" value="0.219607845" />
+				<Property name="B" value="0.188235298" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.733333349" />
+				<Property name="G" value="0.219607845" />
+				<Property name="B" value="0.188235298" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="12" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Fuel" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Common" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="7.0512823E-07" />
+			<Property name="NormalisedValueOffWorld" value="7.0512823E-07" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_FUEL1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_FUEL1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Carbon" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_FUEL1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="true" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="FUEL2">
+			<Property name="Name" value="UI_FUEL_2_NAME" />
+			<Property name="NameLower" value="UI_FUEL_2_NAME_L" />
+			<Property name="ID" value="FUEL2" />
+			<Property name="Symbol" value="UI_FUEL2_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.FUEL.2.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/RESOURCEDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_FUEL2_SUB" />
+			<Property name="Description" value="UI_FUEL_2_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.733333349" />
+				<Property name="G" value="0.219607845" />
+				<Property name="B" value="0.188235298" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.733333349" />
+				<Property name="G" value="0.219607845" />
+				<Property name="B" value="0.188235298" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="24" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Fuel" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="3" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="1.47435912E-06" />
+			<Property name="NormalisedValueOffWorld" value="1.47435912E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_FUEL2_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_FUEL2_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Carbon" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_FUEL2" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="true" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="true" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="OXYGEN">
+			<Property name="Name" value="UI_AIR1_NAME" />
+			<Property name="NameLower" value="UI_AIR1_NAME_L" />
+			<Property name="ID" value="OXYGEN" />
+			<Property name="Symbol" value="UI_AIR_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.AIR.1.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/RESOURCEDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_AIR_SUB" />
+			<Property name="Description" value="UI_AIR1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.733333349" />
+				<Property name="G" value="0.219607845" />
+				<Property name="B" value="0.188235298" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.733333349" />
+				<Property name="G" value="0.219607845" />
+				<Property name="B" value="0.188235298" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="34" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Fuel" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Common" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="2" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="3.500000" />
+				<Property name="BuyMarkupMod" value="1.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="2.11538486E-06" />
+			<Property name="NormalisedValueOffWorld" value="2.11538486E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_OXYGEN_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_OXYGEN_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Oxygen" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_OXYGEN" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="LAUNCHSUB">
+			<Property name="Name" value="UI_LAUNCHSUB_NAME" />
+			<Property name="NameLower" value="UI_LAUNCHSUB_NAME_L" />
+			<Property name="ID" value="LAUNCHSUB" />
+			<Property name="Symbol" value="UI_LAUNCHSUB_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.LAUNCHSUB.1.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TECHDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_LAUNCHSUB_SUB" />
+			<Property name="Description" value="UI_LAUNCHSUB_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.20784314" />
+				<Property name="G" value="0.352941185" />
+				<Property name="B" value="0.490196079" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.20784314" />
+				<Property name="G" value="0.352941185" />
+				<Property name="B" value="0.490196079" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="34" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Common" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="3.500000" />
+				<Property name="BuyMarkupMod" value="1.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="2.11538486E-06" />
+			<Property name="NormalisedValueOffWorld" value="2.11538486E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_LAUNCHSUB_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_LAUNCHSUB_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="LaunchCrystals" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_LAUNCHSUB" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="ROCKETSUB">
+			<Property name="Name" value="UI_ROCKETFUEL_NAME" />
+			<Property name="NameLower" value="UI_ROCKETFUEL_NAME_L" />
+			<Property name="ID" value="ROCKETSUB" />
+			<Property name="Symbol" value="UI_ROCKETFUEL_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.ROCKETSUB.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TECHDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_ROCKETFUEL_SUB" />
+			<Property name="Description" value="UI_ROCKETFUEL_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.870588243" />
+				<Property name="G" value="0.862745106" />
+				<Property name="B" value="0.819607854" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.349019617" />
+				<Property name="G" value="0.607843161" />
+				<Property name="B" value="0.713725507" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="6" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Exotic" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Common" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="3.20512839E-07" />
+			<Property name="NormalisedValueOffWorld" value="3.20512839E-07" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_ROCKETSUB_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_ROCKETSUB_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="FuelAsteroid" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_ROCKETSUB" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="LAND1">
+			<Property name="Name" value="UI_LAND1_NAME" />
+			<Property name="NameLower" value="UI_LAND1_NAME_L" />
+			<Property name="ID" value="LAND1" />
+			<Property name="Symbol" value="UI_LAND1_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.LAND.1.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_LAND1_SUB" />
+			<Property name="Description" value="UI_LAND1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.541176498" />
+				<Property name="G" value="0.498039216" />
+				<Property name="B" value="0.447058827" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.870588243" />
+				<Property name="G" value="0.862745106" />
+				<Property name="B" value="0.819607854" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="14" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Metal" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Common" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="8.33333388E-07" />
+			<Property name="NormalisedValueOffWorld" value="8.33333388E-07" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_LAND1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_LAND1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_LAND1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="LAND2">
+			<Property name="Name" value="UI_LAND2_NAME" />
+			<Property name="NameLower" value="UI_LAND2_NAME_L" />
+			<Property name="ID" value="LAND2" />
+			<Property name="Symbol" value="UI_LAND2_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.LAND.2.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS2.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_LAND2_SUB" />
+			<Property name="Description" value="UI_LAND2_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.541176498" />
+				<Property name="G" value="0.498039216" />
+				<Property name="B" value="0.447058827" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.870588243" />
+				<Property name="G" value="0.862745106" />
+				<Property name="B" value="0.819607854" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="28" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Metal" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="2" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="1.73076933E-06" />
+			<Property name="NormalisedValueOffWorld" value="1.73076933E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_LAND2_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_LAND2_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_LAND2" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="true" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="LAND3">
+			<Property name="Name" value="UI_LAND3_NAME" />
+			<Property name="NameLower" value="UI_LAND3_NAME_L" />
+			<Property name="ID" value="LAND3" />
+			<Property name="Symbol" value="UI_LAND3_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.LAND.3.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS2.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_LAND3_SUB" />
+			<Property name="Description" value="UI_LAND3_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.541176498" />
+				<Property name="G" value="0.498039216" />
+				<Property name="B" value="0.447058827" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.870588243" />
+				<Property name="G" value="0.862745106" />
+				<Property name="B" value="0.819607854" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="82" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Metal" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="10" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="5.19230798E-06" />
+			<Property name="NormalisedValueOffWorld" value="5.19230798E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_LAND3_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_LAND3_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_LAND3" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="true" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="SAND1">
+			<Property name="Name" value="UI_SAND1_NAME" />
+			<Property name="NameLower" value="UI_SAND1_NAME_L" />
+			<Property name="ID" value="SAND1" />
+			<Property name="Symbol" value="UI_SAND1_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.SAND.1.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_SAND1_SUB" />
+			<Property name="Description" value="UI_SAND1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.541176498" />
+				<Property name="G" value="0.498039216" />
+				<Property name="B" value="0.447058827" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.870588243" />
+				<Property name="G" value="0.862745106" />
+				<Property name="B" value="0.819607854" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="2" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Metal" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Common" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="5.76923242E-07" />
+			<Property name="NormalisedValueOffWorld" value="5.76923242E-07" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_SAND1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_SAND1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="CATALYST1">
+			<Property name="Name" value="UI_WATER2_NAME" />
+			<Property name="NameLower" value="UI_WATER2_NAME_L" />
+			<Property name="ID" value="CATALYST1" />
+			<Property name="Symbol" value="UI_WATER2_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.CATALYST.1.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS1.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_CATALYST1_SUB" />
+			<Property name="Description" value="UI_CATALYST_1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.949019611" />
+				<Property name="G" value="0.427450985" />
+				<Property name="B" value="0.0823529437" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.56078434" />
+				<Property name="G" value="0.568627477" />
+				<Property name="B" value="0.580392182" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="41" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Catalyst" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="2" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="3.500000" />
+				<Property name="BuyMarkupMod" value="1.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="2.56410272E-06" />
+			<Property name="NormalisedValueOffWorld" value="2.56410272E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_CATALYST1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_CATALYST1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Sodium" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_CATALYST1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="CATALYST2">
+			<Property name="Name" value="UI_NEWCATA2_NAME" />
+			<Property name="NameLower" value="UI_NEWCATA2_NAME_L" />
+			<Property name="ID" value="CATALYST2" />
+			<Property name="Symbol" value="UI_NEWCATA2_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.CATALYST.2.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS1.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_CATALYST2_SUB" />
+			<Property name="Description" value="UI_CATALYST_2_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.949019611" />
+				<Property name="G" value="0.427450985" />
+				<Property name="B" value="0.0823529437" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.541176498" />
+				<Property name="G" value="0.498039216" />
+				<Property name="B" value="0.447058827" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="82" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Catalyst" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="5" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="3.500000" />
+				<Property name="BuyMarkupMod" value="1.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="5.19230798E-06" />
+			<Property name="NormalisedValueOffWorld" value="5.19230798E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_CATALYST2_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_CATALYST2_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="SodiumPlus" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_CATALYST2" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="true" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="CAVE1">
+			<Property name="Name" value="UI_CAVE1_NAME" />
+			<Property name="NameLower" value="UI_CAVE1_NAME_L" />
+			<Property name="ID" value="CAVE1" />
+			<Property name="Symbol" value="UI_CAVE1_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.CAVE.1.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TECHDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_CAVE1_SUB" />
+			<Property name="Description" value="UI_CAVE1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.000000" />
+				<Property name="G" value="0.360784322" />
+				<Property name="B" value="0.513725519" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.349019617" />
+				<Property name="G" value="0.607843161" />
+				<Property name="B" value="0.713725507" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="76" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Common" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="4.80769268E-06" />
+			<Property name="NormalisedValueOffWorld" value="4.80769268E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_CAVE1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_CAVE1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="CaveSubstance" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_CAVE1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="CAVE2">
+			<Property name="Name" value="UI_CAVE2_NAME" />
+			<Property name="NameLower" value="UI_CAVE2_NAME_L" />
+			<Property name="ID" value="CAVE2" />
+			<Property name="Symbol" value="UI_CAVE2_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.CAVE.2.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TECHDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_CAVE2_SUB" />
+			<Property name="Description" value="UI_CAVE2_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.000000" />
+				<Property name="G" value="0.360784322" />
+				<Property name="B" value="0.513725519" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.349019617" />
+				<Property name="G" value="0.607843161" />
+				<Property name="B" value="0.713725507" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="162" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="4" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="1.03205139E-05" />
+			<Property name="NormalisedValueOffWorld" value="1.03205139E-05" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_CAVE2_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_CAVE2_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="CaveSubstance" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_CAVE2" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="true" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="WATER1">
+			<Property name="Name" value="UI_WATER1_NAME" />
+			<Property name="NameLower" value="UI_WATER1_NAME_L" />
+			<Property name="ID" value="WATER1" />
+			<Property name="Symbol" value="UI_WATER1_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.WATER.1.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_WATER1_SUB" />
+			<Property name="Description" value="UI_WATER1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.117647059" />
+				<Property name="G" value="0.541176498" />
+				<Property name="B" value="0.258823544" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.117647059" />
+				<Property name="G" value="0.541176498" />
+				<Property name="B" value="0.258823544" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="101" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Common" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="6.4102569E-06" />
+			<Property name="NormalisedValueOffWorld" value="6.4102569E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_WATER1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_WATER1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_WATER1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="true" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="WATER2">
+			<Property name="Name" value="UI_NEWWATER2_NAME" />
+			<Property name="NameLower" value="UI_NEWWATER2_NAME_L" />
+			<Property name="ID" value="WATER2" />
+			<Property name="Symbol" value="UI_NEWWATER2_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.WATER.2.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_WATER2_SUB" />
+			<Property name="Description" value="UI_WATER2_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.117647059" />
+				<Property name="G" value="0.541176498" />
+				<Property name="B" value="0.258823544" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.117647059" />
+				<Property name="G" value="0.541176498" />
+				<Property name="B" value="0.258823544" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="205" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="2" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="1.3076924E-05" />
+			<Property name="NormalisedValueOffWorld" value="1.3076924E-05" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_WATER2_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_WATER2_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_WATER2" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="true" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="WATERPLANT">
+			<Property name="Name" value="UI_WATERPLANT_NAME" />
+			<Property name="NameLower" value="UI_WATERPLANT_NAME_L" />
+			<Property name="ID" value="WATERPLANT" />
+			<Property name="Symbol" value="UI_WATERPLANT_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.WATER.PLANT.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_WATERPLANT_SUB" />
+			<Property name="Description" value="UI_WATERPLANT_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.117647059" />
+				<Property name="G" value="0.541176498" />
+				<Property name="B" value="0.258823544" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.117647059" />
+				<Property name="G" value="0.541176498" />
+				<Property name="B" value="0.258823544" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="201" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="2" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="1.28205138E-05" />
+			<Property name="NormalisedValueOffWorld" value="1.28205138E-05" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_WATERPLANT_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_WATERPLANT_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_WATERPLANT" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="STELLAR2">
+			<Property name="Name" value="UI_STELLAR2_NAME" />
+			<Property name="NameLower" value="UI_STELLAR2_NAME_L" />
+			<Property name="ID" value="STELLAR2" />
+			<Property name="Symbol" value="UI_STELLAR_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.STELLAR.2.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_STELLAR_SUB" />
+			<Property name="Description" value="UI_STELLAR2_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.149019614" />
+				<Property name="G" value="0.000000" />
+				<Property name="B" value="0.000000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.149019614" />
+				<Property name="G" value="0.000000" />
+				<Property name="B" value="0.000000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="88" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="2" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="5.57692329E-06" />
+			<Property name="NormalisedValueOffWorld" value="5.57692329E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_STELLAR2_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_STELLAR2_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Terrain" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_STELLAR2" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="true" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="true" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="LUSH1">
+			<Property name="Name" value="UI_LUSH1_NAME" />
+			<Property name="NameLower" value="UI_LUSH1_NAME_L" />
+			<Property name="ID" value="LUSH1" />
+			<Property name="Symbol" value="UI_LUSH_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.BIOME.LUSH.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS2.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_BIOME_SUB" />
+			<Property name="Description" value="UI_LUSH1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.305882365" />
+				<Property name="G" value="0.250980407" />
+				<Property name="B" value="0.309803933" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.305882365" />
+				<Property name="G" value="0.250980407" />
+				<Property name="B" value="0.309803933" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="62" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="5" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="3.91025651E-06" />
+			<Property name="NormalisedValueOffWorld" value="3.91025651E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_LUSH1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_LUSH1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Terrain" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_LUSH1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="DUSTY1">
+			<Property name="Name" value="UI_DUSTY1_NAME" />
+			<Property name="NameLower" value="UI_DUSTY1_NAME_L" />
+			<Property name="ID" value="DUSTY1" />
+			<Property name="Symbol" value="UI_DUSTY_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.BIOME.DUSTY.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS1.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_BIOME_SUB" />
+			<Property name="Description" value="UI_DUSTY1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.898039222" />
+				<Property name="G" value="0.43921569" />
+				<Property name="B" value="0.00784313772" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.882352948" />
+				<Property name="G" value="0.58431375" />
+				<Property name="B" value="0.113725491" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="62" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="5" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="3.91025651E-06" />
+			<Property name="NormalisedValueOffWorld" value="3.91025651E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_DUSTY1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_DUSTY1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Terrain" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_DUSTY1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="TOXIC1">
+			<Property name="Name" value="UI_TOXIC1_NAME" />
+			<Property name="NameLower" value="UI_TOXIC1_NAME_L" />
+			<Property name="ID" value="TOXIC1" />
+			<Property name="Symbol" value="UI_TOXIC_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.BIOME.TOXIC.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS3.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_BIOME_SUB" />
+			<Property name="Description" value="UI_TOXIC1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.000000" />
+				<Property name="G" value="0.650980413" />
+				<Property name="B" value="0.301960796" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.41568628" />
+				<Property name="G" value="0.815686285" />
+				<Property name="B" value="0.117647059" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="62" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="5" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="3.91025651E-06" />
+			<Property name="NormalisedValueOffWorld" value="3.91025651E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_TOXIC1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_TOXIC1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Terrain" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_TOXIC1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="RADIO1">
+			<Property name="Name" value="UI_RADIO1_NAME" />
+			<Property name="NameLower" value="UI_RADIO1_NAME_L" />
+			<Property name="ID" value="RADIO1" />
+			<Property name="Symbol" value="UI_RADIO_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.BIOME.RADIO.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS1.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_BIOME_SUB" />
+			<Property name="Description" value="UI_RADIO1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="1.000000" />
+				<Property name="G" value="0.678431392" />
+				<Property name="B" value="0.000000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="1.000000" />
+				<Property name="G" value="0.678431392" />
+				<Property name="B" value="0.000000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="62" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="5" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="4.500000" />
+				<Property name="BuyMarkupMod" value="1.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="3.91025651E-06" />
+			<Property name="NormalisedValueOffWorld" value="3.91025651E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_RADIO1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_RADIO1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Terrain" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_RADIO1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="COLD1">
+			<Property name="Name" value="UI_COLD1_NAME" />
+			<Property name="NameLower" value="UI_COLD1_NAME_L" />
+			<Property name="ID" value="COLD1" />
+			<Property name="Symbol" value="UI_COLD_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.BIOME.COLD.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TECHDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_BIOME_SUB" />
+			<Property name="Description" value="UI_COLD1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.117647059" />
+				<Property name="G" value="0.309803933" />
+				<Property name="B" value="0.815686285" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.117647059" />
+				<Property name="G" value="0.576470613" />
+				<Property name="B" value="0.815686285" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="62" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="5" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="3.91025651E-06" />
+			<Property name="NormalisedValueOffWorld" value="3.91025651E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_COLD1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_COLD1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Terrain" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_COLD1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="HOT1">
+			<Property name="Name" value="UI_HOT1_NAME" />
+			<Property name="NameLower" value="UI_HOT1_NAME_L" />
+			<Property name="ID" value="HOT1" />
+			<Property name="Symbol" value="UI_HOT_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.BIOME.HOT.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/RESOURCEDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_BIOME_SUB" />
+			<Property name="Description" value="UI_HOT1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.858823538" />
+				<Property name="G" value="0.141176477" />
+				<Property name="B" value="0.000000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.858823538" />
+				<Property name="G" value="0.141176477" />
+				<Property name="B" value="0.000000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="62" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="5" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="3.91025651E-06" />
+			<Property name="NormalisedValueOffWorld" value="3.91025651E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_HOT1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_HOT1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Terrain" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_HOT1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="WATERWORLD1">
+			<Property name="Name" value="UI_WATERWORLD1_NAME" />
+			<Property name="NameLower" value="UI_WATERWORLD1_NAME_L" />
+			<Property name="ID" value="WATERWORLD1" />
+			<Property name="Symbol" value="UI_WATERWORLD1_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.BIOME.WATERWORLD.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/RESOURCEDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_BIOME_SUB" />
+			<Property name="Description" value="UI_WATERWORLD1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.101960786" />
+				<Property name="G" value="0.152941182" />
+				<Property name="B" value="0.200000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.101960786" />
+				<Property name="G" value="0.152941182" />
+				<Property name="B" value="0.200000" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="72" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="5" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="4.55128247E-06" />
+			<Property name="NormalisedValueOffWorld" value="4.55128247E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_WATERWORLD1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_WATERWORLD1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Terrain" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_WWORLD1" />
+			<Property name="OnlyFoundInPurpleSytems" value="true" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="GASGIANT1">
+			<Property name="Name" value="UI_GASGIANT1_NAME" />
+			<Property name="NameLower" value="UI_GASGIANT1_NAME_L" />
+			<Property name="ID" value="GASGIANT1" />
+			<Property name="Symbol" value="UI_GASGIANT1_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.BIOME.GASGIANT.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/RESOURCEDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_BIOME_SUB" />
+			<Property name="Description" value="UI_GASGIANT1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.117647059" />
+				<Property name="G" value="0.309803933" />
+				<Property name="B" value="0.815686285" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.117647059" />
+				<Property name="G" value="0.576470613" />
+				<Property name="B" value="0.815686285" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="82" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="5" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="5.19230798E-06" />
+			<Property name="NormalisedValueOffWorld" value="5.19230798E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_GASGIANT1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_GASGIANT1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Terrain" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_GASGIANT1" />
+			<Property name="OnlyFoundInPurpleSytems" value="true" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="CREATURE1">
+			<Property name="Name" value="UI_PLANTSUB_DEADCREATURE_NAME" />
+			<Property name="NameLower" value="UI_PLANTSUB_DEADCREATURE_NAME_L" />
+			<Property name="ID" value="CREATURE1" />
+			<Property name="Symbol" value="UI_PLANTSUB_DEADCREATURE_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.CREATURE.1.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/RESOURCEDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_HARVESTED_SUB" />
+			<Property name="Description" value="UI_PLANTSUB_DEADCREATURE_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.31764707" />
+				<Property name="G" value="0.152941182" />
+				<Property name="B" value="0.254901975" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.713725507" />
+				<Property name="G" value="0.349019617" />
+				<Property name="B" value="0.572549045" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="40" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Common" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="2.50000016E-06" />
+			<Property name="NormalisedValueOffWorld" value="2.50000016E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_CREATURE1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_CREATURE1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_CREATURE1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="true" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="ROBOT1">
+			<Property name="Name" value="SUB_DEADDRONE_NAME" />
+			<Property name="NameLower" value="SUB_DEADDRONE_NAME_L" />
+			<Property name="ID" value="ROBOT1" />
+			<Property name="Symbol" value="SUB_DEADDRONE_SYMBOL" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.ROBOT.1.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TECHDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="SUB_DEADDRONE_SUBTITLE" />
+			<Property name="Description" value="SUB_DEADDRONE_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.301960796" />
+				<Property name="G" value="0.160784319" />
+				<Property name="B" value="0.34117648" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.549019635" />
+				<Property name="G" value="0.294117659" />
+				<Property name="B" value="0.623529434" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="138" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="8.78205174E-06" />
+			<Property name="NormalisedValueOffWorld" value="8.78205174E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_ROBOT1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_ROBOT1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_ROBOT1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="ASTEROID1">
+			<Property name="Name" value="UI_ASTEROID1_NAME" />
+			<Property name="NameLower" value="UI_ASTEROID1_NAME_L" />
+			<Property name="ID" value="ASTEROID1" />
+			<Property name="Symbol" value="UI_ASTERIOID1_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.ASTEROID.1.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS2.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_ASTERIOID_SUB" />
+			<Property name="Description" value="UI_ASTEROID1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.541176498" />
+				<Property name="G" value="0.498039216" />
+				<Property name="B" value="0.447058827" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.541176498" />
+				<Property name="G" value="0.498039216" />
+				<Property name="B" value="0.447058827" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="186" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Exotic" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Common" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="1.18589751E-05" />
+			<Property name="NormalisedValueOffWorld" value="1.18589751E-05" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_ASTEROID1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_ASTEROID1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_ASTEROID1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="true" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="ASTEROID2">
+			<Property name="Name" value="UI_ASTEROID2_NAME" />
+			<Property name="NameLower" value="UI_ASTEROID2_NAME_L" />
+			<Property name="ID" value="ASTEROID2" />
+			<Property name="Symbol" value="UI_ASTERIOID2_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.ASTEROID.2.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS1.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_ASTERIOID_SUB" />
+			<Property name="Description" value="UI_ASTEROID2_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.666666687" />
+				<Property name="G" value="0.431372553" />
+				<Property name="B" value="0.0235294122" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.666666687" />
+				<Property name="G" value="0.431372553" />
+				<Property name="B" value="0.0235294122" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="353" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Exotic" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="2" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="2.25641033E-05" />
+			<Property name="NormalisedValueOffWorld" value="2.25641033E-05" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_ASTEROID2_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_ASTEROID2_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_ASTEROID2" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="true" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="ASTEROID3">
+			<Property name="Name" value="UI_ASTEROID3_NAME" />
+			<Property name="NameLower" value="UI_ASTEROID3_NAME_L" />
+			<Property name="ID" value="ASTEROID3" />
+			<Property name="Symbol" value="UI_ASTERIOID3_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.ASTEROID.3.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS2.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_ASTERIOID_SUB" />
+			<Property name="Description" value="UI_ASTEROID3_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.313725501" />
+				<Property name="G" value="0.458823532" />
+				<Property name="B" value="0.458823532" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.313725501" />
+				<Property name="G" value="0.458823532" />
+				<Property name="B" value="0.458823532" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="505" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Exotic" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="3" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="3.23076929E-05" />
+			<Property name="NormalisedValueOffWorld" value="3.23076929E-05" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_REFINE_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_ASTEROID3_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_ASTEROID3_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_ASTEROID3" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="true" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="GAS1">
+			<Property name="Name" value="UI_GAS_1_NAME" />
+			<Property name="NameLower" value="UI_GAS_1_NAME_L" />
+			<Property name="ID" value="GAS1" />
+			<Property name="Symbol" value="UI_GAS_1_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/GAS.3.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/RESOURCEDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_GAS_SUBTITLE" />
+			<Property name="Description" value="UI_GAS_1_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.149019614" />
+				<Property name="G" value="0.368627459" />
+				<Property name="B" value="0.227450982" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.149019614" />
+				<Property name="G" value="0.368627459" />
+				<Property name="B" value="0.227450982" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="20" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Common" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="1.21794881E-06" />
+			<Property name="NormalisedValueOffWorld" value="1.21794881E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_PROCESS_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_GAS1_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_GAS1_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_GAS1" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="GAS2">
+			<Property name="Name" value="UI_GAS_2_NAME" />
+			<Property name="NameLower" value="UI_GAS_2_NAME_L" />
+			<Property name="ID" value="GAS2" />
+			<Property name="Symbol" value="UI_GAS_2_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/GAS.2.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TECHDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_GAS_SUBTITLE" />
+			<Property name="Description" value="UI_GAS_2_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.298039228" />
+				<Property name="G" value="0.215686277" />
+				<Property name="B" value="0.501960814" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.298039228" />
+				<Property name="G" value="0.215686277" />
+				<Property name="B" value="0.501960814" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="20" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="1.21794881E-06" />
+			<Property name="NormalisedValueOffWorld" value="1.21794881E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_PROCESS_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_GAS2_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_GAS2_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_GAS2" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="GAS3">
+			<Property name="Name" value="UI_GAS_3_NAME" />
+			<Property name="NameLower" value="UI_GAS_3_NAME_L" />
+			<Property name="ID" value="GAS3" />
+			<Property name="Symbol" value="UI_GAS_3_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/GAS.1.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS1.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_GAS_SUBTITLE" />
+			<Property name="Description" value="UI_GAS_3_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.870588243" />
+				<Property name="G" value="0.572549045" />
+				<Property name="B" value="0.121568628" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.870588243" />
+				<Property name="G" value="0.572549045" />
+				<Property name="B" value="0.121568628" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="20" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="1.21794881E-06" />
+			<Property name="NormalisedValueOffWorld" value="1.21794881E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_PROCESS_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_GAS3_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_GAS3_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_GAS3" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="GAS4">
+			<Property name="Name" value="UI_GAS_4_NAME" />
+			<Property name="NameLower" value="UI_GAS_4_NAME_L" />
+			<Property name="ID" value="GAS4" />
+			<Property name="Symbol" value="UI_GAS_4_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/GAS.4.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS1.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_GAS_SUBTITLE" />
+			<Property name="Description" value="UI_GAS_4_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.00392156886" />
+				<Property name="G" value="0.219607845" />
+				<Property name="B" value="0.490196079" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.117647059" />
+				<Property name="G" value="0.639215708" />
+				<Property name="B" value="0.933333337" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="35" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Earth" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="2.17948741E-06" />
+			<Property name="NormalisedValueOffWorld" value="2.17948741E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_PROCESS_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_GAS4_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_GAS4_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_GAS4" />
+			<Property name="OnlyFoundInPurpleSytems" value="true" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="EX_PURPLE">
+			<Property name="Name" value="UI_EX_PURPLE_NAME" />
+			<Property name="NameLower" value="UI_EX_PURPLE_NAME_L" />
+			<Property name="ID" value="EX_PURPLE" />
+			<Property name="Symbol" value="UI_PURPLE2_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.EXPURPLE.2.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TECHDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_PURPLE2_SUB" />
+			<Property name="Description" value="UI_EX_PURPLE_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.301960796" />
+				<Property name="G" value="0.160784319" />
+				<Property name="B" value="0.34117648" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.549019635" />
+				<Property name="G" value="0.294117659" />
+				<Property name="B" value="0.623529434" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="165" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Stellar" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="5" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="1.05128211E-05" />
+			<Property name="NormalisedValueOffWorld" value="1.05128211E-05" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_EX_PURPLE_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_EX_PURPLE_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="Terrain" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_EX_PURPLE" />
+			<Property name="OnlyFoundInPurpleSytems" value="true" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="true" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="PLANT_SNOW">
+			<Property name="Name" value="UI_PLANTSUB_SNOW_NAME" />
+			<Property name="NameLower" value="UI_PLANTSUB_SNOW_NAME_L" />
+			<Property name="ID" value="PLANT_SNOW" />
+			<Property name="Symbol" value="UI_PLANTSUB_SNOW_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.PLANT.SNOW.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TECHDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_PLANTSUB_SUBTITLE" />
+			<Property name="Description" value="UI_PLANTSUB_SNOW_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.117647059" />
+				<Property name="G" value="0.309803933" />
+				<Property name="B" value="0.815686285" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.117647059" />
+				<Property name="G" value="0.576470613" />
+				<Property name="B" value="0.815686285" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="12" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Flora" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="7.0512823E-07" />
+			<Property name="NormalisedValueOffWorld" value="7.0512823E-07" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_PLANT_SNOW_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_PLANT_SNOW_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="HarvestPlant" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_PLANT_COLD" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="true" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="PLANT_RADIO">
+			<Property name="Name" value="UI_PLANTSUB_RADIO_NAME" />
+			<Property name="NameLower" value="UI_PLANTSUB_RADIO_NAME_L" />
+			<Property name="ID" value="PLANT_RADIO" />
+			<Property name="Symbol" value="UI_PLANTSUB_RADIO_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.PLANT.RADIO.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS1.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_PLANTSUB_SUBTITLE" />
+			<Property name="Description" value="UI_PLANTSUB_RADIO_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.772549033" />
+				<Property name="G" value="0.529411793" />
+				<Property name="B" value="0.113725491" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.78039217" />
+				<Property name="G" value="0.725490212" />
+				<Property name="B" value="0.105882354" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="16" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Flora" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="9.6153849E-07" />
+			<Property name="NormalisedValueOffWorld" value="9.6153849E-07" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_PLANT_RADIO_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_PLANT_RADIO_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="HarvestPlant" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_PLANT_RAD" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="true" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="PLANT_DUST">
+			<Property name="Name" value="UI_PLANTSUB_BARREN_NAME" />
+			<Property name="NameLower" value="UI_PLANTSUB_BARREN_NAME_L" />
+			<Property name="ID" value="PLANT_DUST" />
+			<Property name="Symbol" value="UI_PLANTSUB_BARREN_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.PLANT.DUSTY.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS4.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_PLANTSUB_SUBTITLE" />
+			<Property name="Description" value="UI_PLANTSUB_BARREN_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.137254909" />
+				<Property name="G" value="0.588235319" />
+				<Property name="B" value="0.149019614" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.882352948" />
+				<Property name="G" value="0.58431375" />
+				<Property name="B" value="0.113725491" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="28" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Flora" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="1.73076933E-06" />
+			<Property name="NormalisedValueOffWorld" value="1.73076933E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_PLANT_DUST_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_PLANT_DUST_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="HarvestPlant" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_PLANT_DUST" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="true" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="PLANT_HOT">
+			<Property name="Name" value="UI_PLANTSUB_SCORCHED_NAME" />
+			<Property name="NameLower" value="UI_PLANTSUB_SCORCHED_NAME_L" />
+			<Property name="ID" value="PLANT_HOT" />
+			<Property name="Symbol" value="UI_PLANTSUB_SCORCHED_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.PLANT.HOT.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS1.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_PLANTSUB_SUBTITLE" />
+			<Property name="Description" value="UI_PLANTSUB_SCORCHED_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.725490212" />
+				<Property name="G" value="0.262745112" />
+				<Property name="B" value="0.0941176489" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.949019611" />
+				<Property name="G" value="0.427450985" />
+				<Property name="B" value="0.0823529437" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="70" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Flora" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="4.42307737E-06" />
+			<Property name="NormalisedValueOffWorld" value="4.42307737E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_PLANT_HOT_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_PLANT_HOT_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="HarvestPlant" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_PLANT_HOT" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="true" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="PLANT_LUSH">
+			<Property name="Name" value="UI_PLANTSUB_LUSH_NAME" />
+			<Property name="NameLower" value="UI_PLANTSUB_LUSH_NAME_L" />
+			<Property name="ID" value="PLANT_LUSH" />
+			<Property name="Symbol" value="UI_PLANTSUB_LUSH_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.PLANT.LUSH.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TECHDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_PLANTSUB_SUBTITLE" />
+			<Property name="Description" value="UI_PLANTSUB_LUSH_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.125490203" />
+				<Property name="G" value="0.552941203" />
+				<Property name="B" value="0.670588255" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.607843161" />
+				<Property name="G" value="0.823529422" />
+				<Property name="B" value="0.835294127" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="32" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Flora" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Rare" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="1.98717953E-06" />
+			<Property name="NormalisedValueOffWorld" value="1.98717953E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_PLANT_LUSH_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_PLANT_LUSH_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="HarvestPlant" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_PLANT_LUSH" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="true" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="PLANT_CAVE">
+			<Property name="Name" value="UI_PLANTSUB_CAVE_NAME" />
+			<Property name="NameLower" value="UI_PLANTSUB_CAVE_NAME_L" />
+			<Property name="ID" value="PLANT_CAVE" />
+			<Property name="Symbol" value="UI_PLANTSUB_CAVE_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.PLANT.CAVE.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/ROCKDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_PLANTSUB_SUBTITLE" />
+			<Property name="Description" value="UI_PLANTSUB_CAVE_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.356862754" />
+				<Property name="G" value="0.435294122" />
+				<Property name="B" value="0.20784314" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.588235319" />
+				<Property name="G" value="0.713725507" />
+				<Property name="B" value="0.349019617" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="41" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Flora" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="2.56410272E-06" />
+			<Property name="NormalisedValueOffWorld" value="2.56410272E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_PLANT_CAVE_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_PLANT_CAVE_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="HarvestPlant" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_PLANT_CAVE" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="true" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="PLANT_WATER">
+			<Property name="Name" value="UI_PLANTSUB_WATER_NAME" />
+			<Property name="NameLower" value="UI_PLANTSUB_WATER_NAME_L" />
+			<Property name="ID" value="PLANT_WATER" />
+			<Property name="Symbol" value="UI_PLANTSUB_WATER_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.PLANT.WATER.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TECHDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_PLANTSUB_SUBTITLE" />
+			<Property name="Description" value="UI_PLANTSUB_WATER_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.000000" />
+				<Property name="G" value="0.360784322" />
+				<Property name="B" value="0.513725519" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.349019617" />
+				<Property name="G" value="0.607843161" />
+				<Property name="B" value="0.713725507" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="41" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Flora" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="2.56410272E-06" />
+			<Property name="NormalisedValueOffWorld" value="2.56410272E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_PLANT_WATER_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_PLANT_WATER_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_PLANT_WET" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="true" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="PLANT_POOP">
+			<Property name="Name" value="UI_PLANTSUB_CREATUREPOOP_NAME" />
+			<Property name="NameLower" value="UI_PLANTSUB_CREATUREPOOP_NAME_L" />
+			<Property name="ID" value="PLANT_POOP" />
+			<Property name="Symbol" value="UI_PLANTSUB_CREATUREPOOP_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/U4SUBSTANCES/SUBSTANCE.PLANT.POOP.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/RESOURCEDEBRIS.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_PLANTSUB_SUBTITLE" />
+			<Property name="Description" value="UI_PLANTSUB_CREATUREPOOP_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.474509805" />
+				<Property name="G" value="0.313725501" />
+				<Property name="B" value="0.180392161" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.474509805" />
+				<Property name="G" value="0.313725501" />
+				<Property name="B" value="0.180392161" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="30" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Flora" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Common" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="1.85897443E-06" />
+			<Property name="NormalisedValueOffWorld" value="1.85897443E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_GATHER_OBJ" />
+			<Property name="PinObjectiveTip" value="UI_PIN_PLANT_POOP_OBJ_TIP" />
+			<Property name="PinObjectiveMessage" value="UI_PIN_PLANT_POOP_MSG" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="CreaturePoop" />
+			</Property>
+			<Property name="WikiMissionID" value="WIKI_PLANT_POOP" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="true" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+		<Property name="Table" value="GcRealitySubstanceData" _id="SPACEGUNK3">
+			<Property name="Name" value="UI_MAINTAIN_SUB3_NAME" />
+			<Property name="NameLower" value="UI_MAINTAIN_SUB3_NAME_L" />
+			<Property name="ID" value="SPACEGUNK3" />
+			<Property name="Symbol" value="UI_MAINTAIN_SUB_SYM" />
+			<Property name="Icon" value="TkTextureResource">
+				<Property name="Filename" value="TEXTURES/UI/FRONTEND/ICONS/UPDATE3/SPACEGUNK.3.DDS" />
+			</Property>
+			<Property name="DebrisFile" value="TkModelResource">
+				<Property name="Filename" value="MODELS/EFFECTS/DEBRIS/TERRAINDEBRIS/TERRAINDEBRIS3.SCENE.MBIN" />
+				<Property name="Seed" value="0" />
+			</Property>
+			<Property name="Subtitle" value="UI_MAINTAIN_SUB_SUB" />
+			<Property name="Description" value="UI_MAINTAIN_SUB3_DESC" />
+			<Property name="Colour">
+				<Property name="R" value="0.356862754" />
+				<Property name="G" value="0.435294122" />
+				<Property name="B" value="0.20784314" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="WorldColour">
+				<Property name="R" value="0.588235319" />
+				<Property name="G" value="0.713725507" />
+				<Property name="B" value="0.349019617" />
+				<Property name="A" value="1.000000" />
+			</Property>
+			<Property name="BaseValue" value="20" />
+			<Property name="Category" value="GcRealitySubstanceCategory">
+				<Property name="SubstanceCategory" value="Special" />
+			</Property>
+			<Property name="Rarity" value="GcRarity">
+				<Property name="Rarity" value="Uncommon" />
+			</Property>
+			<Property name="Legality" value="GcLegality">
+				<Property name="Legality" value="Legal" />
+			</Property>
+			<Property name="ChargeValue" value="1" />
+			<Property name="StackMultiplier" value="1" />
+			<Property name="Cost" value="GcItemPriceModifiers">
+				<Property name="SpaceStationMarkup" value="0.000000" />
+				<Property name="LowPriceMod" value="-0.100000" />
+				<Property name="HighPriceMod" value="0.100000" />
+				<Property name="BuyBaseMarkup" value="0.250000" />
+				<Property name="BuyMarkupMod" value="0.000000" />
+			</Property>
+			<Property name="NormalisedValueOnWorld" value="1.21794881E-06" />
+			<Property name="NormalisedValueOffWorld" value="1.21794881E-06" />
+			<Property name="TradeCategory" value="GcTradeCategory">
+				<Property name="TradeCategory" value="None" />
+			</Property>
+			<Property name="WikiEnabled" value="true" />
+			<Property name="EconomyInfluenceMultiplier" value="0.250000" />
+			<Property name="PinObjective" value="UI_FIND_OBJ" />
+			<Property name="PinObjectiveTip" value="" />
+			<Property name="PinObjectiveMessage" value="" />
+			<Property name="PinObjectiveScannableType" value="GcScannerIconTypes">
+				<Property name="ScanIconType" value="None" />
+			</Property>
+			<Property name="WikiMissionID" value="" />
+			<Property name="OnlyFoundInPurpleSytems" value="false" />
+			<Property name="CookingIngredient" value="false" />
+			<Property name="GoodForSelling" value="false" />
+			<Property name="EasyToRefine" value="false" />
+			<Property name="EggModifierIngredient" value="true" />
+		</Property>
+	</Property>
+</Data>

--- a/internal/normalize/unnamed.go
+++ b/internal/normalize/unnamed.go
@@ -1,0 +1,59 @@
+package normalize
+
+// Governing: SPEC-0004 REQ "Display Name Resolution", REQ "Search Boundaries
+// Are Recorded"
+//
+// A small number of products carry a NameLower key that no English
+// localisation table defines. Verified against NMS 5.97 by raw byte grep
+// across all sixteen English tables (nms_loc{1,4,5,6,7,8,9}_english,
+// nms_update3_english, and their usenglish counterparts): 18 of 2,144
+// products, and zero of 111 substances.
+//
+// SPEC-0004 forbids falling back to the raw key or the ID, because an
+// artifact full of UI_STARCHART_BUILDER_NAME_L loads cleanly and looks like
+// data. An enumerated allowlist is not that fallback: it is a reviewed,
+// finite set that a reader can check, and anything outside it still fails.
+//
+// Every entry here is unreferenced — no recipe and no product requirement
+// names any of them — so omitting them leaves the graph closed. That is
+// asserted at runtime rather than assumed, because it is the property that
+// makes omission safe and a game update could change it.
+//
+// The set is dominated by U_CR* crew/frigate items plus two apparently
+// unreleased entries. If a game update names them, they simply stop being
+// skipped; if it adds new unnamed items, generation fails and this list is
+// the place to record the decision.
+var knownUnnamed = map[string]string{
+	"CHART_BUILDER": "UI_STARCHART_BUILDER_NAME_L",
+	"WORLDSMB_SOUL": "UI_WORLDSMB_SOUL_NAME_L",
+	"U_CRFIGHT1":    "UT_CR_FIGHT_NAME_L",
+	"U_CRFIGHT2":    "UT_CR_FIGHT_NAME_L",
+	"U_CRFIGHT3":    "UT_CR_FIGHT_NAME_L",
+	"U_CRFIGHT4":    "UT_CR_FIGHT_NAME_L",
+	"U_CRMINE1":     "UT_CR_MINE_NAME_L",
+	"U_CRMINE2":     "UT_CR_MINE_NAME_L",
+	"U_CRMINE3":     "UT_CR_MINE_NAME_L",
+	"U_CRMINE4":     "UT_CR_MINE_NAME_L",
+	"U_CRSCI1":      "UT_CR_SCI_NAME_L",
+	"U_CRSCI2":      "UT_CR_SCI_NAME_L",
+	"U_CRSCI3":      "UT_CR_SCI_NAME_L",
+	"U_CRSCI4":      "UT_CR_SCI_NAME_L",
+	"U_CRTRADE1":    "UT_CR_TRADE_NAME_L",
+	"U_CRTRADE2":    "UT_CR_TRADE_NAME_L",
+	"U_CRTRADE3":    "UT_CR_TRADE_NAME_L",
+	"U_CRTRADE4":    "UT_CR_TRADE_NAME_L",
+}
+
+// skipUnnamed reports whether an item whose name key did not resolve is a
+// known-unnamed entry that may be omitted.
+//
+// The key must match too: an ID on the list whose key has changed is a
+// different situation — the game moved something — and must fail rather
+// than be silently skipped on the strength of a stale entry.
+func skipUnnamed(id, key string) bool {
+	want, ok := knownUnnamed[id]
+	return ok && want == key
+}
+
+// KnownUnnamedCount reports the size of the allowlist, for reporting.
+func KnownUnnamedCount() int { return len(knownUnnamed) }


### PR DESCRIPTION
## What

Implements #23 — the `items` and `recipes` half of the Tier 1 artifact, built from the product, substance and refiner tables with names resolved through the localisation join.

Against a real install this produces **2,237 items and 2,133 recipes** that assemble and validate as a single artifact.

## Decisions the source forced

| Question | Answer, and how it was established |
|---|---|
| Recipe ids for craft routes | The product's own ID. `AltRequirements` is present on every product row and **empty on all 2,144**, so there is exactly one craft route per product. A populated one now fails rather than silently colliding two routes onto one id. |
| Craft yields | `DefaultCraftAmount`. 2,143 products craft one at a time; exactly one (`AMMO`) crafts 25 — precisely the error a default would hide. |
| Refine/cook yields | `Result/Amount`. Up to 250. |
| Cook vs refine | The per-recipe `Cooking` flag, read rather than inferred. 1,323 of 1,681 refiner rows are cooking. |
| Self-referential recipes | Excluded and counted: **27**, seven of them producing `CATALYST2`. The count lands in `provenance.self_referential_recipes_omitted`, not omitempty, because a zero is a finding rather than an absence. |
| Alternatives | All emitted, none selected. 261 of 403 output/method pairs have more than one route, up to 61. |

## Verified numbers

Everything SPEC-0004 and ADR-0005 quote, checked against the real tables: 27 self-referential, 156 yields other than one, max yield 250, 403 output/method pairs with 261 carrying alternatives, 26 `CATALYST2` refine recipes defined (19 after exclusion), 18 unnamed products, `ULTRAPROD2` → "Stasis Device", and a 34-item craft closure matching the engine's hand-authored Stasis fixture.

## Tests

Fixtures under `internal/normalize/testdata/graph/` are **whole rows sliced from a real 6.45.0.1 decompilation** — `testdata/graph/gen.go` records which rows and why. Four seeds, each for a property that has to be exercised against real data: `ULTRAPROD2` (the 34-item craft closure), `CATALYST2` (26 refine routes, seven self-referential, and the `1x Crystal Sulphide → 50x Sodium Nitrate` yield), `FOOD_P_STELLAR` (so the `Cooking` flag has both values), `AMMO` (the one product that crafts 25).

A pass over a **whole decompiled install** is opt-in via `NMS_SOURCE_DIR`, following the pattern `internal/hgpak` already uses for `NMS_PCBANKS`:

```bash
NMS_SOURCE_DIR=/path/to/decompiled go test ./internal/normalize/ -run RealInstall -v
```

A fixture chosen by someone who already knew what the parser expects cannot show that the rest of the table holds no shape this code has never seen. That is the failure this project has recorded three times, and it is what the opt-in test exists to close. It found the finding below on its first run.

`go vet`, `staticcheck v0.8.0-rc.1`, `gofmt -l` all clean.

## Finding: the generated artifact does not resolve under default methods

**571 of 2,237 items hit a cycle**, all of them refine loops between gatherable substances — `CAVE1 ⇄ CAVE2`, `CATALYST1 ⇄ CATALYST2`, `GAS1 → GAS3 → GAS2 → GAS1`.

The cause is a gap in SPEC-0004, not a bug here. The spec derives raw-obtainability from the *absence* of a recipe, so a substance you gather with a mining beam **and** can refine comes out defaulting to `refine`. Refining runs both ways between several of those pairs.

The engine is right to refuse — SPEC-0001 REQ "Cycle Detection" calls this a runtime condition rather than one to assume away. What is missing is a source of truth for gatherability, and the substance table has one: **`PinObjective`**, which reads `UI_REFINE_OBJ` for the six substances that are refined only, and some flavour of gather/find/process for the other 105.

I measured it rather than assuming: marking raw-obtainability from `PinObjective` resolves **all 2,237 items with zero cycles**.

That is a modelling decision SPEC-0004 does not make, so it is **recorded, not invented in the normalizer**. The opt-in test asserts the cycle today with a comment saying why; when the spec is amended, that assertion changes with it. Suggested follow-up: amend SPEC-0004 REQ "Recipe Graph Construction" to derive `raw_obtainable` from `PinObjective`, and a story to implement it before #25's acceptance run.

Closes #23
Part of #21

Implements SPEC-0004 REQ "Recipe Graph Construction", REQ "Identifier Policy", REQ "Display Name Resolution", REQ "Excluded Content".

🤖 Generated with [Claude Code](https://claude.com/claude-code)