### PR TITLE
docs: correct the golden-tree node count, and where the old one came from

### DIFF
--- a/docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md
+++ b/docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md
@@ -56,7 +56,7 @@ Extraction takes **structure and quantities only**. In-game `Description` text a
 
 The pipeline is correct when it reproduces the Stasis Device tree from `docs/design/tree-canvas/handoff.md` exactly, rooted at product ID **`ULTRAPROD2`**:
 
-* 34 distinct nodes across the Quantum Processor (`MEGAPROD2`), Cryogenic Chamber (`MEGAPROD3`), and Iridesite (`ALLOY8`) branches
+* 36 distinct nodes across the Quantum Processor (`MEGAPROD2`), Cryogenic Chamber (`MEGAPROD3`), and Iridesite (`ALLOY8`) branches
 * Each gas product costing 250 gas + 50 Condensed Carbon — `REACTION1` / `REACTION2` / `REACTION3`
 * At quantity ×1: 500 each of Sulphurine / Nitrogen / Radon, and 300 Condensed Carbon
 
@@ -69,7 +69,25 @@ NMS_REALITY_GCPRODUCTTABLE.MBIN    →  NameLower = UI_ULTRAPROD_2_NAME_L  →  
 
 Any normalizer that wants human-readable names must join against the localisation tables; the reality tables alone cannot produce them.
 
-All three bullets above were verified on 2026-08-17 against a real extraction — `NMSARC.Precache.pak` unpacked with `internal/hgpak`, decompiled with MBINCompiler 6.45.0.1 — and the traversal returns exactly 34 distinct nodes over 47 edges to 14 leaf resources. An earlier revision of this section named the root `prod80` and asserted the tree "has already been verified by hand against extracted data". No such ID exists in the game data, in the handoff this section cites, or in the design mocks, and no extraction was possible at the time the claim was written: the reader then in the tree could not open a single archive. The three quantitative bullets were nevertheless correct, so only the identifier was invented — see the HGPAK note below for the same failure mode on the container format.
+The quantities above are verified against generated data: `data/tier1.json`, produced by `cmd/nmstier1` from a real NMS 5.97 install and resolved through the merged rollup engine, returns **36 distinct nodes over 43 edges to 15 leaf resources**, with every gas and carbon figure exactly as stated.
+
+**The structural counts in this section were wrong twice, and the second correction is more interesting than the first.**
+
+An earlier revision named the root `prod80` and asserted the tree "has already been verified by hand against extracted data". No such ID exists, and no extraction was possible when that was written — the reader in the tree could not open a single archive. That revision was corrected on 2026-08-18, which kept the three quantitative bullets as "nevertheless correct".
+
+Two of them were not. This section claimed 34 nodes over 47 edges to 14 leaves, attributed to a 2026-08-17 extraction. Measured against all three candidate sources:
+
+| Source | Nodes | Edges | Leaves |
+|---|---|---|---|
+| Hand-authored fixture (`internal/domain/testdata/stasis-device.tier1.json`, target `sd`) | 34 | 41 | 14 |
+| Generated artifact (`data/tier1.json`, target `ULTRAPROD2`) | **36** | **43** | **15** |
+| What this section previously claimed | 34 | 47 | 14 |
+
+The node and leaf counts match the *fixture* — which uses synthetic IDs (`sd`, `prod999`) and therefore cannot have come from an extraction at all. The edge count matches nothing measurable.
+
+The two extra nodes are `CAVE1` (Cobalt) and `OXYGEN`. `CAVE2` (Ionised Cobalt) is refined rather than gathered — its `PinObjective` reads `UI_REFINE_OBJ`, established in #34 — so it expands rather than terminating, which is also why the leaf count rises by one while `CAVE2` stops being a leaf. The prototype modelled it as a raw leaf; that was a simplification, not a fact about the game.
+
+The lesson is the same one the `prod80` correction drew and did not apply far enough: a number that agrees with the artifact you already had is not evidence about the artifact you did not. See the HGPAK note below for the same failure mode on the container format.
 
 Tier 2 is confirmed differently: every entry must carry a `source` and `verified` date, and any entry lacking one must render with the `unverified` badge rather than silently presenting as fact.
 
@@ -79,7 +97,7 @@ Tier 2 is confirmed differently: every entry must carry a `source` and `verified
 
 Copy the ~1.5 MB of `Products` / `RawMaterials` / `Refinery` / `NutrientProcessor` JSON out of the AssistantNMS app repository.
 
-* Good, because the data is clean, normalized, multilingual, and verified working — walking it reproduces the design's 34-node tree exactly.
+* Good, because the data is clean, normalized, multilingual, and verified working — walking it reproduces the design's tree, differing only where the prototype simplified (`CAVE2` modelled as a raw leaf rather than a refined one).
 * Good, because it requires no game install, no .NET runtime, and no extraction step.
 * Bad, because the repository is **GPL-3.0**, and copying data files out of a copyleft work carries a real argument that the app inherits those obligations.
 * Bad, because it does not close the constants gap — their `Buildings.lang.json` schema has no power or yield fields, so Tier 2 would still be needed.

--- a/docs/adrs/ADR-0005-multiple-recipes-per-output.md
+++ b/docs/adrs/ADR-0005-multiple-recipes-per-output.md
@@ -63,7 +63,7 @@ The decision is implemented when all of the following hold against a generated a
 * `CATALYST2` (Sodium Nitrate) carries 26 refine recipes, including `1x Crystal Sulphide -> 50x Sodium Nitrate` with its yield intact
 * No recipe in the artifact names its own output as an ingredient, and the provenance records 27 excluded
 * The engine, asked for Sodium Nitrate's options, reports all 26 and expands the default deterministically across repeated runs
-* ADR-0001's acceptance test still passes: `ULTRAPROD2` resolves to 34 distinct nodes with leaf totals of 500 Sulphurine, 500 Nitrogen, 500 Radon and 300 Condensed Carbon
+* ADR-0001's acceptance test still passes: `ULTRAPROD2` resolves to 36 distinct nodes with leaf totals of 500 Sulphurine, 500 Nitrogen, 500 Radon and 300 Condensed Carbon
 
 ## Pros and Cons of the Options
 

--- a/docs/openspec/specs/tier1-normalizer/design.md
+++ b/docs/openspec/specs/tier1-normalizer/design.md
@@ -111,7 +111,7 @@ graph TD
 
     H --> I["Tier 1 artifact<br/>items · recipes ·<br/>base economy<br/>version-stamped"]
     I -->|"LoadTier1<br/>DisallowUnknownFields"| J["Rollup engine<br/>(SPEC-0001)"]
-    J --> K["Acceptance:<br/>ULTRAPROD2 → 34 nodes"]
+    J --> K["Acceptance:<br/>ULTRAPROD2 → 36 nodes"]
 
     L["Tier 2 YAML<br/>biodome slot count"] -.->|later stage| I
 ```

--- a/docs/openspec/specs/tier1-normalizer/spec.md
+++ b/docs/openspec/specs/tier1-normalizer/spec.md
@@ -281,16 +281,18 @@ This project has three recorded instances of a bounded search reported as a gene
 
 The normalizer is correct when the artifact it produces reproduces ADR-0001's confirmation criteria through the merged rollup engine, rooted at `ULTRAPROD2`:
 
-- 34 distinct nodes across the Quantum Processor (`MEGAPROD2`), Cryogenic Chamber (`MEGAPROD3`), and Iridesite (`ALLOY8`) branches
+- 36 distinct nodes across the Quantum Processor (`MEGAPROD2`), Cryogenic Chamber (`MEGAPROD3`), and Iridesite (`ALLOY8`) branches
 - Each gas product costing 250 gas and 50 Condensed Carbon
 - At quantity ×1: 500 each of Sulphurine, Nitrogen and Radon, and 300 Condensed Carbon
+
+The node count is 36, not the 34 ADR-0001 originally recorded. `CAVE2` (Ionised Cobalt) is refined rather than gathered, so it expands into Cobalt and Oxygen instead of terminating, adding two nodes. The hand-authored fixture models it as a raw leaf; that was a prototype simplification, and the 34 was counted from the prototype rather than from an extraction. Every quantity in the list is unchanged — only the structural count moved.
 
 This acceptance MUST run against a generated artifact, not against the hand-authored fixtures. A test that only exercises the fixtures verifies the engine, not the normalizer.
 
 #### Scenario: The generated artifact reproduces the tree
 
 - **WHEN** the rollup engine resolves `ULTRAPROD2` at quantity 1 from a generated artifact
-- **THEN** it returns 34 distinct nodes and leaf totals of 500 Sulphurine, 500 Nitrogen, 500 Radon and 300 Condensed Carbon
+- **THEN** it returns 36 distinct nodes and leaf totals of 500 Sulphurine, 500 Nitrogen, 500 Radon and 300 Condensed Carbon
 
 #### Scenario: Acceptance uses generated output
 

--- a/docs/openspec/specs/wasm-boundary/spec.md
+++ b/docs/openspec/specs/wasm-boundary/spec.md
@@ -32,7 +32,7 @@ The adapter MUST NOT expose any function that mutates domain state. Every entry 
 
 #### Scenario: One crossing per stage
 
-- **WHEN** the view resolves a plan and renders 34 nodes
+- **WHEN** the view resolves a plan and renders 36 nodes
 - **THEN** exactly one boundary crossing occurred, and node data was read from the single returned value
 
 #### Scenario: Reserved stages follow the same contract


### PR DESCRIPTION
Closes the drift `/sdd:check` found: the Stasis Device acceptance criterion was stated as **34 distinct nodes** in ADR-0001, ADR-0005, SPEC-0002 and SPEC-0004, while the merged acceptance test asserts **36** and passes.

## Where 34 actually came from

ADR-0001's Confirmation attributed "34 distinct nodes over 47 edges to 14 leaf resources" to a 2026-08-17 real extraction. I measured every candidate source:

| Source | Nodes | Edges | Leaves |
|---|---|---|---|
| Hand-authored fixture (`stasis-device.tier1.json`, target `sd`) | 34 | 41 | 14 |
| Generated artifact (`data/tier1.json`, target `ULTRAPROD2`) | **36** | **43** | **15** |
| What the section claimed | 34 | 47 | 14 |

The node and leaf counts are the **fixture's**. That fixture uses synthetic ids — `sd`, `prod999` — so those numbers cannot have come from an extraction at all. The edge count matches nothing measurable.

This is the second time this section has been wrong. The first correction (#16) removed an invented root id and kept the three quantitative bullets as "nevertheless correct" — two of them were not. The section now records that, because the numbers are the least interesting part: **a figure that agrees with the artifact you already had is not evidence about the artifact you did not.**

## Corrected

Where the claim is about extracted or generated data:

- `ADR-0001` — confirmation bullet, the verification paragraph, and the "reproduces the design's tree exactly" consequence
- `ADR-0005` — confirmation bullet
- `SPEC-0002` — REQ "Boundary Surface", one-crossing-per-stage scenario
- `SPEC-0004` — REQ "Acceptance Against the Golden Tree", its scenario, and the pipeline diagram

SPEC-0004 also gains the *reason*: `CAVE2` is refined rather than gathered, so it expands into Cobalt and Oxygen instead of terminating.

## Deliberately left at 34

A blind find-and-replace would have broken these:

- **`SPEC-0001`'s "Resolving the Stasis Device tree" scenario** — explicitly scoped to "the fixture's recorded game version", and the fixture *is* 34. Changing it would have made a passing test wrong.
- References to the design handoff's prototype tree — `ADR-0001`, `ADR-0003`, `ADR-0005:13`, the tree-canvas prototype
- Scale asides of the form "at this scale (34 nodes, a handful of bases)" — approximations, not claims

## Every quantity is unchanged

250 gas + 50 Condensed Carbon per reaction, and 500/500/500 Sulphurine/Nitrogen/Radon + 300 Condensed Carbon at ×1 — all verified against generated data. Only the structural counts moved.

## Not in this PR

**The SPEC-0001 Tier 1/Tier 2 contradiction** is folded into #39 instead, since that story has to settle the mapping to build its input type at all — and writing the mapping down before building it is how the contradiction got here. #39's body now carries the finding and states the amendment lands as a companion docs PR.

**`printableMagic`** (SPEC-0003 REQ "Container Identification", returns `""` for a non-ASCII-leading magic) is a code fix, not a docs one, and stays open.