### PR TITLE
feat(domain): stage-2 inputs, base grouping, and constant sources

### DIFF
--- a/internal/domain/rollup.go
+++ b/internal/domain/rollup.go
@@ -1,0 +1,457 @@
+package domain
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+)
+
+// Stage 2's inputs: which leaves belong to which base, how each site is
+// configured, and where every economy constant comes from.
+//
+// Governing: SPEC-0001 REQ "Leaf Assignment to Bases", ADR-0001 (two-tier
+// NMS data ingestion)
+//
+// This file is the boundary between resolving a graph and rolling it up.
+// Stage 1 takes a Tier 1 artifact and a target; it reads no economy
+// constant and needs no base assignment. Stage 2 takes stage 1's output and
+// everything below.
+
+// BaseID identifies a base within a plan. The empty value is not a base —
+// see Unassigned.
+type BaseID string
+
+// Unassigned is the group a leaf lands in when the plan does not say where
+// it comes from.
+//
+// It is deliberately a distinct group rather than a default base: SPEC-0001
+// requires unassigned leaves be "reported in a distinct unassigned group
+// rather than being silently dropped or attributed to a default base",
+// because a plan that quietly builds Frost Crystal at whichever base sorted
+// first is worse than one that says it does not know.
+const Unassigned BaseID = ""
+
+// HotspotClass is the C/B/A/S grade of a hotspot.
+//
+// The class belongs to the hotspot, never to the device: the game has one
+// extractor, not four. Per SPEC-0001 REQ "Producer Rollup" it is configured
+// per site, so every extractor row at a base recomputes together.
+type HotspotClass string
+
+const (
+	ClassC HotspotClass = "C"
+	ClassB HotspotClass = "B"
+	ClassA HotspotClass = "A"
+	ClassS HotspotClass = "S"
+)
+
+var validClasses = map[HotspotClass]bool{ClassC: true, ClassB: true, ClassA: true, ClassS: true}
+
+// Valid reports whether c is one of the four grades.
+func (c HotspotClass) Valid() bool { return validClasses[c] }
+
+// SiteConfig is the per-base configuration the producer stages read.
+type SiteConfig struct {
+	// ExtractorClass is the hotspot grade at this base. Per site rather
+	// than per row, so changing it recomputes every extractor at the base
+	// and nothing anywhere else.
+	//
+	// Governing: SPEC-0001 REQ "Producer Rollup" — "Extractor class MUST be
+	// configured per site, not per row."
+	ExtractorClass HotspotClass
+}
+
+// Curated holds the economy constants no game table states.
+//
+// Governing: SPEC-0001 design.md "Tier 2 constants injected, never
+// hardcoded"; ADR-0001 (curated tier)
+//
+// The list is short and getting shorter. SPEC-0004's normalizer now emits
+// most of what that design entry called Tier 2 — crop yields and growth
+// times, part rates, storage buffers, power draws, hotspot class strengths,
+// refiner throughput — and Constants reads those from the artifact rather
+// than asking a caller to supply them again. What remains here is what a
+// search of the tables did not find.
+//
+// Every field is required. A zero is refused rather than defaulted,
+// because a silently-assumed constant is indistinguishable from a measured
+// one once it reaches a number the user reads.
+type Curated struct {
+	// BiodomeCropSlots is how many plants fit in a biodome. ADR-0001's one
+	// surviving curated entry; the community wiki reports 16 and no table
+	// searched states it. It may be geometric — snap points in the scene —
+	// and therefore extractable after all.
+	BiodomeCropSlots int64
+
+	// FaunaYieldPerCycle is how many units one creature yields per
+	// collection cycle, and FaunaCycleSeconds how long that cycle is.
+	// Neither appears in the reality tables; fauna products are generated
+	// from creature data this pipeline does not read.
+	FaunaYieldPerCycle int64
+	FaunaCycleSeconds  int64
+
+	// StepsPerProcessor is how many nutrient processor steps one processor
+	// covers. A planner policy about how hard to work one machine rather
+	// than a game constant.
+	StepsPerProcessor int64
+
+	// DepotThreshold is the required quantity above which a row reports
+	// supply depots. Also a planner policy — the game does not have an
+	// opinion about when hoarding starts.
+	//
+	// Depot *capacity* is not here: it is U_SILO_S's storage buffer, which
+	// the artifact carries. See Constants.DepotCapacity.
+	DepotThreshold int64
+}
+
+// validate refuses a partially-specified constant set.
+func (c Curated) validate() error {
+	for _, f := range []struct {
+		name string
+		v    int64
+	}{
+		{"biodome crop slots", c.BiodomeCropSlots},
+		{"fauna yield per cycle", c.FaunaYieldPerCycle},
+		{"fauna cycle seconds", c.FaunaCycleSeconds},
+		{"steps per processor", c.StepsPerProcessor},
+		{"depot threshold", c.DepotThreshold},
+	} {
+		if f.v <= 0 {
+			return fmt.Errorf("%w: curated constant %q is %d; it must be supplied, not defaulted",
+				ErrInvalidArtifact, f.name, f.v)
+		}
+	}
+	return nil
+}
+
+// Part IDs the rollup reads by name. Named here rather than inline so the
+// set of buildables this engine depends on is enumerable, and so a game
+// update that renames one fails in a single place.
+const (
+	PartExtractorMineral = "U_EXTRACTOR_S"
+	PartExtractorGas     = "U_GASEXTRACTOR"
+	PartSupplyDepot      = "U_SILO_S"
+	PartBattery          = "U_BATTERY_S"
+	PartGenerator        = "U_GENERATOR_S"
+	PartSolar            = "U_SOLAR_S"
+	PartBiodome          = "BIOROOM"
+	PartRanch            = "CREATURE_FARM"
+	PartFeeder           = "CREATURE_FEED"
+)
+
+// Constants answers "where does this number come from" for every value the
+// producer and power stages need.
+//
+// Governing: SPEC-0001 design.md "Tier 2 constants injected, never
+// hardcoded"
+//
+// Nothing is hardcoded: each accessor either reads the artifact's Economy
+// section or returns a curated value the caller supplied. An accessor whose
+// source is missing returns an error naming what it wanted, so a thinner
+// artifact fails loudly instead of rolling up against zeros.
+type Constants struct {
+	economy *Economy
+	curated Curated
+
+	crops map[string]Crop
+	parts map[string]Part
+	spots map[string]Hotspot
+}
+
+// NewConstants indexes an artifact's economy section against the curated
+// values, refusing an artifact that carries none.
+func NewConstants(t *Tier1, curated Curated) (*Constants, error) {
+	if t == nil || t.Economy == nil {
+		return nil, fmt.Errorf("%w: the artifact carries no economy section; "+
+			"regenerate it with cmd/nmstier1", ErrInvalidArtifact)
+	}
+	if err := curated.validate(); err != nil {
+		return nil, err
+	}
+
+	c := &Constants{
+		economy: t.Economy,
+		curated: curated,
+		crops:   make(map[string]Crop, len(t.Economy.Crops)),
+		parts:   make(map[string]Part, len(t.Economy.Parts)),
+		spots:   make(map[string]Hotspot, len(t.Economy.Hotspots)),
+	}
+	// Crops are indexed by what they yield rather than by the plant's own
+	// ID, because a rollup starts from a leaf item the graph named.
+	for _, crop := range t.Economy.Crops {
+		c.crops[crop.Substance] = crop
+	}
+	for _, p := range t.Economy.Parts {
+		c.parts[p.ID] = p
+	}
+	for _, h := range t.Economy.Hotspots {
+		c.spots[h.Category] = h
+	}
+	return c, nil
+}
+
+// Curated returns the caller-supplied constants.
+func (c *Constants) Curated() Curated { return c.curated }
+
+// CropFor returns the crop that yields the given item.
+func (c *Constants) CropFor(itemID string) (Crop, error) {
+	crop, ok := c.crops[itemID]
+	if !ok {
+		return Crop{}, fmt.Errorf("%w: no crop in the artifact yields %q", ErrUnknownItem, itemID)
+	}
+	return crop, nil
+}
+
+// IsCrop reports whether a farmable plant yields the given item.
+func (c *Constants) IsCrop(itemID string) bool {
+	_, ok := c.crops[itemID]
+	return ok
+}
+
+// Part returns a buildable's economy record.
+func (c *Constants) Part(id string) (Part, error) {
+	p, ok := c.parts[id]
+	if !ok {
+		return Part{}, fmt.Errorf("%w: the artifact carries no part %q", ErrUnknownItem, id)
+	}
+	return p, nil
+}
+
+// DepotCapacity is one supply depot's storage buffer.
+//
+// Read from the artifact rather than curated: the design entry lists depot
+// capacity among the hand-curated constants, but U_SILO_S states it. The
+// *threshold* — when a plan should start reporting depots at all — is the
+// part with no source, and that one is curated.
+func (c *Constants) DepotCapacity() (int64, error) {
+	p, err := c.Part(PartSupplyDepot)
+	if err != nil {
+		return 0, err
+	}
+	if p.Primary.Storage <= 0 {
+		return 0, fmt.Errorf("%w: %s states no storage buffer", ErrInvalidArtifact, PartSupplyDepot)
+	}
+	return p.Primary.Storage, nil
+}
+
+// BatteryCapacity is one battery's stored charge.
+//
+// Also read rather than curated, for the same reason: U_BATTERY_S states it.
+func (c *Constants) BatteryCapacity() (int64, error) {
+	p, err := c.Part(PartBattery)
+	if err != nil {
+		return 0, err
+	}
+	if p.Primary.Storage <= 0 {
+		return 0, fmt.Errorf("%w: %s states no storage buffer", ErrInvalidArtifact, PartBattery)
+	}
+	return p.Primary.Storage, nil
+}
+
+// ClassStrength is a hotspot category's output multiplier at a class, as an
+// exact rational.
+//
+// Governing: SPEC-0001 REQ "Exact Arithmetic and Rounding Discipline" —
+// "Multipliers that are not integers ... MUST be applied as exact rational
+// arithmetic."
+//
+// The conversion from the stored float64 is exact for every value NMS 5.97
+// carries (1, 1.5, 2, 2.5 for resources; 150, 220, 250, 300 for power — all
+// binary-exact). The exposure is upstream rather than here: ClassValues is
+// float64 in the schema, so a source value that is not binary-representable
+// would already have been rounded at decode. No such value exists today;
+// worth revisiting if one appears.
+func (c *Constants) ClassStrength(category string, class HotspotClass) (*big.Rat, error) {
+	if !class.Valid() {
+		return nil, fmt.Errorf("%w: %q is not a hotspot class (C, B, A, S)", ErrInvalidArtifact, class)
+	}
+	h, ok := c.spots[category]
+	if !ok {
+		return nil, fmt.Errorf("%w: the artifact carries no %q hotspot", ErrUnknownItem, category)
+	}
+	var v float64
+	switch class {
+	case ClassC:
+		v = h.Strengths.C
+	case ClassB:
+		v = h.Strengths.B
+	case ClassA:
+		v = h.Strengths.A
+	case ClassS:
+		v = h.Strengths.S
+	}
+	r := new(big.Rat).SetFloat64(v)
+	if r == nil {
+		return nil, fmt.Errorf("%w: %s class %s strength is not a finite number", ErrInvalidArtifact, category, class)
+	}
+	if r.Sign() <= 0 {
+		return nil, fmt.Errorf("%w: %s class %s strength is %v", ErrInvalidArtifact, category, class, v)
+	}
+	return r, nil
+}
+
+// RollupInput is stage 2's input, alongside stage 1's resolved graph.
+type RollupInput struct {
+	// Assignments maps a leaf item ID to the base that produces it. A leaf
+	// absent from the map is unassigned, which is a reported state rather
+	// than an error.
+	Assignments map[string]BaseID
+
+	// Sites configures each base. A base named in Assignments but absent
+	// here is refused rather than defaulted: an extractor class picked for
+	// the caller is a number they never chose showing up in their plan.
+	Sites map[BaseID]SiteConfig
+}
+
+// LeafDemand is one leaf item's requirement at a base.
+type LeafDemand struct {
+	ItemID string
+	Name   string
+
+	// Verified carries stage 1's provenance forward, so a base row derived
+	// from unverified data stays marked as such.
+	Verified bool
+
+	total *big.Rat
+}
+
+// Total returns the required quantity as an exact rational.
+func (d LeafDemand) Total() *big.Rat { return new(big.Rat).Set(d.total) }
+
+// TotalInt returns the requirement as an int64, reporting whether that was
+// exact.
+func (d LeafDemand) TotalInt() (int64, bool) {
+	if !d.total.IsInt() || !d.total.Num().IsInt64() {
+		return 0, false
+	}
+	return d.total.Num().Int64(), true
+}
+
+// BaseGroup is one base's assigned leaves.
+type BaseGroup struct {
+	// Base is the base ID, or Unassigned for the group of leaves the plan
+	// does not place.
+	Base BaseID
+
+	// Site is the base's configuration. Zero for the unassigned group,
+	// which has no site.
+	Site SiteConfig
+
+	// Demands are the leaves assigned here, sorted by item ID.
+	Demands []LeafDemand
+}
+
+// IsUnassigned reports whether this is the group for unplaced leaves.
+func (g BaseGroup) IsUnassigned() bool { return g.Base == Unassigned }
+
+// Grouping is stage 2's first output: stage 1's leaf totals, grouped by base.
+type Grouping struct {
+	// Groups are the bases with assigned leaves, sorted by base ID, with
+	// the unassigned group last if it has anything in it.
+	Groups []BaseGroup
+
+	byBase map[BaseID]*BaseGroup
+}
+
+// Group returns a base's group.
+func (g *Grouping) Group(base BaseID) (BaseGroup, bool) {
+	b, ok := g.byBase[base]
+	if !ok {
+		return BaseGroup{}, false
+	}
+	return *b, true
+}
+
+// Unassigned returns the group of leaves with no base, and whether any exist.
+func (g *Grouping) Unassigned() (BaseGroup, bool) { return g.Group(Unassigned) }
+
+// GroupLeaves groups a resolved graph's leaf totals by assigned base.
+//
+// Governing: SPEC-0001 REQ "Leaf Assignment to Bases"
+//
+// Only leaves are grouped. An intermediate node is something the plan makes
+// rather than something a base produces, so it has no place in a producer
+// rollup — it reaches the rollup through the leaf totals it drove.
+//
+// Reassignment needs no special handling: this is a pure function of the
+// graph and the assignment, so moving a leaf and re-running recomputes both
+// the base it left and the one it joined.
+func GroupLeaves(g *ResolvedGraph, in RollupInput) (*Grouping, error) {
+	if g == nil {
+		return nil, fmt.Errorf("%w: nil resolved graph", ErrInvalidArtifact)
+	}
+
+	// Every base named in an assignment must be configured. Checked before
+	// grouping so the error names the omission rather than surfacing later
+	// as an extractor sized at class "".
+	for item, base := range in.Assignments {
+		if base == Unassigned {
+			return nil, fmt.Errorf("%w: %q is assigned to the empty base id; omit it to leave it unassigned",
+				ErrInvalidArtifact, item)
+		}
+		site, ok := in.Sites[base]
+		if !ok {
+			return nil, fmt.Errorf("%w: base %q has no site configuration", ErrInvalidArtifact, base)
+		}
+		if !site.ExtractorClass.Valid() {
+			return nil, fmt.Errorf("%w: base %q extractor class %q is not one of C, B, A, S",
+				ErrInvalidArtifact, base, site.ExtractorClass)
+		}
+	}
+
+	out := &Grouping{byBase: map[BaseID]*BaseGroup{}}
+	for _, n := range g.Leaves() {
+		base, assigned := in.Assignments[n.ItemID]
+		if !assigned {
+			base = Unassigned
+		}
+		group, ok := out.byBase[base]
+		if !ok {
+			group = &BaseGroup{Base: base, Site: in.Sites[base]}
+			out.byBase[base] = group
+		}
+		group.Demands = append(group.Demands, LeafDemand{
+			ItemID:   n.ItemID,
+			Name:     n.Name,
+			Verified: n.Verified,
+			total:    n.Total(),
+		})
+	}
+
+	// An assignment naming an item the graph does not reach as a leaf is a
+	// stale plan, not a silent no-op. Reported so a leaf that stopped being
+	// a leaf — because a method changed and it now expands — is visible.
+	reached := map[string]bool{}
+	for _, n := range g.Leaves() {
+		reached[n.ItemID] = true
+	}
+	var stale []string
+	for item := range in.Assignments {
+		if !reached[item] {
+			stale = append(stale, item)
+		}
+	}
+	if len(stale) > 0 {
+		sort.Strings(stale)
+		return nil, fmt.Errorf("%w: assigned to a base but not a leaf of this graph: %v",
+			ErrUnknownItem, stale)
+	}
+
+	// Sorted so output ordering never depends on map iteration, with the
+	// unassigned group last because it is a remainder rather than a base.
+	// Governing: SPEC-0001 REQ "Determinism".
+	for _, group := range out.byBase {
+		sort.Slice(group.Demands, func(i, j int) bool {
+			return group.Demands[i].ItemID < group.Demands[j].ItemID
+		})
+		out.Groups = append(out.Groups, *group)
+	}
+	sort.Slice(out.Groups, func(i, j int) bool {
+		a, b := out.Groups[i], out.Groups[j]
+		if a.IsUnassigned() != b.IsUnassigned() {
+			return b.IsUnassigned()
+		}
+		return a.Base < b.Base
+	})
+	return out, nil
+}

--- a/internal/domain/rollup_test.go
+++ b/internal/domain/rollup_test.go
@@ -1,0 +1,463 @@
+package domain
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// realArtifact is the generated dataset, which carries the economy section
+// the constants resolve against. Tests that only need a graph use the
+// hand-authored fixture; tests about where a constant comes from need the
+// real one, because "it reads from Economy" is only meaningful against the
+// Economy the normalizer actually emits.
+func realArtifact(t *testing.T) *Tier1 {
+	t.Helper()
+	f, err := os.Open("../../data/tier1.json")
+	if err != nil {
+		t.Fatalf("opening the generated artifact: %v", err)
+	}
+	defer f.Close()
+	a1, err := LoadTier1(f)
+	if err != nil {
+		t.Fatalf("loading the generated artifact: %v", err)
+	}
+	return a1
+}
+
+// curatedForTest is a complete curated set. Values are the community-reported
+// ones where a report exists and placeholders otherwise; the point of these
+// tests is that they arrive from the caller, not what they are.
+func curatedForTest() Curated {
+	return Curated{
+		BiodomeCropSlots:   16,
+		FaunaYieldPerCycle: 12,
+		FaunaCycleSeconds:  1800,
+		StepsPerProcessor:  2,
+		DepotThreshold:     1000,
+	}
+}
+
+func sites(bases ...BaseID) map[BaseID]SiteConfig {
+	out := map[BaseID]SiteConfig{}
+	for _, b := range bases {
+		out[b] = SiteConfig{ExtractorClass: ClassB}
+	}
+	return out
+}
+
+// SPEC-0001 REQ "Leaf Assignment to Bases":
+// WHEN crops are assigned to one base and gases to another
+// THEN each base's rollup contains only its assigned leaf items.
+func TestLeavesGroupByBase(t *testing.T) {
+	g := resolveStasis(t, 1, nil)
+
+	in := RollupInput{
+		Assignments: map[string]BaseID{
+			// Crops at one base, gases at another.
+			"fc": "farm", "sol": "farm", "cf": "farm", "sb": "farm", "gr": "farm", "fae": "farm",
+			"sul": "gasfield", "nit": "gasfield", "rad": "gasfield",
+		},
+		Sites: sites("farm", "gasfield"),
+	}
+	grouping, err := GroupLeaves(g, in)
+	if err != nil {
+		t.Fatalf("GroupLeaves: %v", err)
+	}
+
+	farm, ok := grouping.Group("farm")
+	if !ok {
+		t.Fatal("farm group missing")
+	}
+	gas, ok := grouping.Group("gasfield")
+	if !ok {
+		t.Fatal("gasfield group missing")
+	}
+
+	for _, d := range farm.Demands {
+		if strings.Contains("sul nit rad", d.ItemID) {
+			t.Errorf("gas %q leaked into the farm group", d.ItemID)
+		}
+	}
+	if len(gas.Demands) != 3 {
+		t.Errorf("gasfield has %d demands, want 3", len(gas.Demands))
+	}
+	for _, d := range gas.Demands {
+		got, exact := d.TotalInt()
+		if !exact || got != 500 {
+			t.Errorf("%s total = %s, want 500", d.ItemID, d.Total().RatString())
+		}
+	}
+
+	// Sorted, so output order never depends on map iteration.
+	for i := 1; i < len(farm.Demands); i++ {
+		if farm.Demands[i-1].ItemID >= farm.Demands[i].ItemID {
+			t.Errorf("farm demands are not sorted: %v", farm.Demands)
+		}
+	}
+}
+
+// SPEC-0001 REQ "Leaf Assignment to Bases":
+// WHEN a leaf item has no base assignment
+// THEN it appears in the unassigned group with its full required total.
+func TestUnassignedLeavesAreSurfaced(t *testing.T) {
+	g := resolveStasis(t, 1, nil)
+
+	// Assign only the gases; everything else is unplaced.
+	grouping, err := GroupLeaves(g, RollupInput{
+		Assignments: map[string]BaseID{"sul": "gasfield", "nit": "gasfield", "rad": "gasfield"},
+		Sites:       sites("gasfield"),
+	})
+	if err != nil {
+		t.Fatalf("GroupLeaves: %v", err)
+	}
+
+	un, ok := grouping.Unassigned()
+	if !ok {
+		t.Fatal("no unassigned group, but most leaves were left unplaced")
+	}
+	if !un.IsUnassigned() {
+		t.Error("the unassigned group does not report itself as unassigned")
+	}
+
+	// Condensed Carbon is unassigned and must carry its whole requirement,
+	// not a share of it and not zero.
+	var cc *LeafDemand
+	for i := range un.Demands {
+		if un.Demands[i].ItemID == "cc" {
+			cc = &un.Demands[i]
+		}
+	}
+	if cc == nil {
+		t.Fatal("cc is not in the unassigned group; an unplaced leaf was dropped")
+	}
+	if got, exact := cc.TotalInt(); !exact || got != 300 {
+		t.Errorf("cc total = %s, want 300", cc.Total().RatString())
+	}
+
+	// It is a distinct group, not a base: nothing was attributed to
+	// gasfield that was not assigned there.
+	gas, _ := grouping.Group("gasfield")
+	if len(gas.Demands) != 3 {
+		t.Errorf("gasfield picked up %d demands, want only its 3 assigned", len(gas.Demands))
+	}
+
+	// And the unassigned group sorts last — a remainder, not a base.
+	if last := grouping.Groups[len(grouping.Groups)-1]; !last.IsUnassigned() {
+		t.Errorf("last group is %q, want the unassigned group", last.Base)
+	}
+
+	// Every leaf lands somewhere.
+	var counted int
+	for _, group := range grouping.Groups {
+		counted += len(group.Demands)
+	}
+	if want := len(g.Leaves()); counted != want {
+		t.Errorf("grouped %d leaves, graph has %d", counted, want)
+	}
+}
+
+// SPEC-0001 REQ "Leaf Assignment to Bases":
+// WHEN a leaf is reassigned from one base to another
+// THEN both the origin and destination base rollups are recomputed.
+func TestReassignmentRecomputesBothBases(t *testing.T) {
+	g := resolveStasis(t, 1, nil)
+
+	before, err := GroupLeaves(g, RollupInput{
+		Assignments: map[string]BaseID{"sul": "alpha", "nit": "alpha", "rad": "beta"},
+		Sites:       sites("alpha", "beta"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := GroupLeaves(g, RollupInput{
+		Assignments: map[string]BaseID{"sul": "alpha", "nit": "beta", "rad": "beta"},
+		Sites:       sites("alpha", "beta"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a0, _ := before.Group("alpha")
+	b0, _ := before.Group("beta")
+	a1, _ := after.Group("alpha")
+	b1, _ := after.Group("beta")
+
+	if len(a0.Demands) != 2 || len(b0.Demands) != 1 {
+		t.Fatalf("before: alpha %d, beta %d; want 2 and 1", len(a0.Demands), len(b0.Demands))
+	}
+	// The origin shrank and the destination grew — both recomputed, not
+	// just the one that gained.
+	if len(a1.Demands) != 1 {
+		t.Errorf("after: alpha has %d demands, want 1 — the origin was not recomputed", len(a1.Demands))
+	}
+	if len(b1.Demands) != 2 {
+		t.Errorf("after: beta has %d demands, want 2", len(b1.Demands))
+	}
+	if a1.Demands[0].ItemID != "sul" {
+		t.Errorf("alpha kept %q, want sul", a1.Demands[0].ItemID)
+	}
+}
+
+// SPEC-0001 REQ "Producer Rollup" — "Extractor class MUST be configured per
+// site, not per row."
+func TestExtractorClassIsPerSite(t *testing.T) {
+	g := resolveStasis(t, 1, nil)
+
+	in := RollupInput{
+		Assignments: map[string]BaseID{"sul": "alpha", "nit": "alpha", "rad": "beta"},
+		Sites: map[BaseID]SiteConfig{
+			"alpha": {ExtractorClass: ClassS},
+			"beta":  {ExtractorClass: ClassC},
+		},
+	}
+	grouping, err := GroupLeaves(g, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	alpha, _ := grouping.Group("alpha")
+	beta, _ := grouping.Group("beta")
+	if alpha.Site.ExtractorClass != ClassS {
+		t.Errorf("alpha class = %q, want S", alpha.Site.ExtractorClass)
+	}
+	if beta.Site.ExtractorClass != ClassC {
+		t.Errorf("beta class = %q, want C", beta.Site.ExtractorClass)
+	}
+	// One class per site, not per row: both of alpha's rows read the same
+	// setting because it lives on the group.
+	if len(alpha.Demands) != 2 {
+		t.Fatalf("alpha has %d demands, want 2", len(alpha.Demands))
+	}
+}
+
+// A base with assignments but no configuration is refused rather than
+// defaulted — an extractor class picked for the caller is a number they
+// never chose showing up in their plan.
+func TestUnconfiguredBaseIsRefused(t *testing.T) {
+	g := resolveStasis(t, 1, nil)
+
+	cases := []struct {
+		name string
+		in   RollupInput
+		want string
+	}{
+		{
+			name: "no site configuration",
+			in: RollupInput{
+				Assignments: map[string]BaseID{"sul": "alpha"},
+				Sites:       map[BaseID]SiteConfig{},
+			},
+			want: "no site configuration",
+		},
+		{
+			name: "class outside the vocabulary",
+			in: RollupInput{
+				Assignments: map[string]BaseID{"sul": "alpha"},
+				Sites:       map[BaseID]SiteConfig{"alpha": {ExtractorClass: "X"}},
+			},
+			want: "not one of C, B, A, S",
+		},
+		{
+			name: "assigned to the empty base id",
+			in: RollupInput{
+				Assignments: map[string]BaseID{"sul": Unassigned},
+				Sites:       sites("alpha"),
+			},
+			want: "empty base id",
+		},
+		{
+			name: "assigned an item that is not a leaf",
+			in: RollupInput{
+				// The Stasis Device itself is the target, not a leaf.
+				Assignments: map[string]BaseID{"sd": "alpha"},
+				Sites:       sites("alpha"),
+			},
+			want: "not a leaf of this graph",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := GroupLeaves(g, tc.in)
+			if err == nil {
+				t.Fatal("GroupLeaves accepted it")
+			}
+			if out != nil {
+				t.Error("a grouping was returned alongside an error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// SPEC-0001 design.md "Tier 2 constants injected, never hardcoded" — every
+// constant the later stages need resolves to an Economy field or to an
+// explicit curated input.
+func TestConstantsResolveToTheirSource(t *testing.T) {
+	c, err := NewConstants(realArtifact(t), curatedForTest())
+	if err != nil {
+		t.Fatalf("NewConstants: %v", err)
+	}
+
+	// From the artifact: crop yields and growth times.
+	crop, err := c.CropFor("PLANT_SNOW")
+	if err != nil {
+		t.Fatalf("CropFor: %v", err)
+	}
+	if crop.Yield.Min != 50 || crop.Yield.Max != 50 {
+		t.Errorf("Frost Crystal yield = %+v, want 50/50", crop.Yield)
+	}
+	if crop.GrowthSeconds != 3600 {
+		t.Errorf("Frost Crystal growth = %d, want 3600", crop.GrowthSeconds)
+	}
+
+	// From the artifact: part rates, storage and draws.
+	ext, err := c.Part(PartExtractorMineral)
+	if err != nil {
+		t.Fatalf("Part: %v", err)
+	}
+	if ext.Primary.Rate != 100 || ext.Primary.Storage != 360000 {
+		t.Errorf("extractor primary = %+v, want rate 100 storage 360000", ext.Primary)
+	}
+	if len(ext.Dependencies) != 1 || ext.Dependencies[0].Rate != -50 {
+		t.Errorf("extractor draws %+v, want a single -50 power dependency", ext.Dependencies)
+	}
+
+	// From the artifact, though the design entry calls them curated: the
+	// silo and the battery both state their buffers.
+	if got, err := c.DepotCapacity(); err != nil || got != 1440000 {
+		t.Errorf("DepotCapacity = %d, %v; want 1440000", got, err)
+	}
+	if got, err := c.BatteryCapacity(); err != nil || got != 45000 {
+		t.Errorf("BatteryCapacity = %d, %v; want 45000", got, err)
+	}
+
+	// From the artifact: class scaling, as an exact rational.
+	for _, tc := range []struct {
+		category string
+		class    HotspotClass
+		want     string
+	}{
+		{"Mineral", ClassC, "1"}, {"Mineral", ClassB, "3/2"}, {"Mineral", ClassS, "5/2"},
+		{"Power", ClassC, "150"}, {"Power", ClassS, "300"},
+	} {
+		got, err := c.ClassStrength(tc.category, tc.class)
+		if err != nil {
+			t.Errorf("ClassStrength(%s, %s): %v", tc.category, tc.class, err)
+			continue
+		}
+		if got.RatString() != tc.want {
+			t.Errorf("%s class %s = %s, want %s", tc.category, tc.class, got.RatString(), tc.want)
+		}
+	}
+
+	// Curated: supplied by the caller, echoed back unchanged.
+	if c.Curated().BiodomeCropSlots != 16 {
+		t.Errorf("biodome slots = %d, want the caller's 16", c.Curated().BiodomeCropSlots)
+	}
+}
+
+// A curated constant left at zero is refused rather than defaulted.
+func TestCuratedConstantsMustBeSupplied(t *testing.T) {
+	a1 := realArtifact(t)
+
+	full := curatedForTest()
+	cases := map[string]func(*Curated){
+		"biodome crop slots":    func(c *Curated) { c.BiodomeCropSlots = 0 },
+		"fauna yield per cycle": func(c *Curated) { c.FaunaYieldPerCycle = 0 },
+		"fauna cycle seconds":   func(c *Curated) { c.FaunaCycleSeconds = 0 },
+		"steps per processor":   func(c *Curated) { c.StepsPerProcessor = 0 },
+		"depot threshold":       func(c *Curated) { c.DepotThreshold = 0 },
+	}
+	for name, clear := range cases {
+		t.Run(name, func(t *testing.T) {
+			curated := full
+			clear(&curated)
+			c, err := NewConstants(a1, curated)
+			if !errors.Is(err, ErrInvalidArtifact) {
+				t.Fatalf("error = %v, want ErrInvalidArtifact", err)
+			}
+			if c != nil {
+				t.Error("constants were returned alongside an error")
+			}
+			if !strings.Contains(err.Error(), name) {
+				t.Errorf("error %q does not name the missing constant", err)
+			}
+		})
+	}
+}
+
+// An artifact with no economy section fails loudly rather than rolling up
+// against zeros.
+func TestMissingEconomyIsRefused(t *testing.T) {
+	fixture := loadFixture(t) // the hand-authored graph carries no economy
+	if fixture.Economy != nil {
+		t.Skip("the fixture now carries an economy section")
+	}
+
+	c, err := NewConstants(fixture, curatedForTest())
+	if !errors.Is(err, ErrInvalidArtifact) {
+		t.Fatalf("error = %v, want ErrInvalidArtifact", err)
+	}
+	if c != nil {
+		t.Error("constants were returned alongside an error")
+	}
+	if !strings.Contains(err.Error(), "economy") {
+		t.Errorf("error %q does not say what was missing", err)
+	}
+}
+
+// A constant whose source the artifact does not carry errors naming what it
+// wanted, rather than returning a zero that looks like data.
+func TestAbsentSourceIsNamed(t *testing.T) {
+	c, err := NewConstants(realArtifact(t), curatedForTest())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := c.Part("U_NOT_A_PART"); !errors.Is(err, ErrUnknownItem) {
+		t.Errorf("Part error = %v, want ErrUnknownItem", err)
+	}
+	if _, err := c.CropFor("NOT_A_CROP"); !errors.Is(err, ErrUnknownItem) {
+		t.Errorf("CropFor error = %v, want ErrUnknownItem", err)
+	}
+	if _, err := c.ClassStrength("Antimatter", ClassS); !errors.Is(err, ErrUnknownItem) {
+		t.Errorf("ClassStrength error = %v, want ErrUnknownItem", err)
+	}
+	if _, err := c.ClassStrength("Mineral", "X"); !errors.Is(err, ErrInvalidArtifact) {
+		t.Errorf("ClassStrength with a bad class = %v, want ErrInvalidArtifact", err)
+	}
+}
+
+// SPEC-0001's stage boundary: resolving a graph reads no economy constant
+// and needs no base assignment.
+//
+// Asserted on the fixture, which carries no economy section at all — if
+// stage 1 had started depending on one, this could not resolve.
+func TestStageOneNeedsNoRollupConfiguration(t *testing.T) {
+	fixture := loadFixture(t)
+	if fixture.Economy != nil {
+		t.Skip("the fixture now carries an economy section")
+	}
+
+	g, err := Resolve(fixture, PlanInput{Target: "sd", Quantity: 1})
+	if err != nil {
+		t.Fatalf("resolving without economy data: %v", err)
+	}
+	if len(g.Nodes) == 0 {
+		t.Fatal("resolved an empty graph")
+	}
+
+	// And grouping with no assignment at all is valid — every leaf simply
+	// lands unassigned.
+	grouping, err := GroupLeaves(g, RollupInput{})
+	if err != nil {
+		t.Fatalf("GroupLeaves with no configuration: %v", err)
+	}
+	if len(grouping.Groups) != 1 || !grouping.Groups[0].IsUnassigned() {
+		t.Errorf("groups = %+v, want one unassigned group", grouping.Groups)
+	}
+}


### PR DESCRIPTION
## What

Implements #39, the foundation story for #40 and #41. Establishes the boundary between resolving a graph and rolling it up: `RollupInput`, `SiteConfig`, `Curated`, `Constants`, and `GroupLeaves`.

## Settling the ADR-vs-spec contradiction

The story's substance was resolving where each constant comes from. SPEC-0001's design lists a dozen as "provisional and hand-curated"; ADR-0001 says the curated tier holds one entry. **Both were wrong, in opposite directions** — and I checked the generated artifact rather than trusting either list.

| Constant | Source | Design said |
|---|---|---|
| Crop yield, growth time | `Economy.Crops[]` | curated |
| Part rates, storage, power draws | `Economy.Parts[]` | curated |
| Class strengths C/B/A/S | `Economy.Hotspots[]` | curated |
| Refiner throughput | `Economy.Refining` | curated |
| **Depot capacity** | **`U_SILO_S.primary.storage` = 1,440,000** | curated |
| **Battery capacity** | **`U_BATTERY_S.primary.storage` = 45,000** | curated |
| Biodome crop slots | curated (ADR-0001's entry) | curated |
| Fauna yield, cycle time | curated — no source found | curated |
| Steps per nutrient processor | curated — planner policy | curated |
| Depot **threshold** | curated — planner policy | curated |

Depot and battery capacity have sources. The threshold — *when* a plan should start reporting depots — does not, because the game has no opinion about when hoarding starts. That distinction is now in the code: `Constants.DepotCapacity()` reads the artifact, `Curated.DepotThreshold` is supplied.

Two of the remaining five are planner policy rather than missing game data, which is worth separating: nobody will ever find them in a table.

## Design

- **Unassigned is a distinct group, not a default base.** It sorts last because it is a remainder. A plan that quietly builds Frost Crystal at whichever base sorted first is worse than one that says it does not know.
- **Reassignment needs no special handling.** `GroupLeaves` is a pure function of the graph and the assignment, so moving a leaf and re-running recomputes both bases. The test asserts the *origin* shrank, not just that the destination grew.
- **A stale assignment is an error.** Naming something that is not a leaf of this graph — because a method changed and it now expands — is reported rather than silently ignored.
- **An unconfigured base is refused.** An extractor class picked for the caller is a number they never chose appearing in their plan.
- **Every curated constant is required.** A zero is refused, not defaulted.
- **Part IDs are enumerated as constants** so the set of buildables this engine depends on is listable, and a rename fails in one place.

## One thing worth knowing about exactness

`ClassStrength` returns `*big.Rat`, and the conversion is exact for every value NMS 5.97 carries — 1, 1.5, 2, 2.5, 150, 220, 250, 300 are all binary-exact.

The exposure is upstream: `ClassValues` is `float64` in the schema, so a source value that is *not* binary-representable would already have been rounded at JSON decode, before this code sees it. No such value exists today, so this is latent rather than live. Noted in the accessor where it would bite. If one ever appears, the fix is in the schema, not here.

## Tests

Grouping tests run against the hand-authored fixture; constant-source tests run against `data/tier1.json`, because "it reads from `Economy`" is only meaningful against the `Economy` the normalizer actually emits.

- Crops at one base and gases at another, with no cross-contamination and sorted output
- An unassigned leaf carries its **full** 300 Condensed Carbon, is in a distinct group, and every leaf lands somewhere (counted against `len(g.Leaves())`)
- Reassignment: origin drops to 1 demand, destination rises to 2
- Extractor class differs per site and is readable from the group
- Four refusal cases: unconfigured base, class outside C/B/A/S, the empty base id, and a non-leaf assignment
- Every curated constant refused at zero, named individually
- `Resolve` still works on the fixture, **which carries no economy section at all** — if stage 1 had started depending on one, that test could not pass

`go vet`, `staticcheck v0.8.0-rc.1`, `gofmt -l` clean.

### Deferred Design Doc Updates

Per the issue, the SPEC-0001 design amendment is a companion docs PR rather than part of this branch:

- `docs/openspec/specs/rollup-engine/design.md`, "Tier 2 constants injected, never hardcoded": replace the list of hand-curated constants with the per-constant source mapping above. Record that depot capacity and battery capacity read from `Economy`, that steps-per-processor and depot threshold are planner policy rather than missing game data, and that fauna yield and cycle time are the only genuinely unsourced game values.
- Same file: note that the injection principle is unchanged — nothing is hardcoded — but that "injected" now means "read from the artifact" for most of the list.

Closes #39
Part of #38

Implements SPEC-0001 REQ "Leaf Assignment to Bases".

🤖 Generated with [Claude Code](https://claude.com/claude-code)