### PR TITLE
fix(hgpak): name the magic found even when it is not printable

### DIFF
--- a/internal/hgpak/hgpak.go
+++ b/internal/hgpak/hgpak.go
@@ -209,8 +209,8 @@ func Open(r io.ReaderAt, size int64) (*Archive, error) {
 	// what was actually found — a PSARC archive must be diagnosable as such
 	// rather than as generic corruption.
 	if !bytes.Equal(hdr[:8], magic[:]) {
-		return nil, fmt.Errorf("magic is %q, want %q: %w",
-			printableMagic(hdr[:8]), "HGPAK", ErrNotHGPAK)
+		return nil, fmt.Errorf("magic is %s, want %q: %w",
+			describeMagic(hdr[:8]), "HGPAK", ErrNotHGPAK)
 	}
 
 	a := &Archive{r: r, size: size}
@@ -475,9 +475,34 @@ func (a *Archive) Close() error {
 	return nil
 }
 
-// printableMagic renders a magic value for an error message, keeping ASCII
-// readable so "PSAR" is recognizable at a glance.
-func printableMagic(b []byte) string {
+// describeMagic renders a magic value for an error message.
+//
+// Governing: SPEC-0003 REQ "Container Identification" — a mismatch MUST fail
+// "with an error naming the magic found", so this must never come back
+// empty.
+//
+// It previously returned only the leading run of printable ASCII, which
+// named nothing at all for a file whose first byte is binary: a gzip archive
+// was refused with `magic is ""`. The PSARC scenario the requirement gives
+// happens to start with four printable bytes, which is why the gap survived
+// — the one case the spec names was the one case that worked.
+//
+// The hex is always present because the magic is eight bytes and a printable
+// prefix is at most part of it: "PSAR" is the recognisable half of a PSARC
+// header, not the whole of it. The prefix stays in front because that
+// recognisability is the point — a reader who sees PSAR knows immediately
+// what they opened, and the requirement's own scenario is about exactly that
+// diagnosis.
+func describeMagic(b []byte) string {
+	if p := printablePrefix(b); p != "" {
+		return fmt.Sprintf("%q (%x)", p, b)
+	}
+	return fmt.Sprintf("%x", b)
+}
+
+// printablePrefix is the leading run of printable ASCII in b, which may be
+// empty.
+func printablePrefix(b []byte) string {
 	end := len(b)
 	for i, c := range b {
 		if c < 0x20 || c > 0x7e {

--- a/internal/hgpak/hgpak_test.go
+++ b/internal/hgpak/hgpak_test.go
@@ -739,3 +739,65 @@ func TestHugeBlockLengthIsRefusedWithSentinel(t *testing.T) {
 // caller sees — so the record stride is restated here rather than exported
 // from the package just for tests.
 const entrySizeForTest = 32
+
+// SPEC-0003 REQ "Container Identification": a mismatch MUST fail "with an
+// error naming the magic found".
+//
+// The requirement's own scenario uses a PSARC file, whose header starts with
+// four printable bytes — so the obvious implementation, reporting the leading
+// printable run, satisfies the scenario while naming nothing for any file
+// that starts with a binary byte. A gzip archive was refused with
+// `magic is ""`, which tells the reader neither what they opened nor that
+// anything was read at all.
+func TestNonPrintableMagicIsStillNamed(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		magic []byte
+		want  string // a substring the message must carry
+	}{
+		{"gzip", []byte{0x1f, 0x8b, 0x08, 0x00, 0, 0, 0, 0}, "1f8b0800"},
+		{"all binary", []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}, "0001020304050607"},
+		{"zstd frame", []byte{0x28, 0xb5, 0x2f, 0xfd, 0, 0, 0, 0}, "28b52ffd"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := make([]byte, 0x30)
+			copy(buf, tc.magic)
+
+			_, err := hgpak.Open(bytes.NewReader(buf), int64(len(buf)))
+			if err == nil {
+				t.Fatal("Open accepted a non-HGPAK file")
+			}
+			if !errors.Is(err, hgpak.ErrNotHGPAK) {
+				t.Errorf("error is %v, want ErrNotHGPAK", err)
+			}
+			msg := err.Error()
+			if strings.Contains(msg, `magic is ""`) || strings.Contains(msg, "magic is ,") {
+				t.Errorf("error names no magic at all: %q", msg)
+			}
+			if !strings.Contains(msg, tc.want) {
+				t.Errorf("error %q does not carry the magic bytes %s", msg, tc.want)
+			}
+		})
+	}
+}
+
+// The eight-byte magic is reported in full even when part of it is
+// printable: "PSAR" is the recognisable half of a PSARC header, not all of
+// it, and a reader diagnosing a wrong-format file wants the rest.
+func TestPrintableMagicIsReportedWithItsFullBytes(t *testing.T) {
+	psarc := make([]byte, 0x30)
+	copy(psarc, []byte("PSAR"))
+	binary.BigEndian.PutUint32(psarc[4:], 0x00010004)
+
+	_, err := hgpak.Open(bytes.NewReader(psarc), int64(len(psarc)))
+	if err == nil {
+		t.Fatal("Open accepted a PSARC archive")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "PSAR") {
+		t.Errorf("error %q lost the recognisable prefix", msg)
+	}
+	if !strings.Contains(msg, "5053415200010004") {
+		t.Errorf("error %q does not carry all eight magic bytes", msg)
+	}
+}


### PR DESCRIPTION
Closes the last outstanding finding from the SPEC-0003 reviews — first raised on #13, carried through eight PRs, and never picked up because it only ever lived in review comments.

## The gap

SPEC-0003 REQ "Container Identification" requires a mismatch to fail *"with an error naming the magic found"*. `printableMagic` returned only the leading run of printable ASCII, so a file whose first byte is binary was refused with:

```
magic is "", want "HGPAK": not an HGPAK archive
```

That names neither what was opened nor that anything was read at all.

**Why it survived so long is the interesting part.** The requirement's own scenario uses a PSARC file, and a PSARC header starts with four printable bytes. So the implementation satisfied the one case the spec names and failed every case it does not — and the test written from that scenario passed. A spec scenario is an example, not a bound, and this is what it looks like when an implementation fits the example rather than the rule.

## The fix

`describeMagic` always carries the eight bytes as hex, and keeps the printable prefix in front of them when there is one:

```
PSARC  magic is "PSAR" (5053415200010004), want "HGPAK": not an HGPAK archive
gzip   magic is 1f8b080000000000, want "HGPAK": not an HGPAK archive
zstd   magic is "(" (28b52ffd00000000), want "HGPAK": not an HGPAK archive
```

The prefix stays because recognisability is the point of the spec's scenario — a reader who sees `PSAR` knows immediately what they opened. The hex is unconditional because the magic is eight bytes and a printable prefix is at most part of it: `"PSAR"` is the recognisable half of a PSARC header, not the whole of it, so even the case that "worked" was naming half the magic.

## Tests

- `TestNonPrintableMagicIsStillNamed` — gzip, all-binary, and zstd-frame leads, each asserting the message is not `magic is ""` and carries the actual bytes
- `TestPrintableMagicIsReportedWithItsFullBytes` — PSARC keeps its recognisable prefix *and* gains the other four bytes

Both **fail against the old implementation**, reporting the literal `magic is ""`. The pre-existing `TestPSARCIsRejectedNamingTheMagic` is untouched and still passes.

## One cosmetic wart, left alone

A magic whose first byte happens to be printable but whose second is not yields a one-character prefix — zstd's `0x28` renders as `"("`. It is noise rather than signal, but suppressing short prefixes would mean inventing a minimum length the spec does not have, and the hex is authoritative in every case. Flagging it rather than papering over it with an arbitrary threshold.

## Verification

| Check | Result |
|---|---|
| `go test -race ./...` | all packages ok |
| `NMS_PCBANKS=... go test` | **97/97 archives** still open |
| `go vet ./...` | clean |
| `staticcheck` v0.8.0-rc.1 | exit 0 |
| `gofmt -l .` | no output |

The 97-archive run matters here: this changes the rejection path, and the acceptance path shares `Open`.