### PR TITLE
feat(domain): producer rollup for farm, extractor, ranch and kitchen

### DIFF
--- a/internal/domain/producer.go
+++ b/internal/domain/producer.go
@@ -1,0 +1,496 @@
+package domain
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+)
+
+// Stage 2's producer half: each base's assigned leaf totals become concrete
+// construction instructions.
+//
+// Governing: SPEC-0001 REQ "Producer Rollup", REQ "Exact Arithmetic and
+// Rounding Discipline"
+//
+// Three of this requirement's scenarios exist because the obvious
+// implementation gets them wrong, and each has its own test: feeders are per
+// base rather than per row, nutrient processors are ceil(total steps / steps
+// per processor) rather than the sum of per-row ceilings, and extractor
+// class is a property of the site.
+//
+// Every quantity below stays a big.Rat until the moment it becomes a thing
+// you build. Rounding happens only at the boundaries SPEC-0001 enumerates —
+// plants, biodomes, extractors, depots, fauna, processors — and always up,
+// because half a biodome is not a biodome.
+
+// ProducerType is the kind of thing a row tells you to build.
+type ProducerType string
+
+const (
+	ProducerFarm      ProducerType = "farm"
+	ProducerExtractor ProducerType = "extractor"
+	ProducerRanch     ProducerType = "ranch"
+	ProducerKitchen   ProducerType = "kitchen"
+)
+
+// FarmRow is one crop at one base.
+type FarmRow struct {
+	ItemID string
+	Name   string
+
+	// Plants and Biodomes are counts you build, each rounded up.
+	Plants   int64
+	Biodomes int64
+
+	// YieldPerPlant is the source's range. Plants are sized on the
+	// pessimistic bound: a plan that assumes the best case under-builds,
+	// and the failure is a farm that never fills the order.
+	YieldPerPlant Range
+
+	// GrowthSeconds is time to maturity, from the artifact.
+	GrowthSeconds int64
+
+	required *big.Rat
+}
+
+// Required returns the row's requirement as an exact rational.
+func (r FarmRow) Required() *big.Rat { return new(big.Rat).Set(r.required) }
+
+// ExtractorRow is one extracted resource at one base.
+type ExtractorRow struct {
+	ItemID string
+	Name   string
+
+	// Class is the site's, not the row's.
+	// Governing: SPEC-0001 REQ "Producer Rollup" — "Extractor class MUST be
+	// configured per site, not per row."
+	Class HotspotClass
+
+	// Extractors is the count sized so the requirement is produced within
+	// the site's configured fill duration.
+	Extractors int64
+
+	// Depots is ceil(required / depot capacity) above the configured
+	// threshold, and zero below it.
+	Depots int64
+
+	required *big.Rat
+	rate     *big.Rat
+	fill     *big.Rat
+}
+
+// Required returns the row's requirement.
+func (r ExtractorRow) Required() *big.Rat { return new(big.Rat).Set(r.required) }
+
+// RatePerSecond is one extractor's output at the site's class.
+func (r ExtractorRow) RatePerSecond() *big.Rat { return new(big.Rat).Set(r.rate) }
+
+// FillSeconds is how long the built extractors actually take to produce the
+// requirement — the resulting fill time, not the target.
+//
+// It is at most the configured duration, and usually less, because the count
+// was rounded up.
+func (r ExtractorRow) FillSeconds() *big.Rat { return new(big.Rat).Set(r.fill) }
+
+// RanchRow is one fauna product at one base.
+type RanchRow struct {
+	ItemID string
+	Name   string
+
+	// Fauna is the creature count required to yield the requirement within
+	// one collection cycle.
+	Fauna int64
+
+	// CycleSeconds is that cycle's duration.
+	CycleSeconds int64
+
+	required *big.Rat
+}
+
+// Required returns the row's requirement.
+func (r RanchRow) Required() *big.Rat { return new(big.Rat).Set(r.required) }
+
+// KitchenStep is one nutrient processor step.
+type KitchenStep struct {
+	// ItemID is what the step produces, Recipe the route it takes.
+	ItemID string
+	Name   string
+	Recipe string
+
+	// Inputs are the step's ingredients, sorted by item ID.
+	Inputs []KitchenInput
+
+	// ProcessSeconds is the step's duration.
+	ProcessSeconds int64
+
+	// Final marks the step that produces the plan target; every other step
+	// is intermediate.
+	//
+	// Governing: SPEC-0001 REQ "Producer Rollup" — Scenario "Final kitchen
+	// step is distinguished".
+	Final bool
+
+	required *big.Rat
+}
+
+// Required returns how many units this step must produce.
+func (s KitchenStep) Required() *big.Rat { return new(big.Rat).Set(s.required) }
+
+// KitchenInput is one ingredient of a step, with its ratio to the output.
+type KitchenInput struct {
+	ItemID string
+
+	perOutput *big.Rat
+}
+
+// PerOutput is how many of this input one unit of the step's output costs —
+// the input-to-output ratio, exact.
+func (i KitchenInput) PerOutput() *big.Rat { return new(big.Rat).Set(i.perOutput) }
+
+// NoBuild is an item whose demand another producer at the same base already
+// satisfies.
+//
+// Governing: SPEC-0001 REQ "Producer Rollup" — "Items whose demand is
+// satisfied by a byproduct of another producer at the same base MUST be
+// reported as requiring no construction, and MUST NOT contribute a producer
+// count or a power draw."
+type NoBuild struct {
+	ItemID string
+	Name   string
+	// From names the producer whose byproduct covers it.
+	From string
+
+	required *big.Rat
+}
+
+// Required returns the demand the byproduct covers.
+func (b NoBuild) Required() *big.Rat { return new(big.Rat).Set(b.required) }
+
+// BaseBuild is one base's construction instructions.
+type BaseBuild struct {
+	Base BaseID
+	Site SiteConfig
+
+	Farms      []FarmRow
+	Extractors []ExtractorRow
+	Ranches    []RanchRow
+	Kitchen    []KitchenStep
+
+	// NutrientProcessors is per base, computed as ceil(total steps / steps
+	// per processor) — never the sum of per-row counts, which is larger
+	// whenever a base carries more than one step.
+	NutrientProcessors int64
+
+	// PelletFeeders is per base: one feeder serves every fed fauna product
+	// there, so this is 0 or 1 however many ranch rows exist.
+	PelletFeeders int64
+
+	// NoBuild are items a byproduct at this base already covers.
+	NoBuild []NoBuild
+}
+
+// Build is stage 2's producer output.
+type Build struct {
+	Bases []BaseBuild
+
+	byBase map[BaseID]*BaseBuild
+}
+
+// Base returns one base's instructions.
+func (b *Build) Base(id BaseID) (BaseBuild, bool) {
+	v, ok := b.byBase[id]
+	if !ok {
+		return BaseBuild{}, false
+	}
+	return *v, true
+}
+
+// ByproductSource names a producer whose output covers another item's demand
+// at the same base.
+//
+// Modelled as a rollup-stage offset rather than a graph edge, so the
+// dependency graph stays a pure structure and the accounting lives where it
+// belongs.
+type ByproductSource struct {
+	// Item is the demand that is covered; From names what covers it.
+	Item string
+	From string
+}
+
+// ProducerInput is what the producer stage needs beyond the grouping.
+type ProducerInput struct {
+	// Byproducts declares, per base, which items another producer there
+	// already yields.
+	Byproducts map[BaseID][]ByproductSource
+
+	// Kitchen names the steps a base's nutrient processor runs, in the
+	// order the plan wants them. Empty for bases that cook nothing.
+	Kitchen map[BaseID][]KitchenStepInput
+}
+
+// KitchenStepInput names one processing step the plan calls for.
+type KitchenStepInput struct {
+	// ItemID is the step's output and Recipe the route; Quantity is how
+	// many units the step must produce.
+	ItemID   string
+	Recipe   string
+	Quantity int64
+}
+
+// RollupProducers turns each base's grouped leaf demands into construction
+// instructions.
+//
+// Governing: SPEC-0001 REQ "Producer Rollup"
+//
+// The unassigned group is skipped: it is a list of things the plan has not
+// placed, and there is no site to build them at. It stays visible in the
+// Grouping so the caller can report it.
+func RollupProducers(g *Grouping, t *Tier1, c *Constants, in ProducerInput) (*Build, error) {
+	if g == nil || c == nil {
+		return nil, fmt.Errorf("%w: producer rollup needs a grouping and constants", ErrInvalidArtifact)
+	}
+
+	out := &Build{byBase: map[BaseID]*BaseBuild{}}
+	for _, group := range g.Groups {
+		if group.IsUnassigned() {
+			continue
+		}
+		build, err := rollupBase(group, t, c, in)
+		if err != nil {
+			return nil, err
+		}
+		out.byBase[group.Base] = build
+	}
+
+	for _, b := range out.byBase {
+		out.Bases = append(out.Bases, *b)
+	}
+	// Governing: SPEC-0001 REQ "Determinism".
+	sort.Slice(out.Bases, func(i, j int) bool { return out.Bases[i].Base < out.Bases[j].Base })
+	return out, nil
+}
+
+func rollupBase(group BaseGroup, t *Tier1, c *Constants, in ProducerInput) (*BaseBuild, error) {
+	build := &BaseBuild{Base: group.Base, Site: group.Site}
+
+	// Byproducts first: an item another producer here already yields
+	// contributes no row at all, so it never reaches the sizing below.
+	covered := map[string]string{}
+	for _, b := range in.Byproducts[group.Base] {
+		covered[b.Item] = b.From
+	}
+
+	for _, demand := range group.Demands {
+		if from, ok := covered[demand.ItemID]; ok {
+			build.NoBuild = append(build.NoBuild, NoBuild{
+				ItemID: demand.ItemID, Name: demand.Name, From: from,
+				required: demand.Total(),
+			})
+			continue
+		}
+
+		switch {
+		case c.IsCrop(demand.ItemID):
+			row, err := farmRow(demand, c)
+			if err != nil {
+				return nil, err
+			}
+			build.Farms = append(build.Farms, row)
+
+		case c.IsFauna(demand.ItemID):
+			build.Ranches = append(build.Ranches, ranchRow(demand, c))
+
+		default:
+			row, err := extractorRow(demand, group.Site, c)
+			if err != nil {
+				return nil, err
+			}
+			build.Extractors = append(build.Extractors, row)
+		}
+	}
+
+	// One feeder serves every fed fauna product at the base.
+	// Governing: SPEC-0001 REQ "Producer Rollup" — Scenario "Feeder is
+	// reported once per base".
+	if len(build.Ranches) > 0 {
+		build.PelletFeeders = 1
+	}
+
+	steps, err := kitchenSteps(in.Kitchen[group.Base], t, c)
+	if err != nil {
+		return nil, err
+	}
+	build.Kitchen = steps
+	// ceil(total steps / steps per processor), computed once from the
+	// total. Summing per-row ceilings would report one processor per step.
+	// Governing: SPEC-0001 REQ "Producer Rollup" — Scenario "Kitchen rollup
+	// sizes processors per base".
+	if n := int64(len(steps)); n > 0 {
+		build.NutrientProcessors = ceilRat(big.NewRat(n, c.Curated().StepsPerProcessor))
+	}
+
+	sortRows(build)
+	return build, nil
+}
+
+// farmRow sizes plants and biodomes for a crop.
+//
+// Governing: SPEC-0001 REQ "Producer Rollup" — Scenario "Farm rollup", and
+// REQ "Exact Arithmetic and Rounding Discipline" — Scenarios "Plants round
+// up" and "Domes round up from plants".
+func farmRow(d LeafDemand, c *Constants) (FarmRow, error) {
+	crop, err := c.CropFor(d.ItemID)
+	if err != nil {
+		return FarmRow{}, err
+	}
+	// The pessimistic bound: a plan sized on the best case under-builds,
+	// and the failure mode is a farm that never fills the order.
+	perPlant := crop.Yield.Min
+	if perPlant <= 0 {
+		return FarmRow{}, fmt.Errorf("%w: crop %q yields %d per plant", ErrInvalidArtifact, crop.ID, perPlant)
+	}
+
+	plants := ceilRat(new(big.Rat).Quo(d.Total(), new(big.Rat).SetInt64(perPlant)))
+	// Domes round up from *plants*, not from the requirement — rounding
+	// twice is the point, because you cannot put 7.8 plants in a dome
+	// either.
+	domes := ceilRat(big.NewRat(plants, c.Curated().BiodomeCropSlots))
+
+	return FarmRow{
+		ItemID: d.ItemID, Name: d.Name,
+		Plants: plants, Biodomes: domes,
+		YieldPerPlant: crop.Yield,
+		GrowthSeconds: crop.GrowthSeconds,
+		required:      d.Total(),
+	}, nil
+}
+
+// extractorRow sizes extractors and depots for a resource.
+//
+// Governing: SPEC-0001 REQ "Producer Rollup" — Scenarios "Extractor sized to
+// fill duration", "Supply depots sized above the threshold" and "No depots
+// below the threshold".
+func extractorRow(d LeafDemand, site SiteConfig, c *Constants) (ExtractorRow, error) {
+	rate, err := c.ExtractorRate(d.ItemID, site.ExtractorClass)
+	if err != nil {
+		return ExtractorRow{}, err
+	}
+	if site.FillSeconds <= 0 {
+		return ExtractorRow{}, fmt.Errorf("%w: site fill duration is %d seconds; it must be configured",
+			ErrInvalidArtifact, site.FillSeconds)
+	}
+
+	// One extractor produces rate × duration over the window.
+	perExtractor := new(big.Rat).Mul(rate, new(big.Rat).SetInt64(site.FillSeconds))
+	count := ceilRat(new(big.Rat).Quo(d.Total(), perExtractor))
+
+	// The resulting fill time, which is shorter than the target whenever
+	// the count rounded up — the number the plan actually reports.
+	fill := new(big.Rat).Quo(d.Total(), new(big.Rat).Mul(rate, new(big.Rat).SetInt64(count)))
+
+	row := ExtractorRow{
+		ItemID: d.ItemID, Name: d.Name,
+		Class: site.ExtractorClass, Extractors: count,
+		required: d.Total(), rate: rate, fill: fill,
+	}
+
+	// Depots only above the threshold; below it the row reports none.
+	threshold := new(big.Rat).SetInt64(c.Curated().DepotThreshold)
+	if d.Total().Cmp(threshold) > 0 {
+		capacity, err := c.DepotCapacity()
+		if err != nil {
+			return ExtractorRow{}, err
+		}
+		row.Depots = ceilRat(new(big.Rat).Quo(d.Total(), new(big.Rat).SetInt64(capacity)))
+	}
+	return row, nil
+}
+
+// ranchRow sizes fauna for a product.
+//
+// Governing: SPEC-0001 REQ "Producer Rollup" — Scenario "Ranch rollup".
+func ranchRow(d LeafDemand, c *Constants) RanchRow {
+	curated := c.Curated()
+	fauna := ceilRat(new(big.Rat).Quo(d.Total(), new(big.Rat).SetInt64(curated.FaunaYieldPerCycle)))
+	return RanchRow{
+		ItemID: d.ItemID, Name: d.Name,
+		Fauna: fauna, CycleSeconds: curated.FaunaCycleSeconds,
+		required: d.Total(),
+	}
+}
+
+// kitchenSteps builds the processing steps for a base.
+//
+// Governing: SPEC-0001 REQ "Producer Rollup" — Scenarios "Kitchen rollup
+// sizes processors per base" and "Final kitchen step is distinguished".
+func kitchenSteps(inputs []KitchenStepInput, t *Tier1, c *Constants) ([]KitchenStep, error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	if t == nil {
+		return nil, fmt.Errorf("%w: kitchen steps need the artifact's recipes", ErrInvalidArtifact)
+	}
+
+	out := make([]KitchenStep, 0, len(inputs))
+	for i, step := range inputs {
+		if step.Quantity <= 0 {
+			return nil, fmt.Errorf("%w: kitchen step %q quantity is %d", ErrInvalidArtifact, step.ItemID, step.Quantity)
+		}
+		item, ok := t.Item(step.ItemID)
+		if !ok {
+			return nil, fmt.Errorf("%w: kitchen step produces %q", ErrUnknownItem, step.ItemID)
+		}
+		recipe, ok := t.Recipe(step.ItemID, MethodCook, step.Recipe)
+		if !ok {
+			return nil, fmt.Errorf("%w: %s has no cook recipe %q", ErrIllegalMethod, item.Name, step.Recipe)
+		}
+
+		s := KitchenStep{
+			ItemID: step.ItemID, Name: item.Name, Recipe: recipe.ID,
+			ProcessSeconds: c.ProcessSeconds(),
+			required:       new(big.Rat).SetInt64(step.Quantity),
+			// The last step named is the one producing the plan target;
+			// everything before it is intermediate.
+			Final: i == len(inputs)-1,
+		}
+		// The ratio is per unit of output, so a recipe yielding more than
+		// one divides through — exactly, never as a float.
+		yield := new(big.Rat).SetInt64(recipe.Producing())
+		for _, ing := range recipe.Inputs {
+			s.Inputs = append(s.Inputs, KitchenInput{
+				ItemID:    ing.Item,
+				perOutput: new(big.Rat).Quo(new(big.Rat).SetInt64(ing.Quantity), yield),
+			})
+		}
+		sort.Slice(s.Inputs, func(a, b int) bool { return s.Inputs[a].ItemID < s.Inputs[b].ItemID })
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// sortRows imposes a stable order on every row collection.
+// Governing: SPEC-0001 REQ "Determinism".
+func sortRows(b *BaseBuild) {
+	sort.Slice(b.Farms, func(i, j int) bool { return b.Farms[i].ItemID < b.Farms[j].ItemID })
+	sort.Slice(b.Extractors, func(i, j int) bool { return b.Extractors[i].ItemID < b.Extractors[j].ItemID })
+	sort.Slice(b.Ranches, func(i, j int) bool { return b.Ranches[i].ItemID < b.Ranches[j].ItemID })
+	sort.Slice(b.NoBuild, func(i, j int) bool { return b.NoBuild[i].ItemID < b.NoBuild[j].ItemID })
+	// Kitchen steps keep their given order: it is the sequence the plan
+	// cooks in, and the final step is identified by position.
+}
+
+// ceilRat rounds a rational up to the next whole unit.
+//
+// Governing: SPEC-0001 REQ "Exact Arithmetic and Rounding Discipline" —
+// "Rounding MUST occur only at stated physical boundaries, and MUST round
+// up, because partial physical units cannot be built."
+//
+// Integer division on the numerator and denominator, so no float is
+// involved at the one place the engine is allowed to lose precision.
+func ceilRat(r *big.Rat) int64 {
+	q, m := new(big.Int).QuoRem(r.Num(), r.Denom(), new(big.Int))
+	if m.Sign() > 0 {
+		q.Add(q, big.NewInt(1))
+	}
+	return q.Int64()
+}

--- a/internal/domain/producer_test.go
+++ b/internal/domain/producer_test.go
@@ -1,0 +1,590 @@
+package domain
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// Synthetic constants, per SPEC-0001 design.md: "Injection also makes every
+// producer and power scenario testable with small synthetic constant sets
+// rather than the full production dataset." Every number below is the one
+// the scenario names.
+func producerArtifact(t *testing.T, economy string, extra ...string) *Tier1 {
+	t.Helper()
+	items := `{"id":"crop_a","name":"Crop A","raw_obtainable":true,"default_method":"raw"},
+	          {"id":"gas_a","name":"Gas A","raw_obtainable":true,"default_method":"raw"},
+	          {"id":"gas_b","name":"Gas B","raw_obtainable":true,"default_method":"raw"},
+	          {"id":"milk","name":"Wild Milk","raw_obtainable":true,"default_method":"raw"},
+	          {"id":"egg","name":"Proto-Egg","raw_obtainable":true,"default_method":"raw"},
+	          {"id":"target","name":"Target","default_method":"raw","raw_obtainable":true}`
+	for _, e := range extra {
+		items += ",\n" + e
+	}
+	src := `{"schema_version":2,"game_version":"test-producer",
+	  "items":[` + items + `],
+	  "recipes":[],
+	  "economy":` + economy + `}`
+	a1, err := LoadTier1(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("loading artifact: %v", err)
+	}
+	return a1
+}
+
+// economyFor builds an economy section with the parts and hotspots the
+// scenarios need.
+func economyFor(cropYield, cropGrowth, extractorRate, depotCapacity int64) string {
+	return `{
+	  "parts":[
+	    {"id":"U_EXTRACTOR_S","primary":{"network":"resources","rate":` + itoa(extractorRate) + `,"storage":360000},"hotspot":"Mineral"},
+	    {"id":"U_GASEXTRACTOR","primary":{"network":"resources","rate":` + itoa(extractorRate) + `,"storage":360000},"hotspot":"Gas"},
+	    {"id":"U_SILO_S","primary":{"network":"resources","rate":0,"storage":` + itoa(depotCapacity) + `}},
+	    {"id":"U_BATTERY_S","primary":{"network":"power","rate":0,"storage":45000}}
+	  ],
+	  "hotspots":[
+	    {"category":"Gas","strengths":{"c":1,"b":1,"a":2,"s":2.5},"weightings":{"c":1,"b":1,"a":1,"s":1}},
+	    {"category":"Mineral","strengths":{"c":1,"b":1,"a":2,"s":2.5},"weightings":{"c":1,"b":1,"a":1,"s":1}}
+	  ],
+	  "crops":[{"id":"PLANT_A","substance":"crop_a","yield":{"min":` + itoa(cropYield) + `,"max":` + itoa(cropYield) + `},"growth_seconds":` + itoa(cropGrowth) + `}]
+	}`
+}
+
+func itoa(v int64) string { return new(big.Int).SetInt64(v).String() }
+
+// demandOf builds a grouping directly, so producer tests exercise sizing
+// rather than re-deriving a graph.
+func demandOf(base BaseID, site SiteConfig, demands map[string]int64) *Grouping {
+	group := &BaseGroup{Base: base, Site: site}
+	for id, qty := range demands {
+		group.Demands = append(group.Demands, LeafDemand{
+			ItemID: id, Name: id, Verified: true,
+			total: new(big.Rat).SetInt64(qty),
+		})
+	}
+	sortDemands(group)
+	return &Grouping{Groups: []BaseGroup{*group}, byBase: map[BaseID]*BaseGroup{base: group}}
+}
+
+func sortDemands(g *BaseGroup) {
+	for i := 1; i < len(g.Demands); i++ {
+		for j := i; j > 0 && g.Demands[j].ItemID < g.Demands[j-1].ItemID; j-- {
+			g.Demands[j], g.Demands[j-1] = g.Demands[j-1], g.Demands[j]
+		}
+	}
+}
+
+func constantsFor(t *testing.T, a1 *Tier1, curated Curated) *Constants {
+	t.Helper()
+	c, err := NewConstants(a1, curated)
+	if err != nil {
+		t.Fatalf("NewConstants: %v", err)
+	}
+	return c
+}
+
+func baseCurated() Curated {
+	return Curated{
+		BiodomeCropSlots: 16, FaunaYieldPerCycle: 12, FaunaCycleSeconds: 1800,
+		StepsPerProcessor: 2, DepotThreshold: 1000, ProcessSeconds: 30,
+		FaunaProducts:    map[string]bool{"milk": true, "egg": true},
+		ResourceHotspots: map[string]string{"gas_a": "Gas", "gas_b": "Gas"},
+	}
+}
+
+func build(t *testing.T, g *Grouping, a1 *Tier1, c *Constants, in ProducerInput) *Build {
+	t.Helper()
+	b, err := RollupProducers(g, a1, c, in)
+	if err != nil {
+		t.Fatalf("RollupProducers: %v", err)
+	}
+	return b
+}
+
+// SPEC-0001 REQ "Producer Rollup":
+// WHEN a base is assigned a crop requiring 200 units at a yield of 25 per
+// plant and a dome capacity of 16 THEN the engine reports 8 plants and 1
+// biodome for that crop.
+func TestFarmRollup(t *testing.T) {
+	a1 := producerArtifact(t, economyFor(25, 3600, 100, 1000))
+	c := constantsFor(t, a1, baseCurated())
+
+	b := build(t, demandOf("alpha", SiteConfig{ExtractorClass: ClassB, FillSeconds: 5400},
+		map[string]int64{"crop_a": 200}), a1, c, ProducerInput{})
+
+	base, ok := b.Base("alpha")
+	if !ok {
+		t.Fatal("alpha missing")
+	}
+	if len(base.Farms) != 1 {
+		t.Fatalf("farms = %d, want 1", len(base.Farms))
+	}
+	row := base.Farms[0]
+	if row.Plants != 8 {
+		t.Errorf("plants = %d, want 8", row.Plants)
+	}
+	if row.Biodomes != 1 {
+		t.Errorf("biodomes = %d, want 1", row.Biodomes)
+	}
+	if row.GrowthSeconds != 3600 {
+		t.Errorf("growth = %d, want 3600", row.GrowthSeconds)
+	}
+}
+
+// SPEC-0001 REQ "Exact Arithmetic and Rounding Discipline":
+// WHEN a crop requires 250 units at a yield of 32 per plant THEN 8 plants,
+// not 7.8125 — and domes round up from plants, so 17 plants at capacity 16
+// is 2 domes.
+func TestPlantsAndDomesRoundUp(t *testing.T) {
+	a1 := producerArtifact(t, economyFor(32, 3600, 100, 1000))
+	c := constantsFor(t, a1, baseCurated())
+
+	b := build(t, demandOf("alpha", SiteConfig{ExtractorClass: ClassB, FillSeconds: 5400},
+		map[string]int64{"crop_a": 250}), a1, c, ProducerInput{})
+	base, _ := b.Base("alpha")
+	if got := base.Farms[0].Plants; got != 8 {
+		t.Errorf("plants = %d, want 8 (250/32 = 7.8125)", got)
+	}
+
+	// 17 plants at a capacity of 16 is two domes: the second rounding is
+	// from plants, not from the requirement.
+	a2 := producerArtifact(t, economyFor(1, 3600, 100, 1000))
+	c2 := constantsFor(t, a2, baseCurated())
+	b2 := build(t, demandOf("alpha", SiteConfig{ExtractorClass: ClassB, FillSeconds: 5400},
+		map[string]int64{"crop_a": 17}), a2, c2, ProducerInput{})
+	base2, _ := b2.Base("alpha")
+	if got := base2.Farms[0].Plants; got != 17 {
+		t.Fatalf("plants = %d, want 17", got)
+	}
+	if got := base2.Farms[0].Biodomes; got != 2 {
+		t.Errorf("biodomes = %d, want 2", got)
+	}
+}
+
+// SPEC-0001 REQ "Producer Rollup":
+// WHEN a base is assigned a gas requiring 500 units, with a class-B rate of
+// 200 per hour and a target fill duration of 1.5 hours THEN 2 extractors and
+// the resulting fill time.
+func TestExtractorSizedToFillDuration(t *testing.T) {
+	// The scenario says 200 units per hour over 1.5 hours. Rate and window
+	// are expressed in the same unit here, so the identical ratio with
+	// integer inputs is a rate of 100 over a window of 3: 100 x 3 = 300
+	// per extractor either way.
+	a1 := producerArtifact(t, economyFor(25, 3600, 100, 1000))
+	c := constantsFor(t, a1, baseCurated())
+
+	b := build(t, demandOf("alpha", SiteConfig{ExtractorClass: ClassB, FillSeconds: 3},
+		map[string]int64{"gas_a": 500}), a1, c, ProducerInput{})
+	base, _ := b.Base("alpha")
+	if len(base.Extractors) != 1 {
+		t.Fatalf("extractor rows = %d, want 1", len(base.Extractors))
+	}
+	row := base.Extractors[0]
+
+	if row.Extractors != 2 {
+		t.Errorf("extractors = %d, want 2 (500 / (100 x 3) = 1.67)", row.Extractors)
+	}
+	// The resulting fill time, which is shorter than the 3 asked for
+	// because the count rounded up: 500 / (100 x 2) = 5/2.
+	if got := row.FillSeconds().RatString(); got != "5/2" {
+		t.Errorf("fill time = %s, want 5/2", got)
+	}
+	if got := row.RatePerSecond().RatString(); got != "100" {
+		t.Errorf("rate = %s, want 100 at class B in this economy", got)
+	}
+	if row.Class != ClassB {
+		t.Errorf("row class = %q, want B", row.Class)
+	}
+
+	// A site with no configured window cannot size anything, and says so.
+	_, err := RollupProducers(demandOf("beta", SiteConfig{ExtractorClass: ClassB},
+		map[string]int64{"gas_a": 500}), a1, c, ProducerInput{})
+	if err == nil {
+		t.Fatal("an unconfigured fill window sized extractors anyway")
+	}
+	if !strings.Contains(err.Error(), "fill duration") {
+		t.Errorf("error %q does not name the missing window", err)
+	}
+}
+
+// SPEC-0001 REQ "Producer Rollup":
+// WHEN the extractor class at a base changes from B to S THEN every
+// extractor row at that base recomputes, and no other base is affected.
+func TestSiteClassAppliesToAllRowsAndOnlyThatBase(t *testing.T) {
+	a1 := producerArtifact(t, economyFor(25, 3600, 100, 1000))
+	c := constantsFor(t, a1, baseCurated())
+
+	// Two bases, two extractor rows each.
+	grouping := func(alphaClass HotspotClass) *Grouping {
+		alpha := &BaseGroup{Base: "alpha", Site: SiteConfig{ExtractorClass: alphaClass, FillSeconds: 1}}
+		beta := &BaseGroup{Base: "beta", Site: SiteConfig{ExtractorClass: ClassB, FillSeconds: 1}}
+		for _, id := range []string{"gas_a", "gas_b"} {
+			alpha.Demands = append(alpha.Demands, LeafDemand{ItemID: id, Name: id, total: new(big.Rat).SetInt64(500)})
+			beta.Demands = append(beta.Demands, LeafDemand{ItemID: id, Name: id, total: new(big.Rat).SetInt64(500)})
+		}
+		return &Grouping{
+			Groups: []BaseGroup{*alpha, *beta},
+			byBase: map[BaseID]*BaseGroup{"alpha": alpha, "beta": beta},
+		}
+	}
+
+	atB := build(t, grouping(ClassB), a1, c, ProducerInput{})
+	atS := build(t, grouping(ClassS), a1, c, ProducerInput{})
+
+	alphaB, _ := atB.Base("alpha")
+	alphaS, _ := atS.Base("alpha")
+	if len(alphaB.Extractors) != 2 || len(alphaS.Extractors) != 2 {
+		t.Fatalf("alpha rows = %d and %d, want 2 each", len(alphaB.Extractors), len(alphaS.Extractors))
+	}
+	// Every row at the base recomputes, not just the first.
+	for i := range alphaB.Extractors {
+		if alphaS.Extractors[i].Extractors >= alphaB.Extractors[i].Extractors {
+			t.Errorf("row %s did not recompute: B needed %d, S needs %d",
+				alphaB.Extractors[i].ItemID, alphaB.Extractors[i].Extractors, alphaS.Extractors[i].Extractors)
+		}
+		if alphaS.Extractors[i].Class != ClassS {
+			t.Errorf("row %s reports class %q, want S", alphaS.Extractors[i].ItemID, alphaS.Extractors[i].Class)
+		}
+	}
+
+	// And no other base moved.
+	betaB, _ := atB.Base("beta")
+	betaS, _ := atS.Base("beta")
+	for i := range betaB.Extractors {
+		if betaB.Extractors[i].Extractors != betaS.Extractors[i].Extractors {
+			t.Errorf("beta row %s changed when alpha's class did", betaB.Extractors[i].ItemID)
+		}
+		if betaS.Extractors[i].Class != ClassB {
+			t.Errorf("beta row %s class = %q, want B", betaS.Extractors[i].ItemID, betaS.Extractors[i].Class)
+		}
+	}
+}
+
+// SPEC-0001 REQ "Producer Rollup":
+// WHEN a resource requires 2500 units at a depot threshold of 1000 and a
+// capacity of 1000 THEN 3 supply depots; at 800 units THEN none.
+func TestSupplyDepotsAroundTheThreshold(t *testing.T) {
+	a1 := producerArtifact(t, economyFor(25, 3600, 100, 1000))
+	c := constantsFor(t, a1, baseCurated()) // threshold 1000, capacity 1000
+
+	for _, tc := range []struct {
+		required int64
+		depots   int64
+	}{
+		{2500, 3}, // ceil(2500/1000)
+		{800, 0},  // below the threshold
+		{1000, 0}, // at the threshold, not above it
+		{1001, 2}, // just above: ceil(1001/1000)
+	} {
+		b := build(t, demandOf("alpha", SiteConfig{ExtractorClass: ClassB, FillSeconds: 3600},
+			map[string]int64{"gas_a": tc.required}), a1, c, ProducerInput{})
+		base, _ := b.Base("alpha")
+		if got := base.Extractors[0].Depots; got != tc.depots {
+			t.Errorf("%d units: depots = %d, want %d", tc.required, got, tc.depots)
+		}
+	}
+}
+
+// SPEC-0001 REQ "Producer Rollup":
+// WHEN a base is assigned a fauna product requiring 100 units at a yield of
+// 12 per creature per cycle THEN 9 fauna, together with the cycle time.
+func TestRanchRollup(t *testing.T) {
+	a1 := producerArtifact(t, economyFor(25, 3600, 100, 1000))
+	c := constantsFor(t, a1, baseCurated())
+
+	b := build(t, demandOf("alpha", SiteConfig{ExtractorClass: ClassB, FillSeconds: 3600},
+		map[string]int64{"milk": 100}), a1, c, ProducerInput{})
+	base, _ := b.Base("alpha")
+	if len(base.Ranches) != 1 {
+		t.Fatalf("ranch rows = %d, want 1", len(base.Ranches))
+	}
+	if got := base.Ranches[0].Fauna; got != 9 {
+		t.Errorf("fauna = %d, want 9 (100/12 = 8.33)", got)
+	}
+	if got := base.Ranches[0].CycleSeconds; got != 1800 {
+		t.Errorf("cycle = %d, want 1800", got)
+	}
+}
+
+// SPEC-0001 REQ "Producer Rollup":
+// WHEN a base is assigned two distinct fauna products that both require
+// feeding THEN 1 pellet feeder for that base, not one per row.
+//
+// The trap: a per-row implementation reports 2 here and passes every
+// single-row test.
+func TestFeederIsReportedOncePerBase(t *testing.T) {
+	a1 := producerArtifact(t, economyFor(25, 3600, 100, 1000))
+	c := constantsFor(t, a1, baseCurated())
+
+	b := build(t, demandOf("alpha", SiteConfig{ExtractorClass: ClassB, FillSeconds: 3600},
+		map[string]int64{"milk": 100, "egg": 60}), a1, c, ProducerInput{})
+	base, _ := b.Base("alpha")
+
+	if len(base.Ranches) != 2 {
+		t.Fatalf("ranch rows = %d, want 2 — the scenario needs both", len(base.Ranches))
+	}
+	if base.PelletFeeders != 1 {
+		t.Errorf("feeders = %d, want 1 for two fed products", base.PelletFeeders)
+	}
+	// A base with no fauna builds no feeder.
+	b = build(t, demandOf("beta", SiteConfig{ExtractorClass: ClassB, FillSeconds: 3600},
+		map[string]int64{"gas_a": 500}), a1, c, ProducerInput{})
+	beta, _ := b.Base("beta")
+	if beta.PelletFeeders != 0 {
+		t.Errorf("a base with no fauna reports %d feeders", beta.PelletFeeders)
+	}
+}
+
+// SPEC-0001 REQ "Producer Rollup":
+// WHEN a base carries 4 nutrient processor steps at 2 steps per processor
+// THEN 2 processors once for that base, not a count on each of the 4 rows.
+//
+// The trap: summing per-row ceilings gives 4, since ceil(1/2) is 1 four
+// times over. The two answers differ whenever a base has more than one step.
+func TestKitchenSizesProcessorsPerBase(t *testing.T) {
+	// No crops: this artifact defines no crop_a, so an economy referencing
+	// one would dangle. Validate checks that, which is the point.
+	const kitchenEconomy = `{
+	  "parts":[
+	    {"id":"U_EXTRACTOR_S","primary":{"network":"resources","rate":100,"storage":360000},"hotspot":"Mineral"},
+	    {"id":"U_GASEXTRACTOR","primary":{"network":"resources","rate":100,"storage":360000},"hotspot":"Gas"},
+	    {"id":"U_SILO_S","primary":{"network":"resources","rate":0,"storage":1000}},
+	    {"id":"U_BATTERY_S","primary":{"network":"power","rate":0,"storage":45000}}
+	  ],
+	  "hotspots":[
+	    {"category":"Gas","strengths":{"c":1,"b":1,"a":2,"s":2.5},"weightings":{"c":1,"b":1,"a":1,"s":1}},
+	    {"category":"Mineral","strengths":{"c":1,"b":1,"a":2,"s":2.5},"weightings":{"c":1,"b":1,"a":1,"s":1}}
+	  ]
+	}`
+
+	const recipes = `{"id":"flour_cook","output":"flour","method":"cook","inputs":[{"item":"wheat","quantity":5}]},
+	                 {"id":"butter_cook","output":"butter","method":"cook","inputs":[{"item":"milk","quantity":4}]},
+	                 {"id":"batter_cook","output":"batter","method":"cook","inputs":[{"item":"flour","quantity":2},{"item":"egg","quantity":3}],"yield":2},
+	                 {"id":"cake_cook","output":"cake","method":"cook","inputs":[{"item":"batter","quantity":1},{"item":"butter","quantity":1}]}`
+	src := `{"schema_version":2,"game_version":"test-kitchen",
+	  "items":[
+	    {"id":"wheat","name":"Wheat","raw_obtainable":true,"default_method":"raw"},
+	    {"id":"milk","name":"Wild Milk","raw_obtainable":true,"default_method":"raw"},
+	    {"id":"egg","name":"Proto-Egg","raw_obtainable":true,"default_method":"raw"},
+	    {"id":"flour","name":"Flour","default_method":"cook"},
+	    {"id":"butter","name":"Butter","default_method":"cook"},
+	    {"id":"batter","name":"Batter","default_method":"cook"},
+	    {"id":"cake","name":"Cake","default_method":"cook"}
+	  ],
+	  "recipes":[` + recipes + `],
+	  "economy":` + kitchenEconomy + `}`
+	a1, err := LoadTier1(strings.NewReader(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := constantsFor(t, a1, baseCurated())
+
+	in := ProducerInput{Kitchen: map[BaseID][]KitchenStepInput{
+		"alpha": {
+			{ItemID: "flour", Recipe: "flour_cook", Quantity: 10},
+			{ItemID: "butter", Recipe: "butter_cook", Quantity: 5},
+			{ItemID: "batter", Recipe: "batter_cook", Quantity: 5},
+			{ItemID: "cake", Recipe: "cake_cook", Quantity: 5},
+		},
+	}}
+	b := build(t, demandOf("alpha", SiteConfig{ExtractorClass: ClassB, FillSeconds: 3600},
+		map[string]int64{"milk": 20}), a1, c, in)
+	base, _ := b.Base("alpha")
+
+	if len(base.Kitchen) != 4 {
+		t.Fatalf("kitchen steps = %d, want 4", len(base.Kitchen))
+	}
+	if base.NutrientProcessors != 2 {
+		t.Errorf("processors = %d, want 2 — ceil(4/2), not the sum of per-row ceilings (4)",
+			base.NutrientProcessors)
+	}
+
+	// WHEN a base's kitchen steps include the one producing the plan target
+	// THEN that step is final and the rest are intermediate.
+	var finals int
+	for _, step := range base.Kitchen {
+		if step.Final {
+			finals++
+			if step.ItemID != "cake" {
+				t.Errorf("final step is %q, want cake", step.ItemID)
+			}
+		}
+	}
+	if finals != 1 {
+		t.Errorf("%d steps marked final, want exactly 1", finals)
+	}
+
+	// Each step reports its input-to-output ratio and duration. Batter
+	// yields 2, so 2 flour per batch is 1 per unit of output.
+	var batter *KitchenStep
+	for i := range base.Kitchen {
+		if base.Kitchen[i].ItemID == "batter" {
+			batter = &base.Kitchen[i]
+		}
+	}
+	if batter == nil {
+		t.Fatal("batter step missing")
+	}
+	ratios := map[string]string{}
+	for _, in := range batter.Inputs {
+		ratios[in.ItemID] = in.PerOutput().RatString()
+	}
+	if ratios["flour"] != "1" {
+		t.Errorf("flour per batter = %s, want 1 (2 per batch at yield 2)", ratios["flour"])
+	}
+	if ratios["egg"] != "3/2" {
+		t.Errorf("egg per batter = %s, want 3/2", ratios["egg"])
+	}
+	if batter.ProcessSeconds != 30 {
+		t.Errorf("process seconds = %d, want the curated 30", batter.ProcessSeconds)
+	}
+}
+
+// A base with an odd number of steps still sizes from the total.
+func TestProcessorsRoundUpFromTheTotal(t *testing.T) {
+	// 5 steps at 2 per processor is 3, and it is ceil(5/2) rather than
+	// 5 × ceil(1/2).
+	if got := ceilRat(big.NewRat(5, 2)); got != 3 {
+		t.Errorf("ceil(5/2) = %d, want 3", got)
+	}
+	if got := ceilRat(big.NewRat(4, 2)); got != 2 {
+		t.Errorf("ceil(4/2) = %d, want 2", got)
+	}
+}
+
+// SPEC-0001 REQ "Producer Rollup":
+// WHEN a base's Condensed Carbon demand is met by the byproduct of gas
+// refining at that same base THEN it requires no construction, with no
+// producer count and no power draw.
+func TestByproductRequiresNoConstruction(t *testing.T) {
+	a1 := producerArtifact(t, economyFor(25, 3600, 100, 1000))
+	c := constantsFor(t, a1, baseCurated())
+
+	in := ProducerInput{Byproducts: map[BaseID][]ByproductSource{
+		"alpha": {{Item: "gas_b", From: "gas_a refining"}},
+	}}
+	b := build(t, demandOf("alpha", SiteConfig{ExtractorClass: ClassB, FillSeconds: 3600},
+		map[string]int64{"gas_a": 500, "gas_b": 300}), a1, c, in)
+	base, _ := b.Base("alpha")
+
+	// No row of any kind for the covered item.
+	for _, row := range base.Extractors {
+		if row.ItemID == "gas_b" {
+			t.Errorf("gas_b got an extractor row with %d extractors", row.Extractors)
+		}
+	}
+	if len(base.Extractors) != 1 {
+		t.Errorf("extractor rows = %d, want 1 — only the uncovered item", len(base.Extractors))
+	}
+
+	// It is reported, not dropped, and it carries its full demand.
+	if len(base.NoBuild) != 1 {
+		t.Fatalf("no-build entries = %d, want 1", len(base.NoBuild))
+	}
+	nb := base.NoBuild[0]
+	if nb.ItemID != "gas_b" || nb.From != "gas_a refining" {
+		t.Errorf("no-build entry = %+v, want gas_b from gas_a refining", nb)
+	}
+	if got := nb.Required().RatString(); got != "300" {
+		t.Errorf("no-build requirement = %s, want 300", got)
+	}
+}
+
+// The unassigned group has no site, so it produces no construction
+// instructions — it stays a list of things the plan has not placed.
+func TestUnassignedGroupBuildsNothing(t *testing.T) {
+	a1 := producerArtifact(t, economyFor(25, 3600, 100, 1000))
+	c := constantsFor(t, a1, baseCurated())
+
+	un := &BaseGroup{Base: Unassigned}
+	un.Demands = append(un.Demands, LeafDemand{ItemID: "gas_a", Name: "Gas A", total: new(big.Rat).SetInt64(500)})
+	g := &Grouping{Groups: []BaseGroup{*un}, byBase: map[BaseID]*BaseGroup{Unassigned: un}}
+
+	b := build(t, g, a1, c, ProducerInput{})
+	if len(b.Bases) != 0 {
+		t.Errorf("unassigned leaves produced %d base builds, want none", len(b.Bases))
+	}
+}
+
+// Nothing in the rollup hardcodes an economy value: changing a constant
+// changes the answer.
+//
+// Governing: SPEC-0001 REQ "Producer Rollup" — "Producer counts MUST derive
+// from constants supplied at call time and MUST NOT be hardcoded."
+func TestNoConstantIsHardcoded(t *testing.T) {
+	cases := []struct {
+		name    string
+		economy string
+		curated Curated
+		check   func(*testing.T, BaseBuild)
+	}{
+		{
+			name:    "crop yield",
+			economy: economyFor(50, 3600, 100, 1000),
+			curated: baseCurated(),
+			check: func(t *testing.T, b BaseBuild) {
+				if b.Farms[0].Plants != 4 { // 200/50
+					t.Errorf("plants = %d, want 4 at a yield of 50", b.Farms[0].Plants)
+				}
+			},
+		},
+		{
+			name:    "dome capacity",
+			economy: economyFor(1, 3600, 100, 1000),
+			curated: func() Curated { c := baseCurated(); c.BiodomeCropSlots = 100; return c }(),
+			check: func(t *testing.T, b BaseBuild) {
+				if b.Farms[0].Biodomes != 2 { // 200 plants at 100 per dome
+					t.Errorf("biodomes = %d, want 2 at a capacity of 100", b.Farms[0].Biodomes)
+				}
+			},
+		},
+		{
+			name:    "depot capacity",
+			economy: economyFor(25, 3600, 100, 250),
+			curated: baseCurated(),
+			check: func(t *testing.T, b BaseBuild) {
+				if b.Extractors[0].Depots != 8 { // ceil(2000/250)
+					t.Errorf("depots = %d, want 8 at a capacity of 250", b.Extractors[0].Depots)
+				}
+			},
+		},
+		{
+			name:    "fauna yield",
+			economy: economyFor(25, 3600, 100, 1000),
+			curated: func() Curated { c := baseCurated(); c.FaunaYieldPerCycle = 50; return c }(),
+			check: func(t *testing.T, b BaseBuild) {
+				if b.Ranches[0].Fauna != 2 { // ceil(100/50)
+					t.Errorf("fauna = %d, want 2 at a yield of 50", b.Ranches[0].Fauna)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a1 := producerArtifact(t, tc.economy)
+			c := constantsFor(t, a1, tc.curated)
+			b := build(t, demandOf("alpha", SiteConfig{ExtractorClass: ClassB, FillSeconds: 3600},
+				map[string]int64{"crop_a": 200, "gas_a": 2000, "milk": 100}), a1, c, ProducerInput{})
+			base, _ := b.Base("alpha")
+			tc.check(t, base)
+		})
+	}
+}
+
+// A resource with no configured hotspot category cannot be sized, and says
+// so rather than defaulting to Mineral.
+func TestUnclassifiedResourceIsRefused(t *testing.T) {
+	a1 := producerArtifact(t, economyFor(25, 3600, 100, 1000))
+	curated := baseCurated()
+	delete(curated.ResourceHotspots, "gas_a")
+	c := constantsFor(t, a1, curated)
+
+	_, err := RollupProducers(demandOf("alpha", SiteConfig{ExtractorClass: ClassB, FillSeconds: 3600},
+		map[string]int64{"gas_a": 500}), a1, c, ProducerInput{})
+	if err == nil {
+		t.Fatal("an unclassified resource was sized anyway")
+	}
+	if !strings.Contains(err.Error(), "gas_a") || !strings.Contains(err.Error(), "hotspot category") {
+		t.Errorf("error %q does not name the item and what is missing", err)
+	}
+}

--- a/internal/domain/rollup.go
+++ b/internal/domain/rollup.go
@@ -59,6 +59,17 @@ type SiteConfig struct {
 	// Governing: SPEC-0001 REQ "Producer Rollup" — "Extractor class MUST be
 	// configured per site, not per row."
 	ExtractorClass HotspotClass
+
+	// FillSeconds is how long the plan is willing to wait for an extractor
+	// row to produce its requirement. Extractor counts are sized to it.
+	//
+	// Per site rather than global because it pairs with the class: a base
+	// on an S hotspot and one on a C hotspot are rarely given the same
+	// patience.
+	//
+	// Governing: SPEC-0001 REQ "Producer Rollup" — "sized so the required
+	// quantity is produced within a configured fill duration".
+	FillSeconds int64
 }
 
 // Curated holds the economy constants no game table states.
@@ -102,6 +113,24 @@ type Curated struct {
 	// Depot *capacity* is not here: it is U_SILO_S's storage buffer, which
 	// the artifact carries. See Constants.DepotCapacity.
 	DepotThreshold int64
+
+	// ProcessSeconds is how long one nutrient processor step takes.
+	// Economy.Refining states throughput per cycle but not the cycle's
+	// duration, so this is supplied.
+	ProcessSeconds int64
+
+	// FaunaProducts and ResourceHotspots are classification rather than
+	// scalars: which leaf items come from creatures, and which hotspot
+	// category each extracted resource sits on.
+	//
+	// Neither is in the tables. Crops classify themselves — Economy.Crops
+	// names the substance each plant yields — but nothing says Wild Milk
+	// comes from a creature or that Sulphurine is a Gas hotspot rather
+	// than a Mineral one. Supplied rather than guessed from the item's
+	// name, which is the kind of inference that has cost this project
+	// before.
+	FaunaProducts    map[string]bool
+	ResourceHotspots map[string]string
 }
 
 // validate refuses a partially-specified constant set.
@@ -115,6 +144,7 @@ func (c Curated) validate() error {
 		{"fauna cycle seconds", c.FaunaCycleSeconds},
 		{"steps per processor", c.StepsPerProcessor},
 		{"depot threshold", c.DepotThreshold},
+		{"process seconds", c.ProcessSeconds},
 	} {
 		if f.v <= 0 {
 			return fmt.Errorf("%w: curated constant %q is %d; it must be supplied, not defaulted",
@@ -192,6 +222,55 @@ func NewConstants(t *Tier1, curated Curated) (*Constants, error) {
 
 // Curated returns the caller-supplied constants.
 func (c *Constants) Curated() Curated { return c.curated }
+
+// ProcessSeconds is one nutrient processor step's duration.
+func (c *Constants) ProcessSeconds() int64 { return c.curated.ProcessSeconds }
+
+// IsFauna reports whether an item comes from a creature rather than a plant
+// or a hotspot.
+func (c *Constants) IsFauna(itemID string) bool { return c.curated.FaunaProducts[itemID] }
+
+// ExtractorRate is one extractor's output for a resource at a class, as an
+// exact rational.
+//
+// Governing: SPEC-0001 REQ "Producer Rollup", REQ "Exact Arithmetic and
+// Rounding Discipline"
+//
+// The base rate comes from the extractor part the resource's hotspot
+// category implies, scaled by that category's class strength. Both halves
+// read from the artifact; only the item-to-category mapping is curated,
+// because nothing in the tables states it.
+//
+// The unit is whatever the part's Rate is denominated in, and the artifact
+// does not say. U_EXTRACTOR_S carries rate 100 against storage 360000,
+// which fills in 3,600 of those units — an hour if the rate is per second.
+// Callers therefore supply SiteConfig.FillSeconds in the same unit; the
+// arithmetic is consistent either way, and the plan's absolute times are
+// only as right as that reading. Worth confirming in game before any
+// duration is shown to a user.
+func (c *Constants) ExtractorRate(itemID string, class HotspotClass) (*big.Rat, error) {
+	category, ok := c.curated.ResourceHotspots[itemID]
+	if !ok {
+		return nil, fmt.Errorf("%w: no hotspot category is configured for %q, so no extractor can be sized for it",
+			ErrUnknownItem, itemID)
+	}
+	part := PartExtractorMineral
+	if category == "Gas" {
+		part = PartExtractorGas
+	}
+	p, err := c.Part(part)
+	if err != nil {
+		return nil, err
+	}
+	if p.Primary.Rate <= 0 {
+		return nil, fmt.Errorf("%w: %s states no extraction rate", ErrInvalidArtifact, part)
+	}
+	strength, err := c.ClassStrength(category, class)
+	if err != nil {
+		return nil, err
+	}
+	return new(big.Rat).Mul(new(big.Rat).SetInt64(p.Primary.Rate), strength), nil
+}
 
 // CropFor returns the crop that yields the given item.
 func (c *Constants) CropFor(itemID string) (Crop, error) {

--- a/internal/domain/rollup_test.go
+++ b/internal/domain/rollup_test.go
@@ -36,6 +36,9 @@ func curatedForTest() Curated {
 		FaunaCycleSeconds:  1800,
 		StepsPerProcessor:  2,
 		DepotThreshold:     1000,
+		ProcessSeconds:     30,
+		FaunaProducts:      map[string]bool{},
+		ResourceHotspots:   map[string]string{},
 	}
 }
 
@@ -371,6 +374,7 @@ func TestCuratedConstantsMustBeSupplied(t *testing.T) {
 		"fauna cycle seconds":   func(c *Curated) { c.FaunaCycleSeconds = 0 },
 		"steps per processor":   func(c *Curated) { c.StepsPerProcessor = 0 },
 		"depot threshold":       func(c *Curated) { c.DepotThreshold = 0 },
+		"process seconds":       func(c *Curated) { c.ProcessSeconds = 0 },
 	}
 	for name, clear := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## What

Implements #40 — the largest story in the epic. Turns each base's assigned leaf totals into construction instructions across four producer types. **All ten Producer Rollup scenarios have a named test** (20 passing test cases including subtests).

## The three traps, each with a test that fails under the obvious implementation

**Feeders are per base.** Two fed fauna products at one base report **one** feeder. A per-row implementation reports two and passes every single-row test, so the test asserts two ranch rows exist first — otherwise it would pass by finding nothing.

**Processors are `ceil(total / per processor)`, not the sum of per-row ceilings.** Four steps at two per processor is **2**. Summing per-row ceilings gives 4, since `ceil(1/2)` is 1 four times over. The two answers differ whenever a base has more than one step.

**Extractor class belongs to the site.** The test builds two bases with two extractor rows each, flips one base from B to S, and asserts *every* row at that base recomputed **and** that no row at the other base moved.

## Rounding

Only at SPEC-0001's enumerated boundaries, always up, via integer `QuoRem` on numerator and denominator — no float at the one place the engine is allowed to lose precision.

Biodomes round from **plants**, not from the requirement. 17 plants at a capacity of 16 is two domes; rounding once from the requirement would give one. Tested directly.

Plants size on the **pessimistic bound** of the yield range. A plan sized on the best case under-builds, and the failure mode is a farm that never fills the order.

## Four more curated constants, and why

The producer stage needs four things no table states. They went into `Curated` rather than being inferred:

| Constant | Why it is curated |
|---|---|
| `ProcessSeconds` | `Economy.Refining` gives throughput per cycle but not the cycle's duration |
| `FaunaProducts` | Nothing says Wild Milk comes from a creature |
| `ResourceHotspots` | Nothing says Sulphurine sits on a Gas hotspot rather than a Mineral one |
| `FaunaYieldPerCycle`, `FaunaCycleSeconds` | already curated from #39 |

Crops classify themselves — `Economy.Crops` names the substance each plant yields — but the other two do not. Guessing a hotspot category from an item's name is exactly the inference that has cost this project before, so **an unclassified resource fails naming itself** rather than defaulting to Mineral. There is a test for that.

## One thing I could not resolve from the source

`ExtractorRate` scales the part's rate by the hotspot class strength, both read from the artifact. **The unit of that rate is not stated anywhere.** `U_EXTRACTOR_S` carries rate 100 against storage 360000, which fills in 3,600 of whatever unit the rate is denominated in — an hour, if the rate is per second.

The rollup is consistent either way, because `SiteConfig.FillSeconds` is supplied in the same unit and only the product `rate × window` matters. But **the plan's absolute times are only as right as that reading**, and it is a reading rather than a fact. Documented on the accessor; worth confirming in game before any duration is shown to a user.

The spec's scenario ("200 units per hour over 1.5 hours → 2 extractors") is reproduced with the identical ratio in integer inputs — rate 100 over a window of 3 — with the scaling explained in the test.

## Also

- The unassigned group produces no construction instructions: there is no site to build at. It stays visible in the `Grouping` so a caller can report it.
- A byproduct-covered item gets **no row of any kind** — not a zero-count row — and is reported under `NoBuild` carrying its full demand, so it is visible rather than dropped.
- `TestNoConstantIsHardcoded` varies crop yield, dome capacity, depot capacity and fauna yield independently and asserts each changes the answer.

`go vet`, `staticcheck v0.8.0-rc.1`, `gofmt -l` clean.

Closes #40
Part of #38

Implements SPEC-0001 REQ "Producer Rollup".

🤖 Generated with [Claude Code](https://claude.com/claude-code)