### PR TITLE
docs: sync ADR and spec statuses with what is actually built

### DIFF
--- a/docs/adrs/ADR-0005-multiple-recipes-per-output.md
+++ b/docs/adrs/ADR-0005-multiple-recipes-per-output.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-08-18
 decision-makers: [Jon Stump]
 extends: [ADR-0001]

--- a/docs/openspec/specs/hgpak-reader/spec.md
+++ b/docs/openspec/specs/hgpak-reader/spec.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: implemented
 date: 2026-08-17
 implements: [ADR-0001]
 supersedes-implementation: [internal/psarc]

--- a/docs/openspec/specs/rollup-engine/spec.md
+++ b/docs/openspec/specs/rollup-engine/spec.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: approved
 date: 2026-08-17
 implements: [ADR-0001, ADR-0003]
 ---

--- a/docs/openspec/specs/tier1-normalizer/spec.md
+++ b/docs/openspec/specs/tier1-normalizer/spec.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: approved
 date: 2026-08-18
 implements: [ADR-0001]
 requires: [SPEC-0001, SPEC-0003]

--- a/docs/openspec/specs/wasm-boundary/spec.md
+++ b/docs/openspec/specs/wasm-boundary/spec.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: approved
 date: 2026-08-18
 implements: [ADR-0003, ADR-0004]
 requires: [SPEC-0001]


### PR DESCRIPTION
Every artifact still carried its authoring-time status, so the metadata actively misrepresented the project — three specs describing merged and verified code were indistinguishable from one with no implementation at all.

Status values only. No frontmatter key reordering, no body changes. All five files were already `yaml-frontmatter`, so the format was preserved in place; no file carried both formats.

| Artifact | Was | Now | Why |
|---|---|---|---|
| ADR-0005 | `proposed` | `accepted` | All three changes shipped — recipe lists and explicit yields with deterministic selection (#30), self-referential exclusion with the count in provenance (#32). SPEC-0001/0002/0004 amended to follow it in #28. |
| SPEC-0003 | `draft` | `implemented` | Epic #7 closed, 4 stories merged, acceptance test extracts 54 tables that MBINCompiler decompiles without error. |
| SPEC-0004 | `draft` | `approved` | Settled and being built against; #25 and #34 open. |
| SPEC-0001 | `draft` | `approved` | Stage 1 built; leaf assignment, producer rollup and power computation unbuilt. |
| SPEC-0002 | `draft` | `approved` | Spec and design settled, no code yet. |

### Recorded, not hidden

SPEC-0003 moves to `implemented` with one known gap: `printableMagic` returns `""` when the magic starts with a non-printable byte, so REQ "Container Identification"'s "name the magic found" is unmet for non-ASCII-leading files. The PSARC case the spec's own scenario names works correctly, which is why it has survived six PRs. Calling it a known limitation is the honest option; the alternative is holding the status at `approved` over an edge case nobody is blocked on.

`approved` rather than `implemented` for the other three is the distinction worth keeping: the design is agreed, the implementation is the remaining work. `draft` said neither.