### PR TITLE
feat(domain): power generation, draw and the deficit fix

### DIFF
--- a/internal/domain/power.go
+++ b/internal/domain/power.go
@@ -144,13 +144,32 @@ func powerFor(base BaseID, c *Constants, in PowerInput) (PowerBudget, error) {
 		perEM:      new(big.Rat),
 	}
 
-	// Electromagnetic generation: a class multiplier on a base output, both
-	// read from the artifact's Power hotspot.
+	// Electromagnetic generation: the generator's own rate scaled by its
+	// hotspot's class strength.
+	//
+	// Governing: ADR-0001 — "A part declares a base Rate and a
+	// DependsOnHotspots category; the hotspot carries the class." Both
+	// factors are read, the same way Constants.ExtractorRate reads them for
+	// U_EXTRACTOR_S and the solar branch below reads U_SOLAR_S's rate.
+	//
+	// U_GENERATOR_S carries rate 1 in NMS 5.97, so dropping the factor would
+	// agree with this for every value the game currently ships — which is
+	// exactly why it is read rather than assumed. A rate of 1 that is
+	// multiplied in documents itself; a rate of 1 that is ignored is
+	// indistinguishable from a rate nobody checked.
 	if cfg.EMGenerators > 0 {
-		perEM, err := c.ClassStrength("Power", cfg.EMClass)
+		gen, err := c.Part(PartGenerator)
 		if err != nil {
 			return PowerBudget{}, fmt.Errorf("base %q: %w", base, err)
 		}
+		if gen.Primary.Rate <= 0 {
+			return PowerBudget{}, fmt.Errorf("%w: %s states no output", ErrInvalidArtifact, PartGenerator)
+		}
+		strength, err := c.ClassStrength("Power", cfg.EMClass)
+		if err != nil {
+			return PowerBudget{}, fmt.Errorf("base %q: %w", base, err)
+		}
+		perEM := new(big.Rat).Mul(new(big.Rat).SetInt64(gen.Primary.Rate), strength)
 		budget.perEM = perEM
 		budget.generation.Add(budget.generation,
 			new(big.Rat).Mul(perEM, new(big.Rat).SetInt64(cfg.EMGenerators)))

--- a/internal/domain/power.go
+++ b/internal/domain/power.go
@@ -1,0 +1,229 @@
+package domain
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+)
+
+// Stage 2's power half: what a base generates, what it draws, and what to
+// build when the second exceeds the first.
+//
+// Governing: SPEC-0001 REQ "Power Computation", REQ "Exact Arithmetic and
+// Rounding Discipline", REQ "Provenance Propagation"
+//
+// Draw is a pure function of what is built and what each part draws, so this
+// stage takes counts rather than producer rows. That keeps it independent of
+// the producer stage's row shapes — the same numbers whether they came from
+// a rollup or from a caller sketching a base by hand.
+
+// PowerUnit is a count of one buildable at a base.
+type PowerUnit struct {
+	PartID string
+	Count  int64
+}
+
+// PowerConfig is a base's generation setup.
+type PowerConfig struct {
+	// EMGenerators sit on a power hotspot and take its class; SolarPanels
+	// are classless and need batteries for the night.
+	//
+	// Governing: SPEC-0001 REQ "Power Computation" — "Generation MUST
+	// support two source types."
+	EMGenerators int64
+	EMClass      HotspotClass
+	SolarPanels  int64
+}
+
+// PowerBudget is one base's power position.
+type PowerBudget struct {
+	Base BaseID
+
+	// Batteries are required for solar night coverage, at the configured
+	// ratio, rounded up.
+	Batteries int64
+
+	// AdditionalGenerators is how many more electromagnetic generators at
+	// the base's class would clear a deficit — zero when there is none.
+	//
+	// Reported rather than left to the view so a deficit presents as an
+	// action rather than a warning.
+	// Governing: SPEC-0001 REQ "Power Computation" — Scenario "Deficit
+	// reports the fix".
+	AdditionalGenerators int64
+
+	// FixUnsized is true when the base is in deficit but no generator class
+	// is configured, so the fix has no size. The deficit is still reported
+	// — a base you cannot yet cost is not a base you should be unable to
+	// see.
+	FixUnsized bool
+
+	// Verified is false when any contributing figure is.
+	// Governing: SPEC-0001 REQ "Provenance Propagation".
+	Verified bool
+
+	generation *big.Rat
+	draw       *big.Rat
+	perEM      *big.Rat
+}
+
+// Generation is the base's total output, exact.
+func (b PowerBudget) Generation() *big.Rat { return new(big.Rat).Set(b.generation) }
+
+// Draw is the base's total consumption, exact and positive.
+func (b PowerBudget) Draw() *big.Rat { return new(big.Rat).Set(b.draw) }
+
+// Balance is generation minus draw: positive is surplus, negative deficit.
+func (b PowerBudget) Balance() *big.Rat { return new(big.Rat).Sub(b.generation, b.draw) }
+
+// Deficit is how much the base is short, or zero when it is not.
+func (b PowerBudget) Deficit() *big.Rat {
+	balance := b.Balance()
+	if balance.Sign() >= 0 {
+		return new(big.Rat)
+	}
+	return balance.Neg(balance)
+}
+
+// InDeficit reports whether draw exceeds generation.
+func (b PowerBudget) InDeficit() bool { return b.Balance().Sign() < 0 }
+
+// PerGenerator is one electromagnetic generator's output at the base's class.
+func (b PowerBudget) PerGenerator() *big.Rat { return new(big.Rat).Set(b.perEM) }
+
+// PowerInput is the power stage's per-base input.
+type PowerInput struct {
+	// Config is each base's generation setup.
+	Config map[BaseID]PowerConfig
+
+	// Draws are the buildables at each base that consume power, as counts
+	// by part ID. Each part's draw comes from the artifact.
+	Draws map[BaseID][]PowerUnit
+
+	// Unverified marks bases whose contributing figures are not verified,
+	// so the budget carries the taint forward.
+	Unverified map[BaseID]bool
+}
+
+// ComputePower produces each base's power budget.
+//
+// Governing: SPEC-0001 REQ "Power Computation"
+func ComputePower(c *Constants, in PowerInput) ([]PowerBudget, error) {
+	if c == nil {
+		return nil, fmt.Errorf("%w: power computation needs constants", ErrInvalidArtifact)
+	}
+
+	bases := map[BaseID]bool{}
+	for base := range in.Config {
+		bases[base] = true
+	}
+	for base := range in.Draws {
+		bases[base] = true
+	}
+
+	out := make([]PowerBudget, 0, len(bases))
+	for base := range bases {
+		budget, err := powerFor(base, c, in)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, budget)
+	}
+	// Governing: SPEC-0001 REQ "Determinism".
+	sort.Slice(out, func(i, j int) bool { return out[i].Base < out[j].Base })
+	return out, nil
+}
+
+func powerFor(base BaseID, c *Constants, in PowerInput) (PowerBudget, error) {
+	cfg := in.Config[base]
+	budget := PowerBudget{
+		Base:       base,
+		Verified:   !in.Unverified[base],
+		generation: new(big.Rat),
+		draw:       new(big.Rat),
+		perEM:      new(big.Rat),
+	}
+
+	// Electromagnetic generation: a class multiplier on a base output, both
+	// read from the artifact's Power hotspot.
+	if cfg.EMGenerators > 0 {
+		perEM, err := c.ClassStrength("Power", cfg.EMClass)
+		if err != nil {
+			return PowerBudget{}, fmt.Errorf("base %q: %w", base, err)
+		}
+		budget.perEM = perEM
+		budget.generation.Add(budget.generation,
+			new(big.Rat).Mul(perEM, new(big.Rat).SetInt64(cfg.EMGenerators)))
+	}
+
+	// Solar is classless, and needs batteries to cover the night.
+	if cfg.SolarPanels > 0 {
+		panel, err := c.Part(PartSolar)
+		if err != nil {
+			return PowerBudget{}, fmt.Errorf("base %q: %w", base, err)
+		}
+		if panel.Primary.Rate <= 0 {
+			return PowerBudget{}, fmt.Errorf("%w: %s states no output", ErrInvalidArtifact, PartSolar)
+		}
+		budget.generation.Add(budget.generation,
+			new(big.Rat).Mul(new(big.Rat).SetInt64(panel.Primary.Rate), new(big.Rat).SetInt64(cfg.SolarPanels)))
+
+		perBattery := c.Curated().PanelsPerBattery
+		if perBattery <= 0 {
+			return PowerBudget{}, fmt.Errorf("%w: panels per battery is %d; it must be supplied",
+				ErrInvalidArtifact, perBattery)
+		}
+		budget.Batteries = ceilRat(big.NewRat(cfg.SolarPanels, perBattery))
+	}
+
+	// Draw: every part's power dependency, times how many are built.
+	//
+	// A part's own primary rate counts too when it is negative on the power
+	// network — a biodome consumes directly rather than through a
+	// dependency, and reading only dependencies would miss it.
+	for _, unit := range in.Draws[base] {
+		if unit.Count <= 0 {
+			continue
+		}
+		part, err := c.Part(unit.PartID)
+		if err != nil {
+			return PowerBudget{}, fmt.Errorf("base %q: %w", base, err)
+		}
+		per := new(big.Rat)
+		if part.Primary.Network == NetworkPower && part.Primary.Rate < 0 {
+			per.Add(per, new(big.Rat).SetInt64(-part.Primary.Rate))
+		}
+		for _, dep := range part.Dependencies {
+			if dep.Network == NetworkPower && dep.Rate < 0 {
+				per.Add(per, new(big.Rat).SetInt64(-dep.Rate))
+			}
+		}
+		budget.draw.Add(budget.draw, new(big.Rat).Mul(per, new(big.Rat).SetInt64(unit.Count)))
+	}
+
+	// The fix, when there is a deficit: how many more generators at this
+	// base's class would clear it.
+	if budget.InDeficit() {
+		perEM := budget.perEM
+		if perEM.Sign() <= 0 {
+			// No generators built yet, so size the fix against the class
+			// the caller configured — what building the first one there
+			// would produce.
+			if !cfg.EMClass.Valid() {
+				// No class either. The deficit is real and reportable; the
+				// fix simply has no size until a class is chosen, and
+				// saying so beats refusing to compute the base at all.
+				budget.FixUnsized = true
+				return budget, nil
+			}
+			resolved, err := c.ClassStrength("Power", cfg.EMClass)
+			if err != nil {
+				return PowerBudget{}, fmt.Errorf("base %q: %w", base, err)
+			}
+			perEM = resolved
+			budget.perEM = resolved
+		}
+		budget.AdditionalGenerators = ceilRat(new(big.Rat).Quo(budget.Deficit(), perEM))
+	}
+	return budget, nil
+}

--- a/internal/domain/power_test.go
+++ b/internal/domain/power_test.go
@@ -1,0 +1,337 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+// A synthetic economy whose Power hotspot strengths are the scenario's
+// numbers: a class-B base output of 110 kPs and a class-A multiplier of 1.5
+// is a class-A output of 165.
+//
+// The artifact states absolute per-class outputs rather than a base and a
+// multiplier, which is the same model expressed once instead of twice.
+const powerEconomy = `{
+  "parts":[
+    {"id":"U_SOLAR_S","primary":{"network":"power","rate":50}},
+    {"id":"U_BATTERY_S","primary":{"network":"power","rate":0,"storage":45000}},
+    {"id":"U_GENERATOR_S","primary":{"network":"power","rate":1},"hotspot":"Power"},
+    {"id":"U_EXTRACTOR_S","primary":{"network":"resources","rate":100,"storage":360000},
+     "dependencies":[{"network":"power","rate":-55,"effect":"EnablesRate"}],"hotspot":"Mineral"},
+    {"id":"BIOROOM","primary":{"network":"power","rate":-20}},
+    {"id":"U_SILO_S","primary":{"network":"resources","rate":0,"storage":1000}}
+  ],
+  "hotspots":[
+    {"category":"Power","strengths":{"c":55,"b":110,"a":165,"s":220},"weightings":{"c":1,"b":1,"a":1,"s":1}},
+    {"category":"Mineral","strengths":{"c":1,"b":1.5,"a":2,"s":2.5},"weightings":{"c":1,"b":1,"a":1,"s":1}}
+  ]
+}`
+
+func powerConstants(t *testing.T) *Constants {
+	t.Helper()
+	src := `{"schema_version":2,"game_version":"test-power",
+	  "items":[{"id":"x","name":"X","raw_obtainable":true,"default_method":"raw"}],
+	  "recipes":[],"economy":` + powerEconomy + `}`
+	a1, err := LoadTier1(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("loading artifact: %v", err)
+	}
+	c, err := NewConstants(a1, Curated{
+		BiodomeCropSlots: 16, FaunaYieldPerCycle: 12, FaunaCycleSeconds: 1800,
+		StepsPerProcessor: 2, DepotThreshold: 1000, PanelsPerBattery: 2,
+	})
+	if err != nil {
+		t.Fatalf("NewConstants: %v", err)
+	}
+	return c
+}
+
+func budgetFor(t *testing.T, c *Constants, in PowerInput, base BaseID) PowerBudget {
+	t.Helper()
+	budgets, err := ComputePower(c, in)
+	if err != nil {
+		t.Fatalf("ComputePower: %v", err)
+	}
+	for _, b := range budgets {
+		if b.Base == base {
+			return b
+		}
+	}
+	t.Fatalf("base %q missing from %d budgets", base, len(budgets))
+	return PowerBudget{}
+}
+
+// SPEC-0001 REQ "Power Computation":
+// WHEN a base has 3 electromagnetic generators at class A, with a class-B
+// base output of 110 kPs and a class-A multiplier of 1.5
+// THEN the engine reports 495 kPs of generation.
+func TestEMGenerationByClass(t *testing.T) {
+	c := powerConstants(t)
+
+	b := budgetFor(t, c, PowerInput{
+		Config: map[BaseID]PowerConfig{"alpha": {EMGenerators: 3, EMClass: ClassA}},
+	}, "alpha")
+
+	if got := b.Generation().RatString(); got != "495" {
+		t.Errorf("generation = %s, want 495 (3 x 165)", got)
+	}
+	if got := b.PerGenerator().RatString(); got != "165" {
+		t.Errorf("per generator = %s, want 165", got)
+	}
+
+	// The class is what moves it: the same three generators at B produce
+	// 330, which is the other scenario's starting position.
+	atB := budgetFor(t, c, PowerInput{
+		Config: map[BaseID]PowerConfig{"alpha": {EMGenerators: 3, EMClass: ClassB}},
+	}, "alpha")
+	if got := atB.Generation().RatString(); got != "330" {
+		t.Errorf("generation at B = %s, want 330", got)
+	}
+}
+
+// SPEC-0001 REQ "Power Computation":
+// WHEN a base is powered by 5 solar panels at a ratio of 1 battery per 2
+// panels THEN the engine reports 3 batteries as required.
+func TestSolarRequiresBatteries(t *testing.T) {
+	c := powerConstants(t)
+
+	b := budgetFor(t, c, PowerInput{
+		Config: map[BaseID]PowerConfig{"alpha": {SolarPanels: 5}},
+	}, "alpha")
+
+	if b.Batteries != 3 {
+		t.Errorf("batteries = %d, want 3 (ceil(5/2))", b.Batteries)
+	}
+	// Solar is classless: the panel's own rate is the output, with no
+	// hotspot strength applied.
+	if got := b.Generation().RatString(); got != "250" {
+		t.Errorf("generation = %s, want 250 (5 x 50)", got)
+	}
+	// And a base with no panels needs no batteries.
+	none := budgetFor(t, c, PowerInput{
+		Config: map[BaseID]PowerConfig{"beta": {EMGenerators: 1, EMClass: ClassB}},
+	}, "beta")
+	if none.Batteries != 0 {
+		t.Errorf("a base with no panels reports %d batteries", none.Batteries)
+	}
+}
+
+// SPEC-0001 REQ "Power Computation":
+// WHEN a base draws 400 kPs against 330 kPs of generation from class-B
+// generators producing 110 each THEN a deficit of 70 kPs and 1 additional
+// generator clears it.
+func TestDeficitReportsTheFix(t *testing.T) {
+	c := powerConstants(t)
+
+	// Draw of 400: 4 extractors at 55 plus 9 biodomes at 20 is 220 + 180.
+	b := budgetFor(t, c, PowerInput{
+		Config: map[BaseID]PowerConfig{"alpha": {EMGenerators: 3, EMClass: ClassB}},
+		Draws: map[BaseID][]PowerUnit{"alpha": {
+			{PartID: "U_EXTRACTOR_S", Count: 4},
+			{PartID: "BIOROOM", Count: 9},
+		}},
+	}, "alpha")
+
+	if got := b.Draw().RatString(); got != "400" {
+		t.Fatalf("draw = %s, want 400", got)
+	}
+	if got := b.Generation().RatString(); got != "330" {
+		t.Fatalf("generation = %s, want 330", got)
+	}
+	if !b.InDeficit() {
+		t.Fatal("the base is not reported as in deficit")
+	}
+	if got := b.Deficit().RatString(); got != "70" {
+		t.Errorf("deficit = %s, want 70", got)
+	}
+	if b.AdditionalGenerators != 1 {
+		t.Errorf("additional generators = %d, want 1 (ceil(70/110))", b.AdditionalGenerators)
+	}
+
+	// A surplus reports no fix and no deficit.
+	surplus := budgetFor(t, c, PowerInput{
+		Config: map[BaseID]PowerConfig{"alpha": {EMGenerators: 4, EMClass: ClassB}},
+		Draws:  map[BaseID][]PowerUnit{"alpha": {{PartID: "U_EXTRACTOR_S", Count: 4}}},
+	}, "alpha")
+	if surplus.InDeficit() {
+		t.Errorf("a base at %s generation and %s draw reports a deficit",
+			surplus.Generation().RatString(), surplus.Draw().RatString())
+	}
+	if surplus.AdditionalGenerators != 0 {
+		t.Errorf("a base at surplus asks for %d more generators", surplus.AdditionalGenerators)
+	}
+	if got := surplus.Balance().RatString(); got != "220" {
+		t.Errorf("balance = %s, want 220", got)
+	}
+}
+
+// SPEC-0001 REQ "Power Computation":
+// WHEN a base at surplus has its generator class downgraded such that
+// generation falls below draw THEN a deficit and the required additional
+// unit count.
+func TestDowngradeReopensADeficit(t *testing.T) {
+	c := powerConstants(t)
+
+	draws := map[BaseID][]PowerUnit{"alpha": {{PartID: "U_EXTRACTOR_S", Count: 6}}} // 330
+
+	atA := budgetFor(t, c, PowerInput{
+		Config: map[BaseID]PowerConfig{"alpha": {EMGenerators: 3, EMClass: ClassA}},
+		Draws:  draws,
+	}, "alpha")
+	if atA.InDeficit() {
+		t.Fatalf("class A should cover it: generation %s against draw %s",
+			atA.Generation().RatString(), atA.Draw().RatString())
+	}
+
+	// Downgrade A → C: 3 x 55 = 165 against a draw of 330.
+	atC := budgetFor(t, c, PowerInput{
+		Config: map[BaseID]PowerConfig{"alpha": {EMGenerators: 3, EMClass: ClassC}},
+		Draws:  draws,
+	}, "alpha")
+	if !atC.InDeficit() {
+		t.Fatal("the downgrade did not reopen the deficit")
+	}
+	if got := atC.Deficit().RatString(); got != "165" {
+		t.Errorf("deficit = %s, want 165", got)
+	}
+	if atC.AdditionalGenerators != 3 {
+		t.Errorf("additional generators = %d, want 3 (ceil(165/55))", atC.AdditionalGenerators)
+	}
+}
+
+// Draw reads each part's power cost from the artifact — both a direct
+// negative rate on the power network and a negative power dependency.
+//
+// A part like the biodome consumes directly rather than through a
+// dependency, so reading only dependencies would report it as free.
+func TestDrawReadsBothDirectAndDependentCosts(t *testing.T) {
+	c := powerConstants(t)
+
+	direct := budgetFor(t, c, PowerInput{
+		Draws: map[BaseID][]PowerUnit{"alpha": {{PartID: "BIOROOM", Count: 3}}},
+	}, "alpha")
+	if got := direct.Draw().RatString(); got != "60" {
+		t.Errorf("biodome draw = %s, want 60 (3 x 20, a direct negative rate)", got)
+	}
+
+	dependent := budgetFor(t, c, PowerInput{
+		Draws: map[BaseID][]PowerUnit{"alpha": {{PartID: "U_EXTRACTOR_S", Count: 2}}},
+	}, "alpha")
+	if got := dependent.Draw().RatString(); got != "110" {
+		t.Errorf("extractor draw = %s, want 110 (2 x 55, a power dependency)", got)
+	}
+
+	// A base with draw and no generation configured is still reportable:
+	// the deficit is real, and only the fix has no size.
+	if !direct.InDeficit() {
+		t.Error("a base with draw and no generation is not reported as in deficit")
+	}
+	if !direct.FixUnsized {
+		t.Error("the fix was sized despite no generator class being configured")
+	}
+	if direct.AdditionalGenerators != 0 {
+		t.Errorf("additional generators = %d with no class configured", direct.AdditionalGenerators)
+	}
+
+	// A part that neither draws nor generates contributes nothing.
+	free := budgetFor(t, c, PowerInput{
+		Draws: map[BaseID][]PowerUnit{"alpha": {{PartID: "U_SILO_S", Count: 10}}},
+	}, "alpha")
+	if got := free.Draw().RatString(); got != "0" {
+		t.Errorf("silo draw = %s, want 0", got)
+	}
+}
+
+// SPEC-0001 REQ "Provenance Propagation" — a budget derived from anything
+// unverified is marked unverified.
+func TestPowerCarriesProvenance(t *testing.T) {
+	c := powerConstants(t)
+
+	in := PowerInput{
+		Config:     map[BaseID]PowerConfig{"alpha": {EMGenerators: 1, EMClass: ClassB}, "beta": {EMGenerators: 1, EMClass: ClassB}},
+		Unverified: map[BaseID]bool{"beta": true},
+	}
+	if b := budgetFor(t, c, in, "alpha"); !b.Verified {
+		t.Error("alpha is marked unverified but nothing contributing to it is")
+	}
+	if b := budgetFor(t, c, in, "beta"); b.Verified {
+		t.Error("beta is marked verified despite an unverified contributor")
+	}
+}
+
+// SPEC-0001 REQ "Determinism" — repeated computation is stable, and bases
+// come back in a defined order.
+func TestPowerComputationIsDeterministic(t *testing.T) {
+	c := powerConstants(t)
+	in := PowerInput{
+		Config: map[BaseID]PowerConfig{
+			"gamma": {EMGenerators: 1, EMClass: ClassB},
+			"alpha": {SolarPanels: 4},
+			"beta":  {EMGenerators: 2, EMClass: ClassS},
+		},
+		Draws: map[BaseID][]PowerUnit{
+			"alpha": {{PartID: "BIOROOM", Count: 2}},
+			"beta":  {{PartID: "U_EXTRACTOR_S", Count: 1}},
+		},
+	}
+
+	first, err := ComputePower(c, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 3 {
+		t.Fatalf("budgets = %d, want 3", len(first))
+	}
+	for i := 1; i < len(first); i++ {
+		if first[i-1].Base >= first[i].Base {
+			t.Errorf("budgets are not sorted by base: %v then %v", first[i-1].Base, first[i].Base)
+		}
+	}
+	for run := 0; run < 25; run++ {
+		got, err := ComputePower(c, in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range got {
+			if got[i].Base != first[i].Base ||
+				got[i].Generation().Cmp(first[i].Generation()) != 0 ||
+				got[i].Draw().Cmp(first[i].Draw()) != 0 {
+				t.Fatalf("run %d differs at index %d", run+2, i)
+			}
+		}
+	}
+}
+
+// A deficit at a base with no generators still reports a fix, sized against
+// the class the caller configured — which is what building the first
+// generator there would produce.
+func TestDeficitWithNoGeneratorsStillSizesTheFix(t *testing.T) {
+	c := powerConstants(t)
+
+	b := budgetFor(t, c, PowerInput{
+		Config: map[BaseID]PowerConfig{"alpha": {EMClass: ClassB}},
+		Draws:  map[BaseID][]PowerUnit{"alpha": {{PartID: "U_EXTRACTOR_S", Count: 4}}},
+	}, "alpha")
+
+	if got := b.Deficit().RatString(); got != "220" {
+		t.Fatalf("deficit = %s, want 220", got)
+	}
+	if b.AdditionalGenerators != 2 {
+		t.Errorf("additional generators = %d, want 2 (ceil(220/110))", b.AdditionalGenerators)
+	}
+}
+
+// An unknown part fails naming itself rather than counting as free.
+func TestUnknownPartIsRefused(t *testing.T) {
+	c := powerConstants(t)
+
+	_, err := ComputePower(c, PowerInput{
+		Draws: map[BaseID][]PowerUnit{"alpha": {{PartID: "U_NOT_A_PART", Count: 1}}},
+	})
+	if err == nil {
+		t.Fatal("an unknown part was counted as drawing nothing")
+	}
+	if !strings.Contains(err.Error(), "U_NOT_A_PART") || !strings.Contains(err.Error(), "alpha") {
+		t.Errorf("error %q does not name the part and the base", err)
+	}
+}

--- a/internal/domain/power_test.go
+++ b/internal/domain/power_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -334,4 +335,95 @@ func TestUnknownPartIsRefused(t *testing.T) {
 	if !strings.Contains(err.Error(), "U_NOT_A_PART") || !strings.Contains(err.Error(), "alpha") {
 		t.Errorf("error %q does not name the part and the base", err)
 	}
+}
+
+// Governing: ADR-0001 — "A part declares a base Rate and a DependsOnHotspots
+// category; the hotspot carries the class."
+//
+// Both factors have to be read. U_GENERATOR_S carries rate 1 in NMS 5.97, so
+// generation computed from the class strength alone agrees with the correct
+// model for every value the game currently ships — the factor is invisible
+// until the rate is not 1. Constants.ExtractorRate reads the same pair for
+// U_EXTRACTOR_S, and the solar branch reads U_SOLAR_S's rate, so a generator
+// ignoring its own rate would be the one place in the engine reading this
+// table a different way.
+//
+// This fixture gives the generator rate 3 precisely so the factor cannot hide.
+func TestGeneratorRateScalesGeneration(t *testing.T) {
+	const econ = `{
+  "parts":[
+    {"id":"U_GENERATOR_S","primary":{"network":"power","rate":3},"hotspot":"Power"},
+    {"id":"U_SOLAR_S","primary":{"network":"power","rate":50}},
+    {"id":"U_BATTERY_S","primary":{"network":"power","rate":0,"storage":45000}},
+    {"id":"BIOROOM","primary":{"network":"power","rate":-20}}
+  ],
+  "hotspots":[
+    {"category":"Power","strengths":{"c":55,"b":110,"a":165,"s":220},"weightings":{"c":1,"b":1,"a":1,"s":1}}
+  ]
+}`
+	c := constantsFrom(t, econ, "test-power-rate")
+
+	// Class B strength 110, generator rate 3, two generators.
+	//   reading both factors: 3 * 110 * 2 = 660
+	//   dropping the rate:        110 * 2 = 220
+	b := budgetFor(t, c, PowerInput{
+		Config: map[BaseID]PowerConfig{"alpha": {EMGenerators: 2, EMClass: ClassB}},
+	}, "alpha")
+
+	if got := b.Generation().RatString(); got != "660" {
+		t.Errorf("generation = %s, want 660 — the generator's own rate is not being read", got)
+	}
+	if got := b.PerGenerator().RatString(); got != "330" {
+		t.Errorf("per generator = %s, want 330 (rate 3 x strength 110)", got)
+	}
+}
+
+// A generator stating no output is refused rather than silently treated as
+// free — the same standard the solar branch already applies to U_SOLAR_S.
+func TestGeneratorWithNoStatedOutputIsRefused(t *testing.T) {
+	const econ = `{
+  "parts":[
+    {"id":"U_GENERATOR_S","primary":{"network":"power","rate":0},"hotspot":"Power"},
+    {"id":"U_SOLAR_S","primary":{"network":"power","rate":50}},
+    {"id":"U_BATTERY_S","primary":{"network":"power","rate":0,"storage":45000}}
+  ],
+  "hotspots":[
+    {"category":"Power","strengths":{"c":55,"b":110,"a":165,"s":220},"weightings":{"c":1,"b":1,"a":1,"s":1}}
+  ]
+}`
+	c := constantsFrom(t, econ, "test-power-zero")
+
+	_, err := ComputePower(c, PowerInput{
+		Config: map[BaseID]PowerConfig{"alpha": {EMGenerators: 1, EMClass: ClassB}},
+	})
+	if err == nil {
+		t.Fatal("Power accepted a generator stating no output")
+	}
+	if !errors.Is(err, ErrInvalidArtifact) {
+		t.Errorf("error is %v, want ErrInvalidArtifact", err)
+	}
+	if !strings.Contains(err.Error(), PartGenerator) {
+		t.Errorf("error %q does not name the part at fault", err)
+	}
+}
+
+// constantsFrom builds Constants from an economy fragment, so a test can vary
+// the artifact rather than the plan.
+func constantsFrom(t *testing.T, economy, version string) *Constants {
+	t.Helper()
+	src := `{"schema_version":2,"game_version":"` + version + `",
+	  "items":[{"id":"x","name":"X","raw_obtainable":true,"default_method":"raw"}],
+	  "recipes":[],"economy":` + economy + `}`
+	a1, err := LoadTier1(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("LoadTier1: %v", err)
+	}
+	c, err := NewConstants(a1, Curated{
+		BiodomeCropSlots: 16, FaunaYieldPerCycle: 12, FaunaCycleSeconds: 1800,
+		StepsPerProcessor: 2, DepotThreshold: 1000, PanelsPerBattery: 2,
+	})
+	if err != nil {
+		t.Fatalf("NewConstants: %v", err)
+	}
+	return c
 }

--- a/internal/domain/power_test.go
+++ b/internal/domain/power_test.go
@@ -40,6 +40,12 @@ func powerConstants(t *testing.T) *Constants {
 	c, err := NewConstants(a1, Curated{
 		BiodomeCropSlots: 16, FaunaYieldPerCycle: 12, FaunaCycleSeconds: 1800,
 		StepsPerProcessor: 2, DepotThreshold: 1000, PanelsPerBattery: 2,
+		// Required since #40 landed: Curated refuses a partially-specified
+		// set, so the power tests must supply the producer stage's constants
+		// even though they never read them.
+		ProcessSeconds:   30,
+		FaunaProducts:    map[string]bool{},
+		ResourceHotspots: map[string]string{},
 	})
 	if err != nil {
 		t.Fatalf("NewConstants: %v", err)
@@ -421,6 +427,12 @@ func constantsFrom(t *testing.T, economy, version string) *Constants {
 	c, err := NewConstants(a1, Curated{
 		BiodomeCropSlots: 16, FaunaYieldPerCycle: 12, FaunaCycleSeconds: 1800,
 		StepsPerProcessor: 2, DepotThreshold: 1000, PanelsPerBattery: 2,
+		// Required since #40 landed: Curated refuses a partially-specified
+		// set, so the power tests must supply the producer stage's constants
+		// even though they never read them.
+		ProcessSeconds:   30,
+		FaunaProducts:    map[string]bool{},
+		ResourceHotspots: map[string]string{},
 	})
 	if err != nil {
 		t.Fatalf("NewConstants: %v", err)

--- a/internal/domain/producer.go
+++ b/internal/domain/producer.go
@@ -487,6 +487,12 @@ func sortRows(b *BaseBuild) {
 //
 // Integer division on the numerator and denominator, so no float is
 // involved at the one place the engine is allowed to lose precision.
+//
+// Shared with the power stage: plants, biodomes, extractors, supply depots,
+// fauna and nutrient processors are this stage's boundaries, and generators
+// and batteries are stage 3's. One ceiling rule, one implementation — the
+// two stages arrived at an identical helper independently, which is the
+// argument for there being only one.
 func ceilRat(r *big.Rat) int64 {
 	q, m := new(big.Int).QuoRem(r.Num(), r.Denom(), new(big.Int))
 	if m.Sign() > 0 {

--- a/internal/domain/producer_test.go
+++ b/internal/domain/producer_test.go
@@ -87,6 +87,9 @@ func baseCurated() Curated {
 	return Curated{
 		BiodomeCropSlots: 16, FaunaYieldPerCycle: 12, FaunaCycleSeconds: 1800,
 		StepsPerProcessor: 2, DepotThreshold: 1000, ProcessSeconds: 30,
+		// Required since #41 landed: the producer tests never read it, but
+		// Curated refuses a partially-specified set.
+		PanelsPerBattery: 2,
 		FaunaProducts:    map[string]bool{"milk": true, "egg": true},
 		ResourceHotspots: map[string]string{"gas_a": "Gas", "gas_b": "Gas"},
 	}

--- a/internal/domain/rollup.go
+++ b/internal/domain/rollup.go
@@ -110,6 +110,16 @@ type Curated struct {
 	// supply depots. Also a planner policy — the game does not have an
 	// opinion about when hoarding starts.
 	//
+	// PanelsPerBattery is how many solar panels one battery covers for the
+	// night. A planner ratio rather than a game constant: the battery's
+	// capacity is in the artifact, but how much darkness to plan for is a
+	// choice.
+	//
+	// Governing: SPEC-0001 REQ "Power Computation" — "Solar panels MUST be
+	// classless and MUST additionally require batteries at a configured
+	// ratio for night coverage."
+	PanelsPerBattery int64
+
 	// Depot *capacity* is not here: it is U_SILO_S's storage buffer, which
 	// the artifact carries. See Constants.DepotCapacity.
 	DepotThreshold int64
@@ -145,6 +155,7 @@ func (c Curated) validate() error {
 		{"steps per processor", c.StepsPerProcessor},
 		{"depot threshold", c.DepotThreshold},
 		{"process seconds", c.ProcessSeconds},
+		{"panels per battery", c.PanelsPerBattery},
 	} {
 		if f.v <= 0 {
 			return fmt.Errorf("%w: curated constant %q is %d; it must be supplied, not defaulted",

--- a/internal/domain/rollup_test.go
+++ b/internal/domain/rollup_test.go
@@ -39,6 +39,7 @@ func curatedForTest() Curated {
 		ProcessSeconds:     30,
 		FaunaProducts:      map[string]bool{},
 		ResourceHotspots:   map[string]string{},
+		PanelsPerBattery:   2,
 	}
 }
 
@@ -375,6 +376,7 @@ func TestCuratedConstantsMustBeSupplied(t *testing.T) {
 		"steps per processor":   func(c *Curated) { c.StepsPerProcessor = 0 },
 		"depot threshold":       func(c *Curated) { c.DepotThreshold = 0 },
 		"process seconds":       func(c *Curated) { c.ProcessSeconds = 0 },
+		"panels per battery":    func(c *Curated) { c.PanelsPerBattery = 0 },
 	}
 	for name, clear := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## What

Implements #41. Each base's generation, draw, and the resulting surplus or deficit. All four Power Computation scenarios have a named test.

## Two generation source types

**Electromagnetic** generators take the Power hotspot's class strength. The spec states EM output as a class-B base times a class multiplier; the artifact states absolute per-class outputs, which is the same model expressed once instead of twice. The scenario's "class-B base of 110 with a class-A multiplier of 1.5" is a class-A strength of 165, and 3 generators is 495 — asserted directly.

**Solar** is classless: the panel's own rate, plus `ceil(panels / panelsPerBattery)` batteries for night coverage. `PanelsPerBattery` joins the curated set — the battery's *capacity* is in the artifact, but how much darkness to plan for is a choice.

## Draw reads both shapes

A part can cost power two ways, and the tests cover each:

- **Directly** — `BIOROOM` has `primary.rate` −20 on the power network
- **Through a dependency** — `U_EXTRACTOR_S` has a `-55` power dependency

Reading only dependencies would report every biodome as free. A part that does neither (a silo) contributes zero.

Draw is a pure function of counts and part costs, so this stage takes **counts** rather than producer rows — which is what keeps it independent of #40, as the issue said it should be.

## A design flaw the tests found

A base with draw and **no generation configured at all** used to fail the whole computation: it hit the deficit branch, found no generator class to size the fix against, and returned an error.

That is the wrong trade. A base you cannot yet cost is not a base you should be unable to *see*. The deficit is now reported with `FixUnsized` set and the count left at zero, so the view can show "you are 60 short" before the user has picked a hotspot class.

## Merge-order note — the two stories are not quite independent

The issue said #40 and #41 could proceed in parallel, and functionally they did. But **both need `ceilRat`**, and I could not import #40's copy from an unmerged branch.

This PR defines it in `power.go`; #52 defines an identical helper in `producer.go`. **Whichever lands second should drop its copy rather than rename it** — one ceiling rule, one implementation. The note is in the code as well as here.

Both PRs also touch `internal/domain/rollup.go` to extend `Curated` (this one adds `PanelsPerBattery`, #52 adds four classification constants), so they are **Tier 1 rather than Tier 0** — the second to merge needs a rebase.

Suggested order: **#52 first** (larger, more constants), then rebase this one and drop the duplicate helper.

## Tests

- EM generation by class, plus the same generators at B to show the class is what moves it
- 5 panels → 3 batteries, classless output, and a base with no panels needing none
- Deficit of 70 against 330 generation → exactly 1 more generator, plus a surplus case reporting no fix
- Downgrade A → C reopens the deficit at 165 and asks for 3
- Direct vs dependent draw, and a part that draws nothing
- Provenance taint per base; determinism over 25 runs with sorted output
- An unknown part fails naming both the part and the base rather than counting as free

`go vet`, `staticcheck v0.8.0-rc.1`, `gofmt -l` clean.

Closes #41
Part of #38

Implements SPEC-0001 REQ "Power Computation".

🤖 Generated with [Claude Code](https://claude.com/claude-code)