### PR TITLE
docs: record where each economy constant actually comes from

### DIFF
--- a/docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md
+++ b/docs/adrs/ADR-0001-two-tier-nms-data-ingestion.md
@@ -35,7 +35,21 @@ Chosen option: **C, direct extraction with a two-tier data model**, because it i
 
 **Tier 1 — extracted.** A Go CLI locates the game's `.pak` archives, unpacks them (they are HGPAK containers — see the note below and SPEC-0003), shells out to MBINCompiler to convert `.MBIN` → `.MXML`, then parses and normalizes the XML in Go into a version-stamped artifact: the recipe graph (products, substances, refinery, nutrient processor), item metadata, the biome→gas mapping from `GcGeneratorUnitComponentData.BiomeGasRewards`, the extractor taxonomy, the base parts catalog, refiner throughput (`RefinerProductsMadeInTime` / `RefinerSubsMadeInTime` and their Survival variants, from `gcgameplayglobals`), the per-part production and consumption rates and storage buffers from `GcBaseLinkGridData`, the C/B/A/S hotspot class strengths and weightings from `REGIONHOTSPOTSTABLE`, and crop yields and growth times. Regenerated per game version; never hand-edited.
 
-**Tier 2 — curated.** A hand-maintained YAML file of the base-economy constants that are genuinely *not* in the game files. As of the 2026-08-18 confirmation that is one entry — biodome crop-slot count — since generator and consumer rates, class scaling, crop yields, and growth times all turned out to be extractable (see the finding below). Each entry carries a `source` and a `verified` date, feeding the same `unverified` badge convention the tree canvas uses.
+**Tier 2 — curated.** A hand-maintained YAML file of the base-economy constants that are genuinely *not* in the game files, plus the ones that are planner policy rather than game data at all. Each entry carries a `source` and a `verified` date, feeding the same `unverified` badge convention the tree canvas uses.
+
+The 2026-08-18 confirmation recorded this as **one** entry — biodome crop-slot count — after generator and consumer rates, class scaling, crop yields and growth times all turned out extractable (see the finding below). Building the stage-2 input type against the generated artifact (#39) found **five**:
+
+| Entry | Why it is curated |
+|---|---|
+| Biodome crop-slot count | No table searched states it. May be geometric — snap points in the scene — and so extractable after all. |
+| Fauna yield per collection cycle | Fauna products come from creature data this pipeline does not read. |
+| Fauna cycle duration | As above. |
+| Steps per nutrient processor | **Planner policy**, not missing data — how hard to work one machine. |
+| Depot threshold | Planner policy. The game has no opinion about when hoarding starts. |
+
+The last two will never be found in a table, and separating them from the genuinely-absent three stops anyone searching for them. Going the other way, two constants SPEC-0001 had listed as curated turned out to be in the artifact: depot capacity is `U_SILO_S`'s storage buffer and battery capacity is `U_BATTERY_S`'s. Note that battery *capacity* is not the batteries-per-panel *ratio*, which remains unresolved.
+
+Tier 2 shrank from twelve-ish to five rather than to one. The direction of the finding holds; the arithmetic did not.
 
 MBINCompiler is invoked as a **subprocess**, never linked. It is LGPL-3.0, and a license governs a program rather than its output, so the extracted artifact carries no copyleft obligation. AssistantNMS is retained as a **cross-check** on Tier 1 correctness — read, compared against, never vendored.
 
@@ -204,7 +218,7 @@ Plants themselves declare `DependentRate = 0` against Power, so a biodome's -50 
 
 Crop yields are flat per crop: Cactus Flesh 100, Gamma Root / Solanium / Frost Crystal / Fungal Mould 50, Star Bulb / Mordite / Faecium 25. Growth times come from the same link-grid `Storage` field — 3,600 s for frostwart, 14,400 s for most, 57,600 s for the slowest.
 
-**Consequences for the two tiers.** Tier 1 gains generator and consumer rates, class strengths and weightings, crop yields, crop growth times, battery capacity, and refiner throughput (`RefinerProductsMadeInTime` / `RefinerSubsMadeInTime` and their Survival variants, from `gcgameplayglobals`). Tier 2 shrinks to a single entry — biodome crop-slot count — plus whatever later proves genuinely absent. The decision itself is unaffected: this ADR already said that "if the constants turn out to be extractable, Tier 2 shrinks or disappears and this decision should be revised rather than superseded," and that is what has happened.
+**Consequences for the two tiers.** Tier 1 gains generator and consumer rates, class strengths and weightings, crop yields, crop growth times, battery capacity, and refiner throughput (`RefinerProductsMadeInTime` / `RefinerSubsMadeInTime` and their Survival variants, from `gcgameplayglobals`). Tier 2 shrinks from twelve-ish entries to five — biodome crop-slot count, fauna yield and cycle duration, steps per nutrient processor, and depot threshold. The last two are planner policy rather than absent game data. This paragraph originally said "a single entry ... plus whatever later proves genuinely absent"; #39 is what settled the remainder, and the answer was four more. The decision itself is unaffected: this ADR already said that "if the constants turn out to be extractable, Tier 2 shrinks or disappears and this decision should be revised rather than superseded," and that is what has happened.
 
 **This ADR moved from `proposed` to `accepted` on 2026-08-18.** The single blocker it set for itself — confirming the Tier 2 finding against decompiled MBIN files rather than libMBIN struct names — is met, and the decision survives the confirmation going against it. Option C was chosen for licensing and refresh-cycle reasons that do not depend on how the tiers are split, and the ADR anticipated this exact outcome in its own text. What changed is the size of Tier 2, not whether the two-tier model is right.
 

--- a/docs/openspec/specs/rollup-engine/design.md
+++ b/docs/openspec/specs/rollup-engine/design.md
@@ -85,11 +85,35 @@ Rounding a batch count up follows the same reasoning as the physical-unit bounda
 
 **Trade-off**: One more place quantities can be wrong, and one more field the normalizer must read correctly. Mitigated by SPEC-0004's requirement that yields come from the source rather than defaulting silently.
 
-### Tier 2 constants injected, never hardcoded
+### Economy constants injected, never hardcoded
 
-**Choice**: All economy constants — crop yields, dome capacity, extractor rates per class, generator outputs, class multipliers, draws, depot thresholds and capacities, battery ratios, fauna yield per collection cycle, cycle durations, and steps per nutrient processor — arrive as a parameter.
+**Choice**: No economy constant is hardcoded. Every one arrives at the call — but "injected" now means *read from the Tier 1 artifact* for most of them, and *supplied by the caller* for a much smaller remainder.
 
-**Rationale**: ADR-0001 marks these as provisional and hand-curated; the game rebalances. The base-planner handoff already treats them as tweakable: *"`emOutput` (kPs, default 110) — swap in real game data without touching code."* Injection also makes every producer and power scenario testable with small synthetic constant sets rather than the full production dataset.
+**Where each constant comes from**, established by building the stage-2 input type against the generated artifact (#39) rather than by reasoning about it:
+
+| Constant | Source |
+|---|---|
+| Crop yield, growth time | `Economy.Crops[]` |
+| Part rates, storage, power draws | `Economy.Parts[]` |
+| Class strengths C/B/A/S | `Economy.Hotspots[]` |
+| Refiner throughput | `Economy.Refining` |
+| Depot capacity | `Economy.Parts[]` — `U_SILO_S.primary.storage`, 1,440,000 |
+| Battery capacity | `Economy.Parts[]` — `U_BATTERY_S.primary.storage`, 45,000 |
+| Biodome crop slots | Curated. No table searched states it; it may be geometric — snap points in the scene — and therefore extractable after all. |
+| Fauna yield per cycle, cycle duration | Curated. Fauna products come from creature data this pipeline does not read. |
+| Steps per nutrient processor | Curated, and **planner policy** rather than absent game data — how hard to work one machine. |
+| Depot threshold | Curated, and planner policy. The game has no opinion about when hoarding starts. |
+
+**This section previously listed the whole set as "provisional and hand-curated"**, which was written before the extraction spike and was wrong in both directions once there was an artifact to check. It over-counted the curated set — most of that list reads from `Economy` — while ADR-0001 under-counted it, recording one surviving entry where there are five.
+
+Two distinctions the earlier list collapsed, and which the type system now keeps apart:
+
+- **Depot capacity has a source; depot threshold does not.** `Constants.DepotCapacity()` reads the artifact; `Curated.DepotThreshold` is supplied. One is a fact about a silo, the other is a decision about when to suggest building one.
+- **Battery capacity is not battery ratio.** `U_BATTERY_S.primary.storage` is a buffer size. The batteries-per-solar-panel ratio that REQ "Power Computation" requires is a separate quantity, is not in `Economy`, and is unresolved — it belongs to stage 3 rather than here.
+
+**Rationale for injection is unchanged**: the game rebalances, and the base-planner handoff already treats these as tweakable — *"`emOutput` (kPs, default 110) — swap in real game data without touching code."* Injection also makes every producer and power scenario testable with small synthetic constant sets rather than the full production dataset. What changed is only where the values come from, not that they arrive at the call.
+
+**Curated constants are required, not defaulted.** A zero is refused. A default here is a number the planner reports that nobody chose.
 
 ### Byproducts offset demand rather than generating construction
 


### PR DESCRIPTION
The companion amendment #49 defers — plus the half its deferred list did not cover.

## Both artifacts were wrong, in opposite directions

| Artifact | Said | Actual |
|---|---|---|
| `SPEC-0001` design, "Tier 2 constants injected" | ~12 constants "provisional and hand-curated" | Most read from `Economy` |
| `ADR-0001` Tier 2 paragraph | "one entry — biodome crop-slot count" | **Five** |

#49 settled the mapping by building the stage-2 input type against the generated artifact rather than reasoning about it. Its deferred-updates section covered `design.md`'s over-count; this PR does that **and** ADR-0001's under-count, which the review of #49 flagged as the missing half.

`design.md` now carries a per-constant source table instead of a list, and says plainly that "injected" means *read from the artifact* for most of it. The injection principle is unchanged — nothing is hardcoded — which is what the original section got right.

## Two distinctions the old list collapsed

Both are easy to re-conflate, so both are now stated explicitly:

**Depot capacity has a source; depot threshold does not.** `U_SILO_S.primary.storage` is 1,440,000. The threshold — *when* a plan should start suggesting depots — is a planner decision the game has no opinion about. One is a fact about a silo, the other is a judgement about when to suggest building one.

**Battery capacity is not battery ratio.** `U_BATTERY_S.primary.storage` is 45,000, a buffer size. The batteries-per-solar-panel ratio that REQ "Power Computation" requires is a *different quantity*, is not in `Economy`, and is unresolved — it belongs to stage 3 (#41). I checked `Curated` in #49 to confirm: it declares five fields and a battery ratio is not among them, so writing "battery ratios are sourced" would have introduced a fresh wrong claim while correcting an old one.

## Planner policy is not missing data

Two of the five curated entries — steps per nutrient processor, and the depot threshold — will never be found in a table, because they are decisions rather than facts. The other three (biodome crop slots, fauna yield, fauna cycle duration) are genuinely absent game data. Separating them stops the next person searching.

Biodome crop slots keeps its own note: it may be geometric — snap points in the scene — and therefore extractable after all.

## ADR-0001 is now internally consistent

Its Consequences paragraph also said "Tier 2 shrinks to a single entry ... plus whatever later proves genuinely absent", while already listing battery capacity as having moved to Tier 1. Both paragraphs now agree, and the hedge is resolved: #39 settled the remainder, and the answer was four more.

Docs only — no code touched.