### PR TITLE
docs: correct SPEC-0004 on the product table, and record the one contradiction

### DIFF
--- a/docs/openspec/specs/tier1-normalizer/design.md
+++ b/docs/openspec/specs/tier1-normalizer/design.md
@@ -136,6 +136,18 @@ Measured rather than assumed: setting `raw_obtainable` from `PinObjective != UI_
 
 **Trade-off**: The rule is a small allow/deny list over an enum this project has seen exactly one build of, so a game update that adds a `PinObjective` value will fail generation rather than classify it. That is the intended direction — the alternative is a default that silently reclassifies items — but it does mean this is a place an update can break, and it is named in the risks below.
 
+**Correction, 2026-08-19**: the first version of this decision said the product table carries no `PinObjective`. It does — on all 2,144 rows. That claim came from reading the substance table's shape and inferring the product table's rather than looking, which is the fourth recorded instance in this project of a bounded search reported as a general result, and it happened in the same change that added a requirement to read facts from the source. The rule survives the correction on its merits rather than on the false premise: 1,240 of those values are empty and the vocabulary is open-ended, running from `UI_BUY_OBJ` and `UI_CRAFT_OBJ` to per-item mission strings like `UI_PIN_VENTGEM_OBJ`. It classifies nothing.
+
+### Where two source facts disagree, the graph wins and the disagreement is recorded
+
+**Choice**: A substance the source marks refined-only that no recipe produces is emitted raw-obtainable, and every such override is reported.
+
+**Rationale**: Found by implementing the rule above against the whole table. `WATERPLANT` (Cyto-Phosphate) reads `UI_REFINE_OBJ` while nothing in the recipe table makes it. One of the two facts has to give, and it has to be the flag: an item with neither a recipe nor a gathering route is one the engine cannot terminate on, so honouring the flag produces an artifact that does not resolve.
+
+What matters is that the override is not silent. The "no recipe, therefore raw" fallback would have swallowed this case without a trace, and the next reader would have had no way to tell a rule being applied from a rule being contradicted. Reporting it makes the disagreement a reviewable line in the output, and a change in that set a change in the game data.
+
+**Trade-off**: One item today, and a mechanism for it. Justified because the alternative is indistinguishable from the bug: a silent fallback that happens to produce the right answer here is the same code that would produce a wrong one somewhere else.
+
 ### Cooking is a flag, not a table
 
 **Choice**: Read `Cooking` from each refiner recipe rather than treating cooking as a separate source.

--- a/docs/openspec/specs/tier1-normalizer/spec.md
+++ b/docs/openspec/specs/tier1-normalizer/spec.md
@@ -65,7 +65,9 @@ Items with no recipe MUST be emitted with `raw_obtainable` true and `default_met
 
 The substance table states gatherability in `PinObjective`, the pinned objective shown for the item. Six substances read `UI_REFINE_OBJ` and are refined only; the other 105 read some flavour of gather, find or process. The normalizer MUST set `raw_obtainable` true for every substance whose `PinObjective` is not `UI_REFINE_OBJ`, and MUST fail rather than guess where the field is absent or holds a value that list does not cover.
 
-The product table carries no equivalent field, so a product that has a recipe MUST NOT be marked raw-obtainable. A product with no recipe still is, by the rule above — that is what gives the engine a leaf rather than an item it cannot terminate on.
+The product table carries `PinObjective` too, on all 2,144 rows, but it is not a gatherability signal: 1,240 are empty and the vocabulary is open-ended, running from `UI_BUY_OBJ` and `UI_CRAFT_OBJ` to per-item mission strings like `UI_PIN_VENTGEM_OBJ`. The normalizer MUST NOT read it. A product that has a recipe MUST NOT be marked raw-obtainable; a product with no recipe still is, by the rule above — that is what gives the engine a leaf rather than an item it cannot terminate on.
+
+**Where the source contradicts itself, the graph wins and the override is recorded.** Six substances read `UI_REFINE_OBJ`, and one of them — `WATERPLANT`, Cyto-Phosphate — is produced by no recipe in the table. Emitting it non-raw would leave an item with neither a recipe nor a gathering route, which the engine cannot terminate on, so it MUST be emitted raw-obtainable. The normalizer MUST record every such override, because it is a disagreement between two source facts rather than a rule being applied, and a change in that set is a change in the game data.
 
 A raw-obtainable item MUST default to `raw` even where it also has recipes. Gathering is the route a player takes by default, expanding it is what produces the cycles above, and the engine's per-node method override exists precisely so a player who wants the refine route can take it.
 
@@ -88,8 +90,18 @@ A raw-obtainable item MUST default to `raw` even where it also has recipes. Gath
 
 #### Scenario: A refine-only substance is not raw
 
-- **WHEN** a substance's `PinObjective` is `UI_REFINE_OBJ`
+- **WHEN** a substance's `PinObjective` is `UI_REFINE_OBJ` and the table defines a recipe producing it
 - **THEN** it is emitted `raw_obtainable` false, defaulting to `refine`
+
+#### Scenario: An unrecognized objective fails rather than defaults
+
+- **WHEN** a substance's `PinObjective` is absent, or holds a value outside the five the source uses
+- **THEN** generation fails naming the substance and the value, rather than classifying it either way
+
+#### Scenario: A refine-only substance no recipe produces is still raw
+
+- **WHEN** a substance's `PinObjective` is `UI_REFINE_OBJ` and no recipe in the table produces it
+- **THEN** it is emitted `raw_obtainable` true, and the override is recorded
 
 #### Scenario: The generated graph resolves
 


### PR DESCRIPTION
## What

The two deferred design-doc updates from [#36](https://github.com/jonstump/nms-base-planner/pull/36). Both were found by implementing the `PinObjective` requirement rather than by re-reading it. No code changes — #36 already implements all of this.

## 1. The product table does carry `PinObjective`

The requirement said "The product table carries no equivalent field." It does, on **all 2,144 rows**.

That claim came from reading the substance table's shape and inferring the product table's rather than looking. It is the fourth recorded instance in this project of a bounded search reported as a general result — and it happened in the same change that added a requirement to read facts from the source instead of inferring them.

**The rule survives the correction on its merits rather than on the false premise.** The field exists but classifies nothing: 1,240 values are empty, and the vocabulary is open-ended — `UI_BUY_OBJ` (288), `UI_CRAFT_OBJ` (112), and per-item mission strings like `UI_PIN_VENTGEM_OBJ`. The requirement now says the normalizer MUST NOT read it, and says why.

## 2. One substance contradicts itself, and the override must be recorded

Six substances read `UI_REFINE_OBJ`. One of them — `WATERPLANT`, Cyto-Phosphate — **is produced by no recipe in the table**. The requirement had no answer for that.

Honouring the flag would leave an item with neither a recipe nor a gathering route, which the engine cannot terminate on. So the graph wins and it is emitted raw-obtainable.

What the requirement now adds is that the override **MUST be recorded**. The "no recipe, therefore raw" fallback would have swallowed this without a trace, and the next reader would have no way to tell a rule being applied from a rule being contradicted. A silent fallback that happens to be right here is the same code that would be wrong somewhere else.

## Scenarios

- The refine-only scenario now states the precondition it always assumed — that a recipe producing it exists.
- **New**: an absent or unrecognized `PinObjective` fails naming the substance and the value, rather than classifying it either way.
- **New**: a refine-only substance no recipe produces is emitted raw, and the override is recorded.

## Design

- The raw-obtainability decision carries a dated correction recording the wrong claim, where it came from, and why the conclusion holds without it.
- A new decision entry on why the graph wins when two source facts disagree, and why recording the disagreement is the part that matters.

Part of #21

Amends SPEC-0004 REQ "Recipe Graph Construction".

🤖 Generated with [Claude Code](https://claude.com/claude-code)