### PR TITLE
feat(bridge): result envelope, exact quantity encoding, determinism

### DIFF
--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -1,0 +1,310 @@
+// Package bridge encodes domain values for the boundary the view consumes.
+//
+// Governing: ADR-0003 (Go domain, thin adapter), SPEC-0002 REQ "Result
+// Envelope", REQ "Exact Quantity Encoding", REQ "Recipe Selection Crossing",
+// REQ "Determinism Across the Boundary"
+//
+// ADR-0003 splits the application into a domain package that imports no
+// syscall/js and a thin adapter that is the only code permitted to touch
+// js.Value. This package is the encoding half of that adapter, and it is
+// deliberately free of syscall/js too: everything here is testable under
+// plain `go test` with no WASM build, and the js-facing shim is a later
+// story that marshals what this produces.
+//
+// The one rule that shapes every type below: a quantity never becomes a
+// JSON number. JavaScript's number type cannot hold 2^53 exactly, and the
+// engine's whole exactness commitment would be spent one step before the
+// value a user reads.
+package bridge
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/jonstump/nms-base-planner/internal/domain"
+)
+
+// ContractVersion is the boundary contract this package implements.
+//
+// Governing: SPEC-0002 REQ "Contract Versioning" — "The version MUST change
+// whenever the envelope shape, the encoding of quantities, or the sentinel
+// code set changes." The consuming view checks it and refuses a mismatch
+// rather than parsing an unexpected shape.
+const ContractVersion = "1.0.0"
+
+// Quantity is an exact quantity on the wire.
+//
+// Governing: SPEC-0002 REQ "Exact Quantity Encoding" — "Every quantity
+// crossing the boundary MUST be encoded as a decimal string, never as a
+// JavaScript number ... Where a total is not an exact integer, it MUST be
+// encoded as an exact decimal or rational string that round-trips without
+// loss."
+//
+// Integral values render as decimal digits ("300"); a fractional value
+// renders as a rational ("5/2"). Both round-trip exactly. The alternative
+// for the fractional case — a fixed number of decimal places — has to
+// choose a precision, and any choice truncates some value the engine
+// computed exactly.
+type Quantity string
+
+// QuantityOf renders an exact rational.
+//
+// big.Rat.RatString is the only formatter used: it emits "a/b", or just "a"
+// when the denominator is one, and it is lossless in both cases.
+// FloatString rounds to a fixed number of places, and Float64 is a
+// conversion this package must not make.
+func QuantityOf(r *big.Rat) Quantity {
+	if r == nil {
+		return "0"
+	}
+	return Quantity(r.RatString())
+}
+
+// QuantityOfInt renders an integer quantity.
+func QuantityOfInt(v int64) Quantity { return Quantity(new(big.Int).SetInt64(v).String()) }
+
+// Rat parses a Quantity back to an exact rational, which is what makes
+// "round-trips without loss" checkable rather than asserted.
+func (q Quantity) Rat() (*big.Rat, bool) {
+	r, ok := new(big.Rat).SetString(string(q))
+	return r, ok
+}
+
+// Envelope is what every entry point returns.
+//
+// Governing: SPEC-0002 REQ "Result Envelope" — "a single envelope carrying
+// an explicit success flag, exactly one of a result payload or an error
+// payload, and the contract version."
+//
+// Data and Error are pointers so that exactly one is present on the wire. A
+// failure marshals with no data key at all rather than with an empty object:
+// the requirement's scenario says "carries no result payload — not an empty
+// one", and a zero-valued struct that renders as {} reads to a consumer as
+// a successful call that produced nothing.
+type Envelope struct {
+	OK              bool           `json:"ok"`
+	ContractVersion string         `json:"contractVersion"`
+	Data            *ResultPayload `json:"data,omitempty"`
+	Error           *ErrorPayload  `json:"error,omitempty"`
+}
+
+// ResultPayload is the success half.
+type ResultPayload struct {
+	Graph *Graph `json:"graph,omitempty"`
+}
+
+// ErrorPayload is the failure half.
+//
+// Code is a stable machine-readable identifier; the sentinel mapping that
+// fills it is #44's story, and until then everything crosses as
+// CodeUnclassified. Message carries the domain's prose, including the
+// wrapped resolution path, with no contractual guarantee of format.
+type ErrorPayload struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// CodeUnclassified is the code reserved for a failure matching no known
+// sentinel. SPEC-0002 REQ "Sentinel Error Preservation" requires the
+// reserved code exist so an unmatched error is never silently mapped onto
+// an unrelated sentinel; the rest of the code set arrives with #44.
+const CodeUnclassified = "UNCLASSIFIED"
+
+// Success builds an envelope carrying a payload and no error.
+func Success(data ResultPayload) Envelope {
+	return Envelope{OK: true, ContractVersion: ContractVersion, Data: &data}
+}
+
+// Failure builds an envelope carrying an error and no payload.
+func Failure(code, message string) Envelope {
+	if code == "" {
+		code = CodeUnclassified
+	}
+	return Envelope{
+		OK:              false,
+		ContractVersion: ContractVersion,
+		Error:           &ErrorPayload{Code: code, Message: message},
+	}
+}
+
+// Plan is the plan state crossing in both directions.
+//
+// Governing: SPEC-0002 REQ "Recipe Selection Crossing"
+//
+// Methods and Recipes are omitempty because absence is meaningful: a node
+// on its default records nothing. ADR-0002 puts plan state in the URL hash,
+// so a payload that grows with graph size rather than with user intent
+// makes the hash grow with it.
+type Plan struct {
+	Target   string            `json:"target"`
+	Quantity Quantity          `json:"quantity"`
+	Methods  map[string]string `json:"methods,omitempty"`
+	Recipes  map[string]string `json:"recipes,omitempty"`
+}
+
+// Node is one resolved node on the wire.
+type Node struct {
+	ItemID string   `json:"itemId"`
+	Name   string   `json:"name"`
+	Total  Quantity `json:"total"`
+
+	Method       string   `json:"method"`
+	LegalMethods []string `json:"legalMethods"`
+
+	// Recipe and LegalRecipes let the view offer alternatives without
+	// reading the artifact, which it has no access to.
+	// Governing: SPEC-0002 REQ "Recipe Selection Crossing"
+	Recipe       string   `json:"recipe,omitempty"`
+	LegalRecipes []string `json:"legalRecipes,omitempty"`
+
+	// Yield is how many units one application of the recipe makes, and
+	// Applications how many applications the total needs — the latter
+	// exact and unrounded, per SPEC-0001's rounding discipline.
+	Yield        Quantity `json:"yield,omitempty"`
+	Applications Quantity `json:"applications,omitempty"`
+
+	Terminal bool `json:"terminal"`
+	Verified bool `json:"verified"`
+
+	Children []Edge `json:"children,omitempty"`
+}
+
+// Edge is one dependency on the wire.
+type Edge struct {
+	To      string   `json:"to"`
+	PerUnit Quantity `json:"perUnit"`
+	Yield   Quantity `json:"yield"`
+}
+
+// Graph is a resolved graph on the wire.
+type Graph struct {
+	Target      string   `json:"target"`
+	Quantity    Quantity `json:"quantity"`
+	GameVersion string   `json:"gameVersion"`
+
+	// Nodes preserve the domain's order: terminals first, target last.
+	// Governing: SPEC-0002 REQ "Determinism Across the Boundary".
+	Nodes []Node `json:"nodes"`
+}
+
+// EncodeGraph renders a resolved graph for the boundary.
+//
+// Governing: SPEC-0002 REQ "Exact Quantity Encoding", REQ "Determinism
+// Across the Boundary"
+//
+// Order is the domain's, unchanged — the adapter does not re-sort, because
+// the tab order the view renders is a domain decision (SPEC-0001 REQ
+// "Determinism") and re-deriving it here would be a second place for it to
+// drift.
+func EncodeGraph(g *domain.ResolvedGraph) (*Graph, error) {
+	if g == nil {
+		return nil, fmt.Errorf("encoding graph: nil resolved graph")
+	}
+	out := &Graph{
+		Target:      g.Target,
+		Quantity:    QuantityOfInt(g.Quantity),
+		GameVersion: g.GameVersion,
+		Nodes:       make([]Node, 0, len(g.Nodes)),
+	}
+	for _, n := range g.Nodes {
+		out.Nodes = append(out.Nodes, encodeNode(n))
+	}
+	return out, nil
+}
+
+func encodeNode(n *domain.Node) Node {
+	out := Node{
+		ItemID: n.ItemID,
+		Name:   n.Name,
+		// Total() is an exact rational and stays one all the way to the
+		// string. TotalInt is deliberately not consulted: it reports
+		// whether the value happens to fit an int64, and a value that does
+		// not must still cross exactly rather than as a substitute.
+		Total:        QuantityOf(n.Total()),
+		Method:       string(n.Method),
+		Recipe:       n.Recipe,
+		LegalRecipes: n.LegalRecipes,
+		Terminal:     n.Terminal,
+		Verified:     n.Verified,
+	}
+	for _, m := range n.LegalMethods {
+		out.LegalMethods = append(out.LegalMethods, string(m))
+	}
+	if n.Yield > 0 {
+		out.Yield = QuantityOfInt(n.Yield)
+	}
+	if a := n.Applications(); a != nil {
+		out.Applications = QuantityOf(a)
+	}
+	for _, e := range n.Children {
+		out.Children = append(out.Children, Edge{
+			To:      e.To,
+			PerUnit: QuantityOfInt(e.PerUnit),
+			Yield:   QuantityOfInt(e.Yield),
+		})
+	}
+	return out
+}
+
+// EncodePlan renders a plan input for the boundary, recording only
+// deliberate choices.
+//
+// Governing: SPEC-0002 REQ "Recipe Selection Crossing" — "WHEN a plan in
+// which every node uses its default recipe is encoded THEN the payload
+// contains no recipe selections."
+func EncodePlan(in domain.PlanInput) Plan {
+	out := Plan{Target: in.Target, Quantity: QuantityOfInt(in.Quantity)}
+	if len(in.Methods) > 0 {
+		out.Methods = make(map[string]string, len(in.Methods))
+		for item, m := range in.Methods {
+			out.Methods[item] = string(m)
+		}
+	}
+	if len(in.Recipes) > 0 {
+		out.Recipes = make(map[string]string, len(in.Recipes))
+		for item, r := range in.Recipes {
+			out.Recipes[item] = r
+		}
+	}
+	return out
+}
+
+// DecodePlan turns a wire plan back into a domain input.
+func DecodePlan(p Plan) (domain.PlanInput, error) {
+	qty, ok := p.Quantity.Rat()
+	if !ok || !qty.IsInt() || !qty.Num().IsInt64() {
+		return domain.PlanInput{}, fmt.Errorf("decoding plan: quantity %q is not a whole number", p.Quantity)
+	}
+	out := domain.PlanInput{Target: p.Target, Quantity: qty.Num().Int64()}
+	if len(p.Methods) > 0 {
+		out.Methods = make(map[string]domain.Method, len(p.Methods))
+		for item, m := range p.Methods {
+			out.Methods[item] = domain.Method(m)
+		}
+	}
+	if len(p.Recipes) > 0 {
+		out.Recipes = make(map[string]string, len(p.Recipes))
+		for item, r := range p.Recipes {
+			out.Recipes[item] = r
+		}
+	}
+	return out, nil
+}
+
+// Marshal renders an envelope as the bytes that cross the boundary.
+//
+// Governing: SPEC-0002 REQ "Determinism Across the Boundary" — "the same
+// plan input is resolved and encoded twice ... the two encoded outputs are
+// byte-identical."
+//
+// Struct field order is fixed by the types, node order is the domain's, and
+// the only maps are the plan's selections, which encoding/json emits with
+// sorted keys. Determinism therefore falls out rather than being imposed.
+func Marshal(e Envelope) ([]byte, error) {
+	blob, err := json.Marshal(e)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling envelope: %w", err)
+	}
+	return blob, nil
+}

--- a/internal/bridge/bridge_test.go
+++ b/internal/bridge/bridge_test.go
@@ -1,0 +1,573 @@
+package bridge_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jonstump/nms-base-planner/internal/bridge"
+	"github.com/jonstump/nms-base-planner/internal/domain"
+)
+
+func loadFixture(t *testing.T) *domain.Tier1 {
+	t.Helper()
+	f, err := os.Open("../domain/testdata/stasis-device.tier1.json")
+	if err != nil {
+		t.Fatalf("opening fixture: %v", err)
+	}
+	defer f.Close()
+	a1, err := domain.LoadTier1(f)
+	if err != nil {
+		t.Fatalf("loading fixture: %v", err)
+	}
+	return a1
+}
+
+func resolve(t *testing.T, in domain.PlanInput) *domain.ResolvedGraph {
+	t.Helper()
+	g, err := domain.Resolve(loadFixture(t), in)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	return g
+}
+
+func encode(t *testing.T, g *domain.ResolvedGraph) []byte {
+	t.Helper()
+	wire, err := bridge.EncodeGraph(g)
+	if err != nil {
+		t.Fatalf("EncodeGraph: %v", err)
+	}
+	blob, err := bridge.Marshal(bridge.Success(bridge.ResultPayload{Graph: wire}))
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	return blob
+}
+
+// SPEC-0002 REQ "Result Envelope":
+// WHEN a call succeeds
+// THEN the envelope reports success, carries the result payload, and carries
+// no error payload.
+func TestSuccessCarriesAPayloadAndNoError(t *testing.T) {
+	g := resolve(t, domain.PlanInput{Target: "sd", Quantity: 1})
+	wire, err := bridge.EncodeGraph(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := bridge.Success(bridge.ResultPayload{Graph: wire})
+
+	if !env.OK {
+		t.Error("envelope does not report success")
+	}
+	if env.Data == nil || env.Data.Graph == nil {
+		t.Fatal("envelope carries no result payload")
+	}
+	if env.Error != nil {
+		t.Errorf("envelope carries an error payload: %+v", env.Error)
+	}
+	if env.ContractVersion != bridge.ContractVersion {
+		t.Errorf("contract version = %q, want %q", env.ContractVersion, bridge.ContractVersion)
+	}
+
+	// On the wire, the error key is absent rather than null.
+	blob, err := bridge.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(blob, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := raw["error"]; present {
+		t.Errorf("a successful envelope carries an error key: %s", blob)
+	}
+}
+
+// SPEC-0002 REQ "Result Envelope":
+// WHEN graph resolution fails
+// THEN the envelope reports failure, carries the error payload, and carries
+// no result payload — not an empty one.
+func TestFailureCarriesAnErrorAndNoPayload(t *testing.T) {
+	// A real domain failure rather than a synthetic one.
+	_, err := domain.Resolve(loadFixture(t), domain.PlanInput{Target: "not_an_item", Quantity: 1})
+	if err == nil {
+		t.Fatal("expected the domain to reject an unknown target")
+	}
+
+	env := bridge.Failure("", err.Error())
+	if env.OK {
+		t.Error("envelope reports success on a failure")
+	}
+	if env.Error == nil {
+		t.Fatal("envelope carries no error payload")
+	}
+	if env.Data != nil {
+		t.Errorf("envelope carries a result payload alongside an error: %+v", env.Data)
+	}
+	if env.Error.Code != bridge.CodeUnclassified {
+		t.Errorf("code = %q, want the reserved unclassified code", env.Error.Code)
+	}
+	if !strings.Contains(env.Error.Message, "not_an_item") {
+		t.Errorf("message %q does not carry the domain's prose", env.Error.Message)
+	}
+
+	// "not an empty one": the data key must be absent, not {}.
+	blob, err := bridge.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(blob, []byte(`"data"`)) {
+		t.Errorf("a failure envelope carries a data key: %s", blob)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(blob, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := raw["data"]; present {
+		t.Errorf("a failure envelope carries a data key: %s", blob)
+	}
+}
+
+// SPEC-0002 REQ "Exact Quantity Encoding":
+// WHEN Condensed Carbon resolves to a total of 300
+// THEN the encoded value is the string "300", not the number 300.
+func TestOrdinaryTotalCrossesAsAString(t *testing.T) {
+	blob := encode(t, resolve(t, domain.PlanInput{Target: "sd", Quantity: 1}))
+
+	if !bytes.Contains(blob, []byte(`"total":"300"`)) {
+		t.Errorf("Condensed Carbon's 300 did not cross as the string \"300\"")
+	}
+	if bytes.Contains(blob, []byte(`"total":300`)) {
+		t.Error("a total crossed as a JSON number")
+	}
+
+	// Structurally: every quantity field in the payload is a string.
+	for _, key := range []string{"total", "quantity", "perUnit", "yield", "applications"} {
+		assertAllStrings(t, blob, key)
+	}
+}
+
+// assertAllStrings walks the encoded payload and fails if any occurrence of
+// the named key holds a JSON number.
+func assertAllStrings(t *testing.T, blob []byte, key string) {
+	t.Helper()
+	var doc any
+	if err := json.Unmarshal(blob, &doc); err != nil {
+		t.Fatal(err)
+	}
+	var walk func(v any)
+	walk = func(v any) {
+		switch node := v.(type) {
+		case map[string]any:
+			for k, child := range node {
+				if k == key {
+					if _, isNumber := child.(float64); isNumber {
+						t.Errorf("%q crossed as a JSON number: %v", k, child)
+					}
+					if _, isString := child.(string); !isString && child != nil {
+						t.Errorf("%q crossed as %T, want a string", k, child)
+					}
+				}
+				walk(child)
+			}
+		case []any:
+			for _, child := range node {
+				walk(child)
+			}
+		}
+	}
+	walk(doc)
+}
+
+// SPEC-0002 REQ "Exact Quantity Encoding":
+// WHEN a total exceeds 2^53−1 THEN the encoded string carries the exact
+// value, and parsing it as a BigInt yields that value unchanged.
+func TestValueBeyondJavaScriptSafeIntegerSurvives(t *testing.T) {
+	// 500 units of gas per Stasis Device, so this lands well past 2^53−1.
+	const qty = 1_000_000_000_000_000
+	g := resolve(t, domain.PlanInput{Target: "sd", Quantity: qty})
+
+	sul, ok := g.Node("sul")
+	if !ok {
+		t.Fatal("sul missing")
+	}
+	want := new(big.Rat).Mul(big.NewRat(500, 1), new(big.Rat).SetInt64(qty))
+	maxSafe := big.NewRat(1<<53-1, 1)
+	if want.Cmp(maxSafe) <= 0 {
+		t.Fatalf("the test quantity %s does not exceed 2^53-1, so this proves nothing", want.RatString())
+	}
+
+	q := bridge.QuantityOf(sul.Total())
+	// Round-trips exactly, which is what a BigInt parse does on the other
+	// side: the string is exact decimal digits.
+	back, ok := q.Rat()
+	if !ok {
+		t.Fatalf("encoded quantity %q does not parse back", q)
+	}
+	if back.Cmp(want) != 0 {
+		t.Errorf("round trip = %s, want %s", back.RatString(), want.RatString())
+	}
+	if strings.ContainsAny(string(q), ".eE") {
+		t.Errorf("quantity %q is not exact decimal digits; a BigInt parse would reject it", q)
+	}
+
+	// The graph value above is past 2^53−1 but happens to be
+	// double-representable, so on its own it does not show that a number
+	// path would lose anything. 2^53+1 does: it is the smallest integer a
+	// double cannot hold, and it is what a consumer parsing with Number
+	// instead of BigInt would silently round.
+	unsafe := new(big.Rat).SetInt(new(big.Int).Add(
+		new(big.Int).Lsh(big.NewInt(1), 53), big.NewInt(1)))
+
+	encoded := bridge.QuantityOf(unsafe)
+	if encoded != "9007199254740993" {
+		t.Fatalf("2^53+1 encoded as %q", encoded)
+	}
+	roundTripped, ok := encoded.Rat()
+	if !ok || roundTripped.Cmp(unsafe) != 0 {
+		t.Errorf("2^53+1 round trip = %v, want %s", roundTripped, unsafe.RatString())
+	}
+
+	// The same value through a float64 does not survive, which is what the
+	// string encoding exists to avoid.
+	viaFloat, _ := unsafe.Float64()
+	if new(big.Rat).SetFloat64(viaFloat).Cmp(unsafe) == 0 {
+		t.Fatal("2^53+1 survived a float64 round trip; this platform is not IEEE-754 double")
+	}
+}
+
+// SPEC-0002 REQ "Exact Quantity Encoding":
+// WHEN a later stage produces a total that is exactly one and a half
+// THEN the encoded value represents that quantity exactly, and no rounding
+// or truncation is applied.
+func TestNonIntegerTotalIsNotRounded(t *testing.T) {
+	// A yield of 2 satisfying a demand of 3: one and a half applications,
+	// and one and a half of the input. The shape SPEC-0001's Applications()
+	// already produces on real refiner data.
+	const artifact = `{
+	  "schema_version": 2, "game_version": "test-halves",
+	  "items": [
+	    {"id":"x","name":"X","raw_obtainable":true,"default_method":"raw"},
+	    {"id":"z","name":"Z","default_method":"refine"}
+	  ],
+	  "recipes": [
+	    {"id":"z_x","output":"z","method":"refine","inputs":[{"item":"x","quantity":1}],"yield":2}
+	  ]
+	}`
+	a1, err := domain.LoadTier1(strings.NewReader(artifact))
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, err := domain.Resolve(a1, domain.PlanInput{Target: "z", Quantity: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	z, _ := g.Node("z")
+	if got := bridge.QuantityOf(z.Applications()); got != "3/2" {
+		t.Errorf("applications = %q, want \"3/2\"", got)
+	}
+	x, _ := g.Node("x")
+	if got := bridge.QuantityOf(x.Total()); got != "3/2" {
+		t.Errorf("x total = %q, want \"3/2\"", got)
+	}
+
+	// Exact on the way back: no rounding, no truncation.
+	back, ok := bridge.QuantityOf(x.Total()).Rat()
+	if !ok || back.Cmp(big.NewRat(3, 2)) != 0 {
+		t.Errorf("round trip = %v, want 3/2", back)
+	}
+	// And it did not silently become "1" or "2".
+	if intVal, exact := x.TotalInt(); exact {
+		t.Errorf("the domain reported %d as exact for a fractional total", intVal)
+	}
+}
+
+// SPEC-0002 REQ "Exact Quantity Encoding":
+// WHEN the adapter encodes any quantity
+// THEN no conversion through float64 occurs, verified by the absence of such
+// conversions in the encoding code.
+//
+// Checked mechanically by parsing this package's own source, because the
+// scenario asks for verification rather than a comment saying so. A
+// float64 conversion, a FloatString call (which rounds to a fixed number of
+// places), or a Float64/Float32 call anywhere in the encoding path fails
+// this test.
+func TestNoFloatInTheEncodingPath(t *testing.T) {
+	sources, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var checked int
+	for _, path := range sources {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		checked++
+
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			switch fn := call.Fun.(type) {
+			case *ast.Ident:
+				// A float64(x) or float32(x) conversion.
+				if fn.Name == "float64" || fn.Name == "float32" {
+					t.Errorf("%s: %s conversion in the encoding path",
+						fset.Position(call.Pos()), fn.Name)
+				}
+			case *ast.SelectorExpr:
+				// FloatString rounds to a fixed number of places; Float64
+				// and Float32 leave the exact domain entirely.
+				switch fn.Sel.Name {
+				case "FloatString", "Float64", "Float32", "SetFloat64":
+					t.Errorf("%s: %s call in the encoding path",
+						fset.Position(call.Pos()), fn.Sel.Name)
+				}
+			}
+			return true
+		})
+
+		// Belt and braces: no float type appears in a declaration either.
+		blob, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, banned := range []string{"float64", "float32"} {
+			// Comments may discuss floats; declarations may not use them.
+			for _, line := range strings.Split(string(blob), "\n") {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "//") {
+					continue
+				}
+				if strings.Contains(line, banned) {
+					t.Errorf("%s: %q appears in code: %s", path, banned, trimmed)
+				}
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no non-test sources were checked, so this proves nothing")
+	}
+}
+
+// SPEC-0002 REQ "Recipe Selection Crossing":
+// WHEN a plan specifying a non-default recipe for one node crosses the
+// boundary and is returned THEN that node reports the specified recipe, and
+// its expansion reflects it.
+func TestNonDefaultRecipeCrossesAndExpands(t *testing.T) {
+	// The fixture's Glass has two routes; the craft one is its default.
+	// Pin the refine route and check both the report and the expansion.
+	in := domain.PlanInput{
+		Target: "sd", Quantity: 1,
+		Methods: map[string]domain.Method{"gla": domain.MethodRefine},
+		Recipes: map[string]string{"gla": "gla_refine"},
+	}
+	wire := bridge.EncodePlan(in)
+	if wire.Recipes["gla"] != "gla_refine" {
+		t.Fatalf("plan recipes = %v, want gla_refine", wire.Recipes)
+	}
+
+	back, err := bridge.DecodePlan(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, err := domain.Resolve(loadFixture(t), back)
+	if err != nil {
+		t.Fatalf("resolving the round-tripped plan: %v", err)
+	}
+	encoded, err := bridge.EncodeGraph(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gla *bridge.Node
+	for i := range encoded.Nodes {
+		if encoded.Nodes[i].ItemID == "gla" {
+			gla = &encoded.Nodes[i]
+		}
+	}
+	if gla == nil {
+		t.Fatal("gla missing from the encoded graph")
+	}
+	if gla.Recipe != "gla_refine" {
+		t.Errorf("node recipe = %q, want gla_refine", gla.Recipe)
+	}
+	// The expansion reflects it: the refine route takes 250 Frost Crystal,
+	// the craft route 40.
+	if len(gla.Children) != 1 || gla.Children[0].PerUnit != "250" {
+		t.Errorf("gla children = %+v, want one edge of 250", gla.Children)
+	}
+}
+
+// SPEC-0002 REQ "Recipe Selection Crossing":
+// WHEN a plan in which every node uses its default recipe is encoded
+// THEN the payload contains no recipe selections.
+func TestDefaultsCostNoPayload(t *testing.T) {
+	wire := bridge.EncodePlan(domain.PlanInput{Target: "sd", Quantity: 1})
+
+	if wire.Recipes != nil {
+		t.Errorf("recipes = %v, want none", wire.Recipes)
+	}
+	if wire.Methods != nil {
+		t.Errorf("methods = %v, want none", wire.Methods)
+	}
+
+	blob, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{`"recipes"`, `"methods"`} {
+		if bytes.Contains(blob, []byte(key)) {
+			t.Errorf("an all-defaults plan carries %s: %s", key, blob)
+		}
+	}
+}
+
+// SPEC-0002 REQ "Recipe Selection Crossing":
+// WHEN the view receives a resolved graph
+// THEN each node carries its legal recipes for the chosen method, without
+// the view reading the artifact.
+func TestNodesCarryTheirLegalRecipes(t *testing.T) {
+	g := resolve(t, domain.PlanInput{Target: "sd", Quantity: 1})
+	wire, err := bridge.EncodeGraph(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var checked int
+	for _, n := range wire.Nodes {
+		if n.Terminal {
+			if n.Recipe != "" {
+				t.Errorf("terminal %s carries recipe %q", n.ItemID, n.Recipe)
+			}
+			continue
+		}
+		checked++
+		if n.Recipe == "" {
+			t.Errorf("%s carries no recipe", n.ItemID)
+		}
+		if len(n.LegalRecipes) == 0 {
+			t.Errorf("%s carries no legal recipes; the view would have to read the artifact", n.ItemID)
+		}
+		var found bool
+		for _, r := range n.LegalRecipes {
+			if r == n.Recipe {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s selected %q, which is not among its legal recipes %v", n.ItemID, n.Recipe, n.LegalRecipes)
+		}
+		if len(n.LegalMethods) == 0 {
+			t.Errorf("%s carries no legal methods", n.ItemID)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no non-terminal nodes were checked")
+	}
+}
+
+// SPEC-0002 REQ "Determinism Across the Boundary":
+// WHEN the same plan input is resolved and encoded twice in the same process
+// THEN the two encoded outputs are byte-identical.
+func TestEncodingIsByteIdentical(t *testing.T) {
+	in := domain.PlanInput{
+		Target: "sd", Quantity: 4,
+		Methods: map[string]domain.Method{"cc": domain.MethodRefine, "gla": domain.MethodRefine},
+		Recipes: map[string]string{"gla": "gla_refine"},
+	}
+
+	first := encode(t, resolve(t, in))
+	for i := 0; i < 25; i++ {
+		if got := encode(t, resolve(t, in)); !bytes.Equal(got, first) {
+			t.Fatalf("run %d differs from the first; map iteration is leaking into the encoding", i+2)
+		}
+	}
+
+	// The plan payload's maps encode with sorted keys, which is what makes
+	// the URL hash stable across runs.
+	planFirst, err := json.Marshal(bridge.EncodePlan(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 25; i++ {
+		got, err := json.Marshal(bridge.EncodePlan(in))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, planFirst) {
+			t.Fatalf("plan encoding run %d differs from the first", i+2)
+		}
+	}
+}
+
+// SPEC-0002 REQ "Determinism Across the Boundary":
+// WHEN an encoded graph is decoded by the consumer
+// THEN node order matches the domain's order — terminals first, target last.
+func TestNodeOrderMatchesTheDomain(t *testing.T) {
+	g := resolve(t, domain.PlanInput{Target: "sd", Quantity: 1})
+	wire, err := bridge.EncodeGraph(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(wire.Nodes) != len(g.Nodes) {
+		t.Fatalf("encoded %d nodes, domain has %d", len(wire.Nodes), len(g.Nodes))
+	}
+	for i, n := range g.Nodes {
+		if wire.Nodes[i].ItemID != n.ItemID {
+			t.Fatalf("node %d is %q, domain has %q — order was not preserved",
+				i, wire.Nodes[i].ItemID, n.ItemID)
+		}
+	}
+	if !wire.Nodes[0].Terminal {
+		t.Error("the first node is not a terminal")
+	}
+	if last := wire.Nodes[len(wire.Nodes)-1]; last.ItemID != "sd" {
+		t.Errorf("the last node is %q, want the target", last.ItemID)
+	}
+}
+
+// SPEC-0002 REQ "Determinism Across the Boundary":
+// WHEN a node is marked unverified by the domain
+// THEN it arrives at the consumer marked unverified.
+func TestProvenanceSurvivesTheCrossing(t *testing.T) {
+	g := resolve(t, domain.PlanInput{Target: "sd", Quantity: 1})
+	wire, err := bridge.EncodeGraph(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	domainVerified := map[string]bool{}
+	var unverified int
+	for _, n := range g.Nodes {
+		domainVerified[n.ItemID] = n.Verified
+		if !n.Verified {
+			unverified++
+		}
+	}
+	if unverified == 0 {
+		t.Fatal("the fixture has no unverified nodes, so this proves nothing")
+	}
+
+	for _, n := range wire.Nodes {
+		if n.Verified != domainVerified[n.ItemID] {
+			t.Errorf("%s crossed as verified=%v, domain says %v", n.ItemID, n.Verified, domainVerified[n.ItemID])
+		}
+	}
+}


### PR DESCRIPTION
## What

Implements #43, the foundation story for #44 and #45. New `internal/bridge` package — the encoding half of ADR-0003's adapter, deliberately free of `syscall/js` so **all twelve scenarios run under plain `go test` with no WASM build**.

## Encoding decisions

**Quantities cross as strings, never JSON numbers.** `big.Rat.RatString` is the only formatter used: integral values render as digits (`"300"`), fractional ones as rationals (`"3/2"`), and both round-trip exactly. `FloatString` rounds to a fixed number of places and `Float64` leaves the exact domain, so neither appears anywhere in the package.

**`Data` and `Error` are pointers**, so exactly one is present. A failure marshals with **no `data` key at all** rather than an empty object. The requirement says "carries no result payload — not an empty one", and `{}` reads to a consumer as a call that succeeded and produced nothing.

**Node order is the domain's, unchanged.** The adapter does not re-sort — the tab order is a domain decision per SPEC-0001, and re-deriving it here would be a second place for it to drift.

## The float64 scenario, verified rather than claimed

The issue flagged that "verified by the absence of such conversions in the encoding code" wants something mechanical. `TestNoFloatInTheEncodingPath` parses this package's own source with `go/ast` and fails on a `float64`/`float32` conversion, a `FloatString` call, or a `Float64`/`Float32`/`SetFloat64` call — naming file and line.

I checked it has teeth by swapping `RatString` for `FloatString(6)`:

```
bridge_test.go:319: bridge.go:61:18: FloatString call in the encoding path
```

## A test that was silently passing by not running

The safe-integer scenario first used a graph total of 5×10¹⁷. That is past 2^53−1, but it happens to be **double-representable** — and the guard I wrote against exactly that case called `t.Skip`, so the whole test was skipped and none of its assertions ran. Vacuous.

It now also encodes **2^53+1** — the smallest integer a double cannot hold, and precisely what a consumer parsing with `Number` instead of `BigInt` would silently round — and asserts the string round-trips exactly while the `float64` round trip does not.

Being past 2^53−1 is the criterion the scenario cares about; double-representability was the wrong property to branch on.

## Tests — twelve scenarios, one per spec scenario

| Requirement | Scenarios |
|---|---|
| Result Envelope | success carries payload and no `error` key; failure carries error and **no `data` key**, checked both as a substring and structurally |
| Exact Quantity Encoding | `"300"` as a string, plus a structural walk asserting *every* `total`/`quantity`/`perUnit`/`yield`/`applications` in the payload is a JSON string; 2^53+1 survives; `3/2` is not rounded; no float in the path |
| Recipe Selection Crossing | a pinned non-default recipe round-trips **and its expansion changes** (250 Frost Crystal, not 40); an all-defaults plan carries neither key; every non-terminal node carries legal recipes containing its selection |
| Determinism | 25 encode runs byte-identical, graph and plan; node order matches the domain index-for-index with a terminal first and the target last; unverified nodes arrive unverified |

The provenance and legal-recipe tests both `t.Fatal` if the fixture stops exercising them, so neither can pass by finding nothing to check.

`go vet`, `staticcheck v0.8.0-rc.1`, `gofmt -l` clean. No `syscall/js` import anywhere in `internal/`.

## Scope note

Sentinel error codes are #44. Everything crosses as `UNCLASSIFIED` for now — the reserved code SPEC-0002 requires exist so an unmatched error is never silently mapped onto an unrelated sentinel. #44 fills in the mapping and will likely extend `ErrorPayload`; that is expected of a foundation story rather than a guess I should have made here.

Closes #43
Part of #42

Implements SPEC-0002 REQ "Result Envelope", REQ "Exact Quantity Encoding", REQ "Recipe Selection Crossing", REQ "Determinism Across the Boundary".

🤖 Generated with [Claude Code](https://claude.com/claude-code)