### PR TITLE
docs: amend SPEC-0004 for raw-obtainability and product crop rewards

### DIFF
--- a/docs/openspec/specs/tier1-normalizer/design.md
+++ b/docs/openspec/specs/tier1-normalizer/design.md
@@ -62,6 +62,20 @@ Four facts shape this design:
 
 **Rationale**: The artifact is committed. Nondeterministic ordering makes every regeneration an unreviewable diff, which means nobody reviews it, which means a real balance change lands unnoticed among reordering noise. Determinism is what keeps `git diff` meaningful as the review surface.
 
+### Refiner throughput carries both difficulty variants
+
+**Choice**: Emit the standard and Survival figures side by side rather than picking one.
+
+**Rationale**: This resolves what was an open question in this design. `gcgameplayglobals` states both (`RefinerSubsMadeInTime` 250 against 100 on Survival), the planner knows which save it is planning for and the normalizer does not, and carrying both costs four integers.
+
+### Crop yields are read from whichever reward shape the entry carries
+
+**Choice**: Read both `GcRewardSpecificSubstance` and `GcRewardSpecificProduct`, and take the yielded item from the reward's own `ID` rather than from the key the reward was looked up by.
+
+**Rationale**: Both were found by running the normalizer against the real reward table rather than by reading the requirement. Eight of twelve farmable plants yield a substance and four yield a product, so a spec naming only the substance form describes a normalizer that drops four crops and still produces a loadable artifact. Separately, the reward key and the yielded item agree for eleven of twelve crops — `PLANT_BARREN` yields `PLANT_DUST` — which is exactly the ratio that makes "the key is the item" look true.
+
+**Trade-off**: Neither generalisation is provable from twelve cases. Both are written as "read what the entry says" rather than as a rule about which plants use which shape, so a thirteenth crop in a future build needs no change here.
+
 ### Base-economy data as ranges, keyed by hotspot
 
 **Choice**: Preserve minimum and maximum where the source expresses a range, and attach class scaling to hotspot categories rather than to devices.
@@ -112,6 +126,16 @@ The four source groups are the reason the normalizer is not a single-table read.
 
 **Trade-off**: A larger artifact. 2,159 recipes rather than roughly 400 if deduplicated. Acceptable: it is a static asset, and the alternative discards most of refining.
 
+### Raw-obtainability is a fact about the item, not a fact about the recipe table
+
+**Choice**: Read `raw_obtainable` from the substance table's `PinObjective`, and let a raw-obtainable item default to `raw` even where it also has recipes.
+
+**Rationale**: The first version of this spec derived raw-obtainability from the absence of a recipe, which quietly assumed the two are exclusive. They are not — you mine Cobalt and you can refine it — and the assumption produced a graph that does not resolve: 571 of 2,237 items hit a cycle under default methods, every one of them a refine loop between gatherable substances. The engine is right to refuse; SPEC-0001 REQ "Cycle Detection" treats cycles as a runtime condition rather than one to design away. The fix belongs in the producer, and the source states the fact directly rather than requiring it to be inferred.
+
+Measured rather than assumed: setting `raw_obtainable` from `PinObjective != UI_REFINE_OBJ` resolves all 2,237 items with no cycles.
+
+**Trade-off**: The rule is a small allow/deny list over an enum this project has seen exactly one build of, so a game update that adds a `PinObjective` value will fail generation rather than classify it. That is the intended direction — the alternative is a default that silently reclassifies items — but it does mean this is a place an update can break, and it is named in the risks below.
+
 ### Cooking is a flag, not a table
 
 **Choice**: Read `Cooking` from each refiner recipe rather than treating cooking as a separate source.
@@ -123,6 +147,7 @@ The four source groups are the reason the normalizer is not a single-table read.
 - **A game update moves a field.** Likely eventually. Mitigated by failing closed with a named error, so the next update presents as a precise failure rather than corrupt output.
 - **MBINCompiler lags the game.** ADR-0001 already records this. The normalizer inherits it and can do nothing about it beyond failing clearly.
 - **The schema extension is a wide change.** `DisallowUnknownFields` forces producer, schema, loader, and fixtures to move together. Split the stories by data section, not by layer.
+- **`PinObjective` is an enum read from one build.** Gatherability now depends on it, and a value NMS 5.97 does not contain will fail generation. Deliberate — the alternative silently reclassifies an item — but it is a new way for a game update to stop the pipeline.
 - **Localisation coverage may be incomplete for some items.** Failing on an unresolved key is deliberate, but if the tables genuinely omit names for some obscure items it becomes a hard blocker. If that happens the right answer is an explicit allowlist of known-unnamed IDs, not a silent fallback.
 - **Everything here was verified against one build.** NMS 5.97, paks spanning 2026-05-04 to 2026-06-16. Every structural claim in the spec names the table it came from so a future reader can tell measurement from assumption.
 
@@ -139,6 +164,5 @@ The hand-authored fixtures stay after step 2, as golden files rather than as the
 ## Open Questions
 
 - Should the artifact be one file or split per section? One file is simpler and matches `LoadTier1` today; splitting would make `git diff` narrower when only economy data changes.
-- Refiner throughput is difficulty-dependent (`RefinerSubsMadeInTime` 250 versus 100 on Survival). Does the artifact carry both and let the planner choose, or does the planner assume Normal?
 - Is there a stable machine-readable game version in the install, or does `game_version` have to be derived from pak timestamps and the executable's version string?
 - Biodome crop-slot count is reported as 16 by the community wiki and is not in any table searched. Is it geometric — snap points in the scene — and therefore extractable after all, or genuinely Tier 2?

--- a/docs/openspec/specs/tier1-normalizer/spec.md
+++ b/docs/openspec/specs/tier1-normalizer/spec.md
@@ -61,6 +61,14 @@ Every `Input.item` and every `Recipe.output` MUST reference an `Item.id` present
 
 Items with no recipe MUST be emitted with `raw_obtainable` true and `default_method` `raw`, so the rollup engine's terminal-node handling has the leaves it expects.
 
+**Raw-obtainability MUST be read from the source, not inferred from the absence of a recipe.** Having a recipe and being gatherable are independent: you mine Cobalt with a terrain manipulator *and* you can refine it. Deriving `raw_obtainable` from "has no recipe" therefore marks every gatherable substance as non-raw the moment the game gives it a refine route, and the item defaults to `refine`. Because refining runs both ways between several such pairs — `CAVE1 ⇄ CAVE2`, `CATALYST1 ⇄ CATALYST2`, `GAS1 → GAS3 → GAS2 → GAS1` — the resulting graph is not resolvable: 571 of 2,237 items hit a cycle under pure defaults.
+
+The substance table states gatherability in `PinObjective`, the pinned objective shown for the item. Six substances read `UI_REFINE_OBJ` and are refined only; the other 105 read some flavour of gather, find or process. The normalizer MUST set `raw_obtainable` true for every substance whose `PinObjective` is not `UI_REFINE_OBJ`, and MUST fail rather than guess where the field is absent or holds a value that list does not cover.
+
+The product table carries no equivalent field, so a product that has a recipe MUST NOT be marked raw-obtainable. A product with no recipe still is, by the rule above — that is what gives the engine a leaf rather than an item it cannot terminate on.
+
+A raw-obtainable item MUST default to `raw` even where it also has recipes. Gathering is the route a player takes by default, expanding it is what produces the cycles above, and the engine's per-node method override exists precisely so a player who wants the refine route can take it.
+
 **Every recipe the source defines MUST be emitted.** Per ADR-0005 the artifact carries a list of recipes per output and method, not one: 261 of 403 refiner output/method pairs have more than one route, up to 61 for a single item. The normalizer MUST NOT select, deduplicate, or otherwise discard alternatives — selection is the engine's job and depends on expansion the normalizer does not perform.
 
 **Each recipe's yield MUST be read from the source.** 156 of 1,681 refiner recipes produce a quantity other than one, up to 250. A yield MUST NOT default silently to one; where the source does not state it, generation MUST fail rather than assume.
@@ -73,6 +81,21 @@ Items with no recipe MUST be emitted with `raw_obtainable` true and `default_met
 
 - **WHEN** the source defines 26 refine recipes producing `CATALYST2`
 - **THEN** the artifact carries all 26, and the normalizer selects none of them
+#### Scenario: Gatherability comes from the source
+
+- **WHEN** a substance's `PinObjective` is `UI_GATHER_REFINE_OBJ` and the table also defines refine recipes for it
+- **THEN** it is emitted `raw_obtainable` true with `default_method` `raw`, and its refine recipes are emitted alongside
+
+#### Scenario: A refine-only substance is not raw
+
+- **WHEN** a substance's `PinObjective` is `UI_REFINE_OBJ`
+- **THEN** it is emitted `raw_obtainable` false, defaulting to `refine`
+
+#### Scenario: The generated graph resolves
+
+- **WHEN** the rollup engine resolves each item in a generated artifact under default methods
+- **THEN** every item resolves, and none reports a cycle
+
 
 #### Scenario: Yields survive
 
@@ -144,13 +167,17 @@ The artifact MUST carry the base-economy values confirmed extractable on 2026-08
 
 - Per-part production and consumption **rates** and **storage** buffers, from `GcBaseLinkGridData`, together with the network each applies to and any dependent-connection rate
 - **Hotspot class strengths and weightings** for C/B/A/S per hotspot category, from `REGIONHOTSPOTSTABLE`
-- **Crop yields**, from the reward table's `GcRewardSpecificSubstance` minimum and maximum amounts
+- **Crop yields**, from the reward table's minimum and maximum amounts — under `GcRewardSpecificSubstance` or `GcRewardSpecificProduct`, whichever the entry carries
 - **Crop growth times**, from the plant's `PlantGrowth` connection storage value
 - **Refiner throughput**, from `gcgameplayglobals`, including the difficulty variants
 
 Class scaling MUST be modelled as a property of the hotspot, not of the device. A part declares a base rate and a hotspot dependency; the class belongs to the hotspot. The normalizer MUST NOT emit per-class device variants, which do not exist in the source data.
 
 Yields and class strengths that the source expresses as a minimum and a maximum MUST be preserved as a range. Collapsing a range to a single value discards information the planner needs to show best and worst case.
+
+**A crop's reward may be a product rather than a substance.** Eight of the twelve farmable plants hand back a substance under `GcRewardSpecificSubstance`; the other four — venom sacs, gravitino balls, nip-nip buds and albumen pearls — hand back a product under `GcRewardSpecificProduct`, which carries an identical `AmountMin`/`AmountMax` shape. The normalizer MUST read both forms. Reading only the substance form silently drops four of twelve crops, which is a smaller artifact that still loads.
+
+**A crop's reward key is not its substance.** The reward table is keyed by the plant's interaction id, and the item it yields is named inside the entry: `PLANT_BARREN` yields `PLANT_DUST`. The normalizer MUST take the yielded item from the reward's own `ID` rather than from the key it looked the reward up by. The two agree for eleven of twelve crops, which is what makes assuming they always agree dangerous.
 
 #### Scenario: Rates carry their network
 
@@ -166,6 +193,16 @@ Yields and class strengths that the source expresses as a minimum and a maximum 
 
 - **WHEN** a crop yield is expressed as a minimum and maximum in the source
 - **THEN** both bounds are emitted, rather than one derived value
+
+#### Scenario: A crop yielding a product is emitted
+
+- **WHEN** a plant's reward entry carries `GcRewardSpecificProduct` rather than `GcRewardSpecificSubstance`
+- **THEN** the crop is emitted with that product as its yielded item, rather than omitted
+
+#### Scenario: The yielded item comes from the reward, not the key
+
+- **WHEN** a plant's reward entry is keyed `PLANT_BARREN` and names `PLANT_DUST` inside
+- **THEN** the emitted crop yields `PLANT_DUST`
 
 ### Requirement: Schema Extension and Load Compatibility
 

--- a/internal/normalize/economy.go
+++ b/internal/normalize/economy.go
@@ -440,9 +440,9 @@ func readCrops(root string, rows []node) ([]domain.Crop, []domain.Search, error)
 		"by their PlantGrowth connection, resolved to a reward key through the flora entity "+
 		"their placement scene names, and to a substance and amount through the reward table. "+
 		"The reward key and the substance are not always the same — PLANT_BARREN yields "+
-		"PLANT_DUST. Five of the twelve yield a product rather than a substance, under "+
-		"GcRewardSpecificProduct; SPEC-0004 names only GcRewardSpecificSubstance, so both "+
-		"forms are read. Wild-harvest entries (WILD_*) were not read: they are not farmed.",
+		"PLANT_DUST. Four of the twelve yield a product rather than a substance, under "+
+		"GcRewardSpecificProduct, so both reward forms are read. Wild-harvest entries "+
+		"(WILD_*) were not read: they are not farmed.",
 		len(crops))
 	if len(containers) > 0 {
 		note += fmt.Sprintf(" Buildables on the growth network with no flora entity are carried "+
@@ -508,13 +508,11 @@ type reward struct {
 
 // rewardKinds are the reward shapes a farmable plant can hand back.
 //
-// SPEC-0004 names only GcRewardSpecificSubstance. Against the real table
-// that covers seven of the twelve farmable plants: the other five —
-// venom sacs, gravitino balls, nip-nip buds, albumen pearls and creature
-// pellets — yield a *product*, under GcRewardSpecificProduct with an
-// identical Amount shape. Reading only the substance form would have
-// dropped them silently, so both are read and the divergence is recorded
-// on the crop search note.
+// Against the real table the substance form covers eight of the twelve
+// farmable plants: the other four — venom sacs, gravitino balls, nip-nip
+// buds and albumen pearls — yield a *product*, under
+// GcRewardSpecificProduct with an identical Amount shape. Reading only the
+// substance form would have dropped them silently, so both are read.
 var rewardKinds = []string{"GcRewardSpecificSubstance", "GcRewardSpecificProduct"}
 
 // readRewards indexes the reward table by entry id.


### PR DESCRIPTION
## What

Two amendments to SPEC-0004, both for things the real tables do that the spec's wording did not cover. Both were found by running the normalizer against a whole install rather than against a fixture — which is what the opt-in `NMS_SOURCE_DIR` pass in #32 exists to do.

No behaviour change. One factual correction to a comment and an emitted note, explained below.

## 1. Raw-obtainability MUST be read from the source

REQ "Recipe Graph Construction" derived `raw_obtainable` from the *absence* of a recipe. That assumes gathering and refining are exclusive. They are not — you mine Cobalt with a terrain manipulator **and** you can refine it — so every gatherable substance came out non-raw the moment the game gave it a refine route, and defaulted to `refine`.

Refining runs both ways between several such pairs (`CAVE1 ⇄ CAVE2`, `CATALYST1 ⇄ CATALYST2`, `GAS1 → GAS3 → GAS2 → GAS1`), so **571 of 2,237 items hit a cycle under pure defaults**. The engine is right to refuse — SPEC-0001 REQ "Cycle Detection" treats cycles as a runtime condition rather than one to design away — so the fix belongs in the producer.

The substance table states the fact directly in **`PinObjective`**: six substances read `UI_REFINE_OBJ` and are refined only; the other 105 read some flavour of gather, find or process. Measured rather than assumed: setting `raw_obtainable` from `PinObjective != UI_REFINE_OBJ` resolves **all 2,237 items with zero cycles**.

The requirement now also says what to do at the edges, because they are where a rule like this goes wrong:

- A **substance** whose `PinObjective` is absent or holds a value the list does not cover → **fail**, do not guess.
- A **product** that has a recipe → not raw-obtainable; the product table carries no equivalent field.
- A **product with no recipe** → still raw-obtainable, by the existing rule. That is what gives the engine a leaf rather than an item it cannot terminate on.
- A raw-obtainable item → defaults to `raw` even where it also has recipes, with the engine's per-node override there for players who want the refine route.

Three scenarios added, including the one that would have caught this: resolving every item in a generated artifact under default methods reports no cycle.

## 2. Crop yields come in two reward shapes

REQ "Base Economy Data" named only `GcRewardSpecificSubstance`. **Four of the twelve** farmable plants yield a *product* instead, under `GcRewardSpecificProduct` with an identical `AmountMin`/`AmountMax` shape. Reading one form drops four crops and still produces an artifact that loads.

Separately: **the reward key is not the yielded item.** The table is keyed by the plant's interaction id and names the item inside the entry — `PLANT_BARREN` yields `PLANT_DUST`. The two agree for eleven of twelve crops, which is exactly the ratio that makes the wrong rule look right.

Two scenarios added for each.

## Also

- Design entries recording why gatherability is a fact about the item rather than about the recipe table, and why both reward shapes are read — including what neither generalisation proves from twelve cases.
- A new risk: `PinObjective` is an enum read from one build, so a value NMS 5.97 does not contain now fails generation. Deliberate, but it is a new way for a game update to stop the pipeline.
- Resolves the design's open question on refiner difficulty variants — the artifact carries both, which #24 already implements.

## The one code change

#24's comment and its emitted search note said *five* of twelve crops yield a product. It is **four** — creature pellets (`CREATURE1`) are a substance, and I miscounted when writing that PR. Nothing read or emitted changes, because both reward forms were already read; but the note ships **inside the artifact**, so the count is corrected here alongside the spec text it came from rather than left to drift.

## What this does not do

Neither amendment is implemented. `PinObjective` needs a story before #25's acceptance run — #32's opt-in test asserts the cycle today with a comment saying why, so that assertion changes when the implementation lands.

Part of #21

Amends SPEC-0004 REQ "Recipe Graph Construction", REQ "Base Economy Data".

🤖 Generated with [Claude Code](https://claude.com/claude-code)