### PR TITLE
feat(normalize): read raw-obtainability from PinObjective

### DIFF
--- a/internal/normalize/tables.go
+++ b/internal/normalize/tables.go
@@ -42,6 +42,19 @@ type Graph struct {
 	// their name key, sorted. Every one is checked to be unreferenced.
 	UnnamedOmitted []string
 
+	// RawByNecessity lists substances the source marks refined-only that no
+	// recipe in fact produces, sorted. They are emitted raw-obtainable
+	// anyway, because an item with neither a recipe nor a gathering route is
+	// one the engine cannot terminate on.
+	//
+	// Recorded rather than silently overridden: it is the source
+	// contradicting itself, and one of them is `WATERPLANT` (Cyto-Phosphate),
+	// whose PinObjective reads UI_REFINE_OBJ while no refiner recipe makes
+	// it. A change in this list is a change in the game data.
+	//
+	// Governing: SPEC-0004 REQ "Search Boundaries Are Recorded"
+	RawByNecessity []string
+
 	// LocalisationFiles records which tables the name resolution read.
 	//
 	// Governing: SPEC-0004 REQ "Search Boundaries Are Recorded"
@@ -65,7 +78,7 @@ func BuildGraph(src Sources) (*Graph, error) {
 		return nil, err
 	}
 
-	subItems, err := parseSubstances(src.Substances, loc)
+	subItems, refinedOnly, err := parseSubstances(src.Substances, loc)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +94,7 @@ func BuildGraph(src Sources) (*Graph, error) {
 	items := append(subItems, prodItems...)
 	recipes := append(craft, refined...)
 
-	resolveMethods(items, recipes)
+	rawByNecessity := resolveMethods(items, recipes, refinedOnly)
 
 	// Omitting an unnamed item is only safe while nothing references it.
 	// Asserted rather than assumed: a game update could start using one, and
@@ -97,40 +110,89 @@ func BuildGraph(src Sources) (*Graph, error) {
 		Recipes:                recipes,
 		SelfReferentialOmitted: selfRef,
 		UnnamedOmitted:         sortedStrings(skipped),
+		RawByNecessity:         rawByNecessity,
 		LocalisationFiles:      loc.Files(),
 	}, nil
+}
+
+// pinObjectives is the closed vocabulary of the substance table's
+// PinObjective field, mapped to whether the substance can be obtained
+// without a refiner.
+//
+// Governing: SPEC-0004 REQ "Recipe Graph Construction" — "Raw-obtainability
+// MUST be read from the source, not inferred from the absence of a recipe."
+//
+// Having a recipe and being gatherable are independent: you mine Cobalt with
+// a terrain manipulator and you can also refine it. Inferring raw-ness from
+// "has no recipe" made every gatherable substance with a refine route
+// default to refine, and refining runs both ways between several such pairs
+// — CAVE1 ⇄ CAVE2, CATALYST1 ⇄ CATALYST2, GAS1 → GAS3 → GAS2 → GAS1. 571 of
+// 2,237 items were unresolvable as a result.
+//
+// All five values below occur in NMS 5.97, over all 111 substances. The map
+// is closed on purpose: a sixth value is a game update changing something
+// this rule depends on, and failing is better than classifying it by
+// whichever default happened to be written here.
+var pinObjectives = map[string]bool{
+	"UI_GATHER_OBJ":        true,  // gathered directly
+	"UI_GATHER_REFINE_OBJ": true,  // gathered, and refinable too
+	"UI_FIND_OBJ":          true,  // found rather than mined, but still no refiner
+	"UI_PROCESS_OBJ":       true,  // the gases, from an atmosphere harvester
+	"UI_REFINE_OBJ":        false, // refined only: the six that are not raw
+}
+
+// rawObtainable reads a substance's gatherability from the source.
+func rawObtainable(table, id string, r node) (bool, error) {
+	pin, err := r.str(table, id, "PinObjective")
+	if err != nil {
+		return false, err
+	}
+	raw, known := pinObjectives[pin]
+	if !known {
+		return false, Unrecognized(table, id, "PinObjective",
+			"one of the five objectives NMS 5.97 uses", pin)
+	}
+	return raw, nil
 }
 
 // parseSubstances reads the substance table. Substances have no recipe of
 // their own; anything craftable from them lives in the product or recipe
 // tables.
-func parseSubstances(path string, loc *Localisation) ([]domain.Item, error) {
+func parseSubstances(path string, loc *Localisation) ([]domain.Item, map[string]bool, error) {
 	name := filepath.Base(path)
 	doc, err := readMXML(path, "cGcSubstanceTable")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	rows, err := doc.rows(name, "Table", "GcRealitySubstanceData")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	items := make([]domain.Item, 0, len(rows))
+	refinedOnly := map[string]bool{}
 	for _, r := range rows {
 		id, err := r.nonEmpty(name, r.ID, "ID")
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		key, err := r.nonEmpty(name, id, "NameLower")
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		display, err := loc.Resolve(name, id, key)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		items = append(items, domain.Item{ID: id, Name: display})
+		raw, err := rawObtainable(name, id, r)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !raw {
+			refinedOnly[id] = true
+		}
+		items = append(items, domain.Item{ID: id, Name: display, RawObtainable: raw})
 	}
-	return items, nil
+	return items, refinedOnly, nil
 }
 
 // parseProducts reads the product table, emitting one item per product and a
@@ -344,10 +406,20 @@ func parseRecipes(path string) ([]domain.Recipe, int, error) {
 
 // resolveMethods assigns each item its default method and marks the leaves.
 //
-// Precedence is craft, then refine, then cook, then raw. An item with no
-// recipe at all becomes a raw-obtainable terminal, which is what the rollup
-// engine's terminal-node handling expects to find at the bottom of a tree.
-func resolveMethods(items []domain.Item, recipes []domain.Recipe) {
+// A raw-obtainable item defaults to raw even where it also has recipes:
+// gathering is the route a player takes by default, expanding it is what
+// produces the refine cycles, and the engine's per-node method override is
+// there for a player who wants the refine route. Otherwise precedence is
+// craft, then refine, then cook.
+//
+// An item with no recipe at all becomes a raw-obtainable terminal anyway.
+// That is not an inference about the game so much as a requirement of the
+// graph: without it the engine has an item it cannot terminate on. Where
+// that overrides a substance the source marked refined-only, the id is
+// returned so the caller can record the contradiction rather than bury it.
+//
+// Governing: SPEC-0004 REQ "Recipe Graph Construction"
+func resolveMethods(items []domain.Item, recipes []domain.Recipe, refinedOnly map[string]bool) []string {
 	byOutput := make(map[string]map[domain.Method]bool, len(recipes))
 	for _, r := range recipes {
 		m, ok := byOutput[r.Output]
@@ -357,9 +429,12 @@ func resolveMethods(items []domain.Item, recipes []domain.Recipe) {
 		}
 		m[r.Method] = true
 	}
+	var rawByNecessity []string
 	for i := range items {
 		methods := byOutput[items[i].ID]
 		switch {
+		case items[i].RawObtainable:
+			items[i].DefaultMethod = domain.MethodRaw
 		case methods[domain.MethodCraft]:
 			items[i].DefaultMethod = domain.MethodCraft
 		case methods[domain.MethodRefine]:
@@ -369,8 +444,12 @@ func resolveMethods(items []domain.Item, recipes []domain.Recipe) {
 		default:
 			items[i].DefaultMethod = domain.MethodRaw
 			items[i].RawObtainable = true
+			if refinedOnly[items[i].ID] {
+				rawByNecessity = append(rawByNecessity, items[i].ID)
+			}
 		}
 	}
+	return sortedStrings(rawByNecessity)
 }
 
 // checkClosed verifies every recipe endpoint resolves to an item in the

--- a/internal/normalize/tables_real_test.go
+++ b/internal/normalize/tables_real_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jonstump/nms-base-planner/internal/domain"
@@ -130,36 +131,86 @@ func TestRealInstallGraphMatchesTheRecordedCounts(t *testing.T) {
 		t.Errorf("ULTRAPROD2 name = %q, want %q", it.Name, "Stasis Device")
 	}
 
-	// A recorded finding, not desired behaviour.
+	// The whole point of reading gatherability from the source: under pure
+	// defaults, every item resolves.
 	//
-	// SPEC-0004 derives raw-obtainability from the absence of a recipe, so
-	// a substance you gather with a mining beam *and* can refine — Cobalt,
-	// Sodium, the gases — comes out defaulting to refine. Refining runs
-	// both ways between several of those pairs, so resolving under pure
-	// defaults hits a cycle: 571 of the 2,237 items do, all of them
-	// refine loops between gatherable substances.
-	//
-	// The engine is right to refuse; SPEC-0001 REQ "Cycle Detection" calls
-	// this a runtime condition rather than one to assume away. What is
-	// missing is a source of truth for gatherability, and the substance
-	// table has one — PinObjective, which reads UI_REFINE_OBJ for the six
-	// substances that are refined only and some flavour of gather, find or
-	// process for the rest. Marking raw-obtainability from it resolves all
-	// 2,237 with no cycles.
-	//
-	// That is a modelling decision SPEC-0004 does not make, so it is
-	// recorded here rather than invented in the normalizer. When the spec
-	// is amended, this assertion changes with it.
-	_, err = domain.Resolve(a1, domain.PlanInput{Target: "ULTRAPROD2", Quantity: 1})
-	if !errors.Is(err, domain.ErrCycleDetected) {
-		t.Fatalf("resolving the Stasis Device: error = %v, want ErrCycleDetected until "+
-			"raw-obtainability is read from the source", err)
+	// Governing: SPEC-0004 REQ "Recipe Graph Construction" — Scenario "The
+	// generated graph resolves". Before PinObjective was read, 571 of these
+	// hit a refine cycle between gatherable substances.
+	var cycles []string
+	for _, it := range g.Items {
+		_, err := domain.Resolve(a1, domain.PlanInput{Target: it.ID, Quantity: 1})
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, domain.ErrCycleDetected) {
+			cycles = append(cycles, it.ID)
+			continue
+		}
+		t.Errorf("resolving %s: %v", it.ID, err)
+	}
+	if len(cycles) != 0 {
+		limit := len(cycles)
+		if limit > 10 {
+			limit = 10
+		}
+		t.Errorf("%d of %d items hit a cycle under default methods: %v",
+			len(cycles), len(g.Items), cycles[:limit])
 	}
 
-	// The cycle is between refinable substances, not anywhere in the craft
-	// tree: every craft input still resolves to an item, which is what this
-	// story is responsible for.
-	if got := len(a1.RecipesFor("ULTRAPROD2", domain.MethodCraft)); got != 1 {
-		t.Errorf("ULTRAPROD2 craft recipes = %d, want 1", got)
+	// Six substances read UI_REFINE_OBJ. Five of them are emitted non-raw;
+	// WATERPLANT (Cyto-Phosphate) is marked refined-only by the source while
+	// no refiner recipe produces it, so it is emitted raw by necessity and
+	// recorded as a contradiction rather than silently overridden.
+	refineOnly := map[string]bool{
+		"CAVE2": true, "WATER2": true,
+		"LAND3": true, "LAUNCHSUB2": true, "STELLAR2": true,
 	}
+	if got, want := g.RawByNecessity, []string{"WATERPLANT"}; len(got) != len(want) || (len(got) > 0 && got[0] != want[0]) {
+		t.Errorf("raw by necessity = %v, want %v", got, want)
+	}
+	substances := substanceIDs(t, filepath.Join(tables, "nms_reality_gcsubstancetable.MXML"))
+	if len(substances) != 111 {
+		t.Errorf("substance table holds %d rows, want 111", len(substances))
+	}
+	var nonRaw []string
+	for _, it := range g.Items {
+		if !substances[it.ID] {
+			continue
+		}
+		if it.RawObtainable {
+			if it.DefaultMethod != domain.MethodRaw {
+				t.Errorf("%s is raw-obtainable but defaults to %q", it.ID, it.DefaultMethod)
+			}
+			continue
+		}
+		nonRaw = append(nonRaw, it.ID)
+		if !refineOnly[it.ID] {
+			t.Errorf("%s is not raw-obtainable and is not one of the six refine-only substances", it.ID)
+		}
+	}
+	if len(nonRaw) != len(refineOnly) {
+		t.Errorf("non-raw substances = %v, want the six refine-only ones", nonRaw)
+	}
+}
+
+// substanceIDs reads the substance table's row ids, so the assertions above
+// can tell a substance from a product without the graph carrying the
+// distinction into the artifact, where nothing needs it.
+func substanceIDs(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const marker = `<Property name="Table" value="GcRealitySubstanceData" _id="`
+	out := map[string]bool{}
+	for _, row := range strings.Split(string(blob), marker)[1:] {
+		id, _, ok := strings.Cut(row, `"`)
+		if !ok {
+			t.Fatalf("malformed row marker in %s", path)
+		}
+		out[id] = true
+	}
+	return out
 }

--- a/internal/normalize/tables_test.go
+++ b/internal/normalize/tables_test.go
@@ -692,3 +692,193 @@ func copyGraphTree(t *testing.T) string {
 	}
 	return dst
 }
+
+// SPEC-0004 REQ "Recipe Graph Construction":
+// WHEN a substance's `PinObjective` is `UI_GATHER_REFINE_OBJ` and the table
+// also defines refine recipes for it
+// THEN it is emitted raw-obtainable with default method raw, and its refine
+// recipes are emitted alongside.
+func TestGatherabilityComesFromTheSource(t *testing.T) {
+	g := buildGraph(t)
+	a1 := graphArtifact(t)
+	byID := itemsByID(g)
+
+	// Cobalt: mined with a terrain manipulator, and refinable. Having a
+	// recipe does not stop it being raw — that conflation is what made 571
+	// of 2,237 items unresolvable.
+	cobalt, ok := byID["CAVE1"]
+	if !ok {
+		t.Fatal("CAVE1 missing from the graph")
+	}
+	if !cobalt.RawObtainable {
+		t.Error("CAVE1 is not raw-obtainable; its PinObjective is UI_GATHER_OBJ")
+	}
+	if cobalt.DefaultMethod != domain.MethodRaw {
+		t.Errorf("CAVE1 defaults to %q, want raw", cobalt.DefaultMethod)
+	}
+	// The alternatives are still there for a player who wants them.
+	if len(a1.RecipesFor("CAVE1", domain.MethodRefine)) == 0 {
+		t.Error("CAVE1 lost its refine recipes when it was marked raw")
+	}
+	if legal := a1.LegalMethods("CAVE1"); len(legal) < 2 {
+		t.Errorf("CAVE1 legal methods = %v, want raw and refine", legal)
+	}
+
+	// Ionised Cobalt: the other half of the pair that used to cycle.
+	ionised, ok := byID["CAVE2"]
+	if !ok {
+		t.Fatal("CAVE2 missing from the graph")
+	}
+	if ionised.RawObtainable {
+		t.Error("CAVE2 is raw-obtainable; its PinObjective is UI_REFINE_OBJ")
+	}
+	if ionised.DefaultMethod != domain.MethodRefine {
+		t.Errorf("CAVE2 defaults to %q, want refine", ionised.DefaultMethod)
+	}
+}
+
+// SPEC-0004 REQ "Recipe Graph Construction":
+// WHEN the rollup engine resolves each item in a generated artifact under
+// default methods
+// THEN every item resolves, and none reports a cycle.
+func TestGeneratedGraphResolvesUnderDefaults(t *testing.T) {
+	a1 := graphArtifact(t)
+
+	var cycles []string
+	for _, it := range a1.Items {
+		_, err := domain.Resolve(a1, domain.PlanInput{Target: it.ID, Quantity: 1})
+		switch {
+		case err == nil:
+		case errors.Is(err, domain.ErrCycleDetected):
+			cycles = append(cycles, it.ID)
+		default:
+			t.Errorf("resolving %s: %v", it.ID, err)
+		}
+	}
+	if len(cycles) != 0 {
+		t.Errorf("%d items hit a cycle under default methods: %v", len(cycles), cycles)
+	}
+
+	// The pair that used to loop is the reason this test exists: resolving
+	// Ionised Cobalt reaches Cobalt and stops there.
+	rg, err := domain.Resolve(a1, domain.PlanInput{Target: "CAVE2", Quantity: 1})
+	if err != nil {
+		t.Fatalf("resolving CAVE2: %v", err)
+	}
+	cobalt, ok := rg.Node("CAVE1")
+	if !ok {
+		t.Fatal("CAVE1 missing from the resolved tree")
+	}
+	if !cobalt.Terminal {
+		t.Error("CAVE1 expanded rather than terminating; the loop is still open")
+	}
+}
+
+// A source that says something this rule has never seen fails rather than
+// classifying it by whichever default happened to be written.
+func TestUnrecognizedPinObjectiveFails(t *testing.T) {
+	root := copyGraphTree(t)
+	p := filepath.Join(root, "substances.MXML")
+	blob, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const from = `<Property name="PinObjective" value="UI_GATHER_OBJ" />`
+	if !strings.Contains(string(blob), from) {
+		t.Fatal("the fixture no longer carries UI_GATHER_OBJ, so this case proves nothing")
+	}
+	edited := strings.Replace(string(blob), from,
+		`<Property name="PinObjective" value="UI_TELEPORT_OBJ" />`, 1)
+	if err := os.WriteFile(p, []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := normalize.BuildGraph(graphSources(root))
+	if !errors.Is(err, normalize.ErrStructureUnrecognized) {
+		t.Fatalf("error = %v, want ErrStructureUnrecognized", err)
+	}
+	if g != nil {
+		t.Error("a graph was returned alongside an error")
+	}
+	if !strings.Contains(err.Error(), "UI_TELEPORT_OBJ") {
+		t.Errorf("error %q does not name the value it did not recognize", err)
+	}
+	if !strings.Contains(err.Error(), "PinObjective") {
+		t.Errorf("error %q does not name the field", err)
+	}
+}
+
+// An absent field fails rather than defaulting either way.
+func TestAbsentPinObjectiveFails(t *testing.T) {
+	root := copyGraphTree(t)
+	p := filepath.Join(root, "substances.MXML")
+	blob, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Strip the field from CAVE1's row only, so the failure is attributable.
+	const marker = `<Property name="Table" value="GcRealitySubstanceData" _id="CAVE1">`
+	i := strings.Index(string(blob), marker)
+	if i < 0 {
+		t.Fatal("CAVE1 is not in the fixture")
+	}
+	head, tail := string(blob)[:i], string(blob)[i:]
+	const field = `<Property name="PinObjective" value="UI_GATHER_OBJ" />`
+	if !strings.Contains(tail, field) {
+		t.Fatal("CAVE1 no longer carries UI_GATHER_OBJ")
+	}
+	if err := os.WriteFile(p, []byte(head+strings.Replace(tail, field, "", 1)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := normalize.BuildGraph(graphSources(root))
+	if !errors.Is(err, normalize.ErrStructureUnrecognized) {
+		t.Fatalf("error = %v, want ErrStructureUnrecognized", err)
+	}
+	if g != nil {
+		t.Error("a graph was returned alongside an error")
+	}
+	if !strings.Contains(err.Error(), "CAVE1") {
+		t.Errorf("error %q does not name the substance", err)
+	}
+}
+
+// The product table's PinObjective is not a gatherability signal — it is
+// mostly empty and its vocabulary is open-ended, carrying one-off strings
+// like `UI_PIN_VENTGEM_OBJ`. Products therefore take raw-obtainability from
+// the graph alone: a product with no recipe is a leaf, and one with a recipe
+// is not raw.
+func TestProductRawObtainabilityComesFromTheGraph(t *testing.T) {
+	g := buildGraph(t)
+	byID := itemsByID(g)
+
+	produced := map[string]bool{}
+	for _, r := range g.Recipes {
+		produced[r.Output] = true
+	}
+
+	// VENTGEM (Crystal Sulphide) is a product that no recipe in the fixture
+	// makes, and whose PinObjective is a one-off mission string.
+	gem, ok := byID["VENTGEM"]
+	if !ok {
+		t.Fatal("VENTGEM missing from the graph")
+	}
+	if produced["VENTGEM"] {
+		t.Fatal("the fixture now produces VENTGEM, so this case is not being exercised")
+	}
+	if !gem.RawObtainable || gem.DefaultMethod != domain.MethodRaw {
+		t.Errorf("VENTGEM raw=%v default=%q, want a raw terminal", gem.RawObtainable, gem.DefaultMethod)
+	}
+
+	// The Stasis Device is crafted, so it is not a leaf.
+	sd, ok := byID["ULTRAPROD2"]
+	if !ok {
+		t.Fatal("ULTRAPROD2 missing")
+	}
+	if sd.RawObtainable {
+		t.Error("ULTRAPROD2 is raw-obtainable; it is crafted")
+	}
+	if sd.DefaultMethod != domain.MethodCraft {
+		t.Errorf("ULTRAPROD2 defaults to %q, want craft", sd.DefaultMethod)
+	}
+}

--- a/internal/normalize/testdata/graph/gen.go
+++ b/internal/normalize/testdata/graph/gen.go
@@ -27,7 +27,9 @@
 //	recipes               every recipe producing one of those items. That
 //	                      is 26 for CATALYST2 alone (ADR-0005's worked
 //	                      example), seven of them self-referential, and it
-//	                      includes yields other than one.
+//	                      includes yields other than one. CAVE1 and CAVE2
+//	                      bring the refine loop that made raw-obtainability
+//	                      a correctness question rather than a cosmetic one.
 //	localisation          only the Id and English properties of the keys
 //	                      the emitted items name. The real rows carry
 //	                      fifteen further translations that no code here
@@ -51,6 +53,8 @@ var seeds = []string{
 	"CATALYST2",      // Sodium Nitrate: 26 refine recipes, seven self-referential
 	"FOOD_P_STELLAR", // a cooked product, so the Cooking flag has both values
 	"AMMO",           // the one product in the table that crafts 25 at a time
+	"CAVE1",          // Cobalt: gathered *and* refinable, the case that broke
+	"CAVE2",          // Ionised Cobalt: refined only, and CAVE1's other half
 }
 
 // knownUnnamed products, included so the allowlist path is exercised. These

--- a/internal/normalize/testdata/graph/recipes.MXML
+++ b/internal/normalize/testdata/graph/recipes.MXML
@@ -140,6 +140,29 @@
 				</Property>
 			</Property>
 		</Property>
+		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_24">
+			<Property name="Id" value="REFINERECIPE_24" />
+			<Property name="RecipeType" value="RECIPE_CAVE2" />
+			<Property name="RecipeName" value="R_NAME_CAVE2" />
+			<Property name="TimeToMake" value="30.000000" />
+			<Property name="Cooking" value="false" />
+			<Property name="Result" value="GcRefinerRecipeElement">
+				<Property name="Id" value="CAVE1" />
+				<Property name="Type" value="GcInventoryType">
+					<Property name="InventoryType" value="Substance" />
+				</Property>
+				<Property name="Amount" value="2" />
+			</Property>
+			<Property name="Ingredients">
+				<Property name="Ingredients" value="GcRefinerRecipeElement" _id="CAVE2">
+					<Property name="Id" value="CAVE2" />
+					<Property name="Type" value="GcInventoryType">
+						<Property name="InventoryType" value="Substance" />
+					</Property>
+					<Property name="Amount" value="1" />
+				</Property>
+			</Property>
+		</Property>
 		<Property name="Table" value="GcRefinerRecipe" _id="REFINERECIPE_26">
 			<Property name="Id" value="REFINERECIPE_26" />
 			<Property name="RecipeType" value="RECIPE_FUEL1" />


### PR DESCRIPTION
## What

Implements #34. Raw-obtainability now comes from the substance table's `PinObjective` instead of being inferred from the absence of a recipe.

**Over a real install, all 2,237 items now resolve under default methods with zero cycles** — 571 of them could not before.

## The rule

All 111 substances carry one of five `PinObjective` values. The map is **closed**: a sixth value fails generation rather than being classified by whichever default happened to be written here.

| Value | Count | Raw-obtainable |
|---|---:|---|
| `UI_FIND_OBJ` | 42 | yes |
| `UI_GATHER_OBJ` | 41 | yes |
| `UI_GATHER_REFINE_OBJ` | 18 | yes |
| `UI_PROCESS_OBJ` | 4 | yes — the gases, from an atmosphere harvester |
| `UI_REFINE_OBJ` | 6 | **no** |

A raw-obtainable item defaults to `raw` even where it has recipes, and keeps them as legal alternatives — `CAVE1` still reports both `raw` and `refine` as legal methods, so the per-node override does its job.

## Two things found while implementing

Both are recorded rather than smoothed over.

**1. The source contradicts itself once.** `WATERPLANT` (Cyto-Phosphate) reads `UI_REFINE_OBJ` while **no refiner recipe produces it**. It has to be emitted raw or the engine has an item it cannot terminate on — but silently letting the "no recipe → raw" fallback overwrite a source-stated fact is how you lose track of a data change. It is emitted raw and reported in `Graph.RawByNecessity`, and the opt-in test asserts that list is exactly `[WATERPLANT]`.

**2. I was wrong about the product table.** SPEC-0004 (as I wrote it in #33) says "The product table carries no equivalent field". It does — all 2,144 product rows carry `PinObjective`. I checked the substance table's shape and inferred the product table's without grepping it, which is the same bounded-search-reported-as-general-result this project has now recorded four times.

The rule itself is unaffected: the field is not a gatherability signal for products. 1,240 are empty, and the vocabulary is open-ended — `UI_BUY_OBJ` (288), `UI_CRAFT_OBJ` (112), and one-off mission strings like `UI_PIN_VENTGEM_OBJ`. Products still take raw-obtainability from the graph. Only the spec's *reason* is wrong, and it is deferred below.

## Tests

Fixture-level, against real sliced rows:

- `CAVE1` (Cobalt) — raw-obtainable, defaults `raw`, **still carries its refine recipes** and reports both methods legal
- `CAVE2` (Ionised Cobalt) — not raw, defaults `refine`
- Every item in the generated artifact resolves with no cycle; resolving `CAVE2` reaches `CAVE1` and **terminates there**, which is the loop that used to close
- An unrecognized `PinObjective` fails, naming the value and the field
- An absent `PinObjective` fails, naming the substance
- A product with no recipe is a raw terminal; a product with one is not

`CAVE1`/`CAVE2` were added as fixture seeds so the gatherable-and-refinable case is exercised against real rows rather than assumed — before that, `CAVE1` had no recipes in the fixture and the test passed for the wrong reason. `testdata/graph/gen.go` records why.

Opt-in whole-install pass (`NMS_SOURCE_DIR`) now asserts the systemic property: every one of the 2,237 items resolves, no cycles, and the five refine-only substances are the only substances emitted non-raw — checked in both directions so a sixth joining them is caught.

`go vet`, `staticcheck v0.8.0-rc.1`, `gofmt -l` all clean.

### Deferred Design Doc Updates

- `docs/openspec/specs/tier1-normalizer/spec.md`, REQ "Recipe Graph Construction": "The product table carries no equivalent field" is false — it carries `PinObjective` on all 2,144 rows. Restate the reason: the field exists but is not a gatherability signal for products (1,240 empty, open-ended vocabulary including `UI_BUY_OBJ` and per-item mission strings). The requirement itself does not change.
- Same requirement: add the contradiction case — a substance marked `UI_REFINE_OBJ` that no recipe produces MUST still be emitted raw-obtainable, and the override MUST be recorded.

Closes #34
Part of #21

Implements SPEC-0004 REQ "Recipe Graph Construction" (as amended for PinObjective).

🤖 Generated with [Claude Code](https://claude.com/claude-code)