### PR TITLE
feat(bridge): module lifecycle, boundary surface, and mechanical purity

### DIFF
--- a/cmd/planner/main.go
+++ b/cmd/planner/main.go
@@ -1,0 +1,61 @@
+//go:build js && wasm
+
+// Command planner is the WASM entry point: the only place in the tree that
+// touches syscall/js.
+//
+// Governing: ADR-0003 (Go domain, thin adapter), SPEC-0002 REQ "Boundary
+// Surface", REQ "Module Lifecycle and Readiness", REQ "Event Loop Safety"
+//
+// It does one thing: hand strings between JavaScript and bridge.Module. Every
+// decision about what the entry points are, when they are callable, and what
+// comes back lives in internal/bridge, which builds and tests without WASM.
+// This file is deliberately too small to hide a bug in.
+package main
+
+import (
+	"syscall/js"
+
+	"github.com/jonstump/nms-base-planner/internal/bridge"
+)
+
+func main() {
+	module := bridge.NewModule()
+
+	// One namespace object carrying the stage entry points. No domain
+	// function is reachable from the global scope: the only exported names
+	// are these, and each returns a complete envelope.
+	//
+	// Governing: SPEC-0002 REQ "Boundary Surface".
+	namespace := js.Global().Get("Object").New()
+	for _, name := range bridge.EntryPoints {
+		namespace.Set(name, entryPoint(module, name))
+	}
+	namespace.Set("contractVersion", bridge.ContractVersion)
+	js.Global().Set(bridge.Namespace, namespace)
+
+	// Park forever. Returning from main tears the Go runtime down and every
+	// registered function with it.
+	//
+	// This is the only blocking construct in the module, and it is outside
+	// every entry point: the calls themselves are synchronous and
+	// straight-line, so nothing can deadlock against the event loop by
+	// waiting on it from inside a call.
+	// Governing: SPEC-0002 REQ "Event Loop Safety".
+	select {}
+}
+
+// entryPoint wraps one named call.
+//
+// Synchronous and straight-line by construction: it reads one string
+// argument, dispatches, and returns one string. No goroutine, no channel, no
+// callback into JavaScript — so a call can neither block the event loop
+// waiting for JavaScript nor deadlock against the Go scheduler.
+func entryPoint(module *bridge.Module, name string) js.Func {
+	return js.FuncOf(func(_ js.Value, args []js.Value) any {
+		var arg string
+		if len(args) > 0 && args[0].Type() == js.TypeString {
+			arg = args[0].String()
+		}
+		return module.CallJSON(name, arg)
+	})
+}

--- a/internal/bridge/module.go
+++ b/internal/bridge/module.go
@@ -1,0 +1,186 @@
+package bridge
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/jonstump/nms-base-planner/internal/domain"
+)
+
+// The module's surface and lifecycle, in a form that needs no WASM build.
+//
+// Governing: ADR-0003 (Go domain, thin adapter), SPEC-0002 REQ "Boundary
+// Surface", REQ "Module Lifecycle and Readiness", REQ "Event Loop Safety"
+//
+// Everything the boundary decides lives here: what the entry points are,
+// when they are callable, and what comes back. The syscall/js shim in
+// cmd/planner does nothing but hand strings across, so the interesting
+// behaviour is testable under plain go test and the js half stays too small
+// to hide a bug in.
+
+// Module is the boundary's stateful half: it holds the loaded artifact and
+// gates the entry points on it.
+//
+// Instantiation and artifact loading are distinct steps, per SPEC-0002 REQ
+// "Module Lifecycle and Readiness" — a module that exists but has no data is
+// a different failure from a module that failed to load, and conflating them
+// sends a user to the wrong place.
+type Module struct {
+	mu       sync.RWMutex
+	artifact *domain.Tier1
+}
+
+// NewModule creates an unloaded module. It is not ready until Load succeeds.
+func NewModule() *Module { return &Module{} }
+
+// Ready reports whether an artifact has been loaded.
+func (m *Module) Ready() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.artifact != nil
+}
+
+// Load validates a Tier 1 artifact and makes the module ready.
+//
+// A validation failure is reported as an invalid artifact rather than as a
+// module load failure: the module instantiated fine, and the data is what is
+// wrong.
+//
+// Governing: SPEC-0002 REQ "Module Lifecycle and Readiness" — Scenario "A
+// bad artifact is not a module failure".
+func (m *Module) Load(artifactJSON string) Envelope {
+	a1, err := domain.LoadTier1(strings.NewReader(artifactJSON))
+	if err != nil {
+		// Classified as an artifact problem by *context*, not by whichever
+		// sentinel the error happens to wrap first.
+		//
+		// The domain double-wraps some validation failures — a recipe
+		// naming an item no table defines is both ErrInvalidArtifact and
+		// ErrUnknownItem — and CodeFor would return the more specific one.
+		// That is right when a *plan* names a missing item, which is the
+		// caller's problem. It is wrong here: anything that fails while
+		// loading our own artifact is our data being inconsistent, and a
+		// view told UNKNOWN_ITEM would send the user looking at their plan.
+		//
+		// Governing: SPEC-0002 REQ "Module Lifecycle and Readiness" — "the
+		// failure is reported as an invalid-artifact error".
+		return Failure(CodeInvalidArtifact, err.Error())
+	}
+	m.mu.Lock()
+	m.artifact = a1
+	m.mu.Unlock()
+	return Success(ResultPayload{})
+}
+
+// Resolve runs stage 1 and returns one envelope carrying the whole graph.
+//
+// Governing: SPEC-0002 REQ "Boundary Surface" — "coarse-grained so one call
+// performs one complete stage". The view gets every node from this single
+// value; there is no per-node accessor to cross the boundary again for.
+func (m *Module) Resolve(planJSON string) Envelope {
+	artifact, ok := m.loaded()
+	if !ok {
+		return FailureFrom(fmt.Errorf("resolve: %w", ErrNotReady))
+	}
+
+	var plan Plan
+	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
+		return FailureFrom(fmt.Errorf("%w: %v", ErrMalformedInput, err))
+	}
+	in, err := DecodePlanStrict(plan)
+	if err != nil {
+		return FailureFrom(err)
+	}
+
+	graph, err := domain.Resolve(artifact, in)
+	if err != nil {
+		return FailureFrom(err)
+	}
+	wire, err := EncodeGraph(graph)
+	if err != nil {
+		return FailureFrom(err)
+	}
+	return Success(ResultPayload{Graph: wire})
+}
+
+// Rollup and Power are RESERVED for stages 2 and 3.
+//
+// Governing: SPEC-0002 REQ "Boundary Surface" — "WHEN rollup or power is
+// added in a later stage THEN it accepts and returns the same envelope
+// shape defined by REQ 'Result Envelope', with no bespoke calling
+// convention."
+//
+// Declared now, with the same signature as Resolve, so the shape is fixed
+// before there is an implementation to bend it around. Each returns a
+// not-ready failure until its stage is wired: a reserved name that returns
+// undefined would be indistinguishable from a typo on the view's side.
+func (m *Module) Rollup(planJSON string) Envelope { return m.reserved("rollup") }
+
+// Power is RESERVED for stage 3. See Rollup.
+func (m *Module) Power(planJSON string) Envelope { return m.reserved("power") }
+
+func (m *Module) reserved(name string) Envelope {
+	return FailureFrom(fmt.Errorf("%s is reserved and not yet wired: %w", name, ErrNotReady))
+}
+
+// loaded returns the artifact under a read lock.
+func (m *Module) loaded() (*domain.Tier1, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.artifact, m.artifact != nil
+}
+
+// EntryPoints are the names the namespace object carries.
+//
+// Governing: SPEC-0002 REQ "Boundary Surface" — one named entry point per
+// domain stage, on a single namespace object, with nothing state-mutating
+// beyond the lifecycle.
+//
+// Enumerated here rather than inline in the js shim so the surface is
+// listable from a plain test, and so adding one is a change to this list
+// rather than a change scattered through registration code.
+var EntryPoints = []string{"load", "ready", "resolve", "rollup", "power"}
+
+// Namespace is the single global name the module registers under.
+const Namespace = "nmsPlanner"
+
+// Call dispatches a named entry point.
+//
+// The js shim does nothing but pass a name and a string through here, which
+// is what keeps it thin enough to be uninteresting.
+func (m *Module) Call(name, arg string) Envelope {
+	switch name {
+	case "load":
+		return m.Load(arg)
+	case "ready":
+		if !m.Ready() {
+			return FailureFrom(fmt.Errorf("module: %w", ErrNotReady))
+		}
+		return Success(ResultPayload{})
+	case "resolve":
+		return m.Resolve(arg)
+	case "rollup":
+		return m.Rollup(arg)
+	case "power":
+		return m.Power(arg)
+	default:
+		return Failure(CodeMalformedInput,
+			fmt.Sprintf("%q is not an entry point on %s; expected one of %v", name, Namespace, EntryPoints))
+	}
+}
+
+// CallJSON dispatches and marshals in one step, which is the whole of what
+// the js shim needs.
+func (m *Module) CallJSON(name, arg string) string {
+	blob, err := Marshal(m.Call(name, arg))
+	if err != nil {
+		// Marshalling an envelope cannot fail on any value this package
+		// builds, but returning a bare Go error string across the boundary
+		// would break the contract the view parses against.
+		return `{"ok":false,"contractVersion":"` + ContractVersion +
+			`","error":{"code":"` + CodeUnclassified + `","message":"envelope could not be marshalled"}}`
+	}
+	return string(blob)
+}

--- a/internal/bridge/module_test.go
+++ b/internal/bridge/module_test.go
@@ -1,0 +1,277 @@
+package bridge_test
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jonstump/nms-base-planner/internal/bridge"
+)
+
+func fixtureJSON(t *testing.T) string {
+	t.Helper()
+	blob, err := os.ReadFile("../domain/testdata/stasis-device.tier1.json")
+	if err != nil {
+		t.Fatalf("reading the fixture: %v", err)
+	}
+	return string(blob)
+}
+
+func loadedModule(t *testing.T) *bridge.Module {
+	t.Helper()
+	m := bridge.NewModule()
+	if env := m.Load(fixtureJSON(t)); !env.OK {
+		t.Fatalf("loading the fixture: %+v", env.Error)
+	}
+	return m
+}
+
+// SPEC-0002 REQ "Boundary Surface":
+// WHEN the module has initialized THEN exactly one namespace object is
+// registered, carrying the stage entry points, and no domain function is
+// reachable from the global scope directly.
+//
+// The registration itself is three lines of syscall/js in cmd/planner; what
+// is worth testing is the surface it registers, which is enumerated here.
+func TestSurfaceIsOneNamespaceWithNamedEntryPoints(t *testing.T) {
+	if bridge.Namespace == "" {
+		t.Fatal("no namespace name")
+	}
+	if len(bridge.EntryPoints) == 0 {
+		t.Fatal("no entry points enumerated")
+	}
+
+	seen := map[string]bool{}
+	for _, name := range bridge.EntryPoints {
+		if seen[name] {
+			t.Errorf("entry point %q is listed twice", name)
+		}
+		seen[name] = true
+	}
+	// The stages the spec requires and reserves.
+	for _, required := range []string{"load", "ready", "resolve", "rollup", "power"} {
+		if !seen[required] {
+			t.Errorf("entry point %q is missing", required)
+		}
+	}
+
+	// Every name dispatches to something that returns a well-formed
+	// envelope — no name is registered that would return undefined.
+	m := loadedModule(t)
+	for _, name := range bridge.EntryPoints {
+		var env bridge.Envelope
+		if err := json.Unmarshal([]byte(m.CallJSON(name, "{}")), &env); err != nil {
+			t.Errorf("%s returned unparseable output: %v", name, err)
+			continue
+		}
+		if env.ContractVersion != bridge.ContractVersion {
+			t.Errorf("%s returned contract version %q", name, env.ContractVersion)
+		}
+		if env.OK == (env.Error != nil) {
+			t.Errorf("%s returned ok=%v with error=%v — exactly one must hold", name, env.OK, env.Error)
+		}
+	}
+
+	// An unknown name is a named failure rather than undefined.
+	var env bridge.Envelope
+	if err := json.Unmarshal([]byte(m.CallJSON("resolveAll", "{}")), &env); err != nil {
+		t.Fatal(err)
+	}
+	if env.OK {
+		t.Error("an unknown entry point reported success")
+	}
+	if !strings.Contains(env.Error.Message, "resolveAll") {
+		t.Errorf("message %q does not name the entry point that does not exist", env.Error.Message)
+	}
+}
+
+// SPEC-0002 REQ "Boundary Surface":
+// WHEN the view resolves a plan and renders 34 nodes THEN exactly one
+// boundary crossing occurred, and node data was read from the single
+// returned value.
+func TestResolvingCrossesTheBoundaryOnce(t *testing.T) {
+	m := loadedModule(t)
+
+	// One call, one string back, everything in it.
+	out := m.CallJSON("resolve", `{"target":"sd","quantity":"1"}`)
+	var env bridge.Envelope
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("parsing the envelope: %v", err)
+	}
+	if !env.OK {
+		t.Fatalf("resolve failed: %+v", env.Error)
+	}
+	if env.Data == nil || env.Data.Graph == nil {
+		t.Fatal("no graph in the payload")
+	}
+	if got := len(env.Data.Graph.Nodes); got != 34 {
+		t.Errorf("nodes = %d, want the fixture's 34", got)
+	}
+
+	// Every node's data is present in that one value: no second crossing
+	// would be needed to render any of it.
+	for _, n := range env.Data.Graph.Nodes {
+		if n.ItemID == "" || n.Name == "" || n.Total == "" {
+			t.Errorf("node %+v is missing data the view would have to fetch separately", n)
+		}
+		if !n.Terminal && len(n.LegalRecipes) == 0 {
+			t.Errorf("node %s carries no legal recipes; the view would need the artifact", n.ItemID)
+		}
+	}
+}
+
+// SPEC-0002 REQ "Module Lifecycle and Readiness":
+// WHEN an entry point is called before the readiness signal has resolved
+// THEN it returns a failure envelope with the not-ready code, and does not
+// hang or return undefined.
+func TestEntryPointsBeforeReadinessReturnNotReady(t *testing.T) {
+	m := bridge.NewModule()
+	if m.Ready() {
+		t.Fatal("a fresh module reports ready")
+	}
+
+	// It returns — the assertion that it does not hang. A deadlock would
+	// fail the test by timing out rather than by returning.
+	done := make(chan bridge.Envelope, 1)
+	go func() { done <- m.Resolve(`{"target":"sd","quantity":"1"}`) }()
+
+	var env bridge.Envelope
+	select {
+	case env = <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("resolve did not return before readiness; it hung")
+	}
+
+	if env.OK {
+		t.Error("resolve succeeded on an unloaded module")
+	}
+	if env.Error == nil {
+		t.Fatal("no error payload — the view would see undefined")
+	}
+	if env.Error.Code != bridge.CodeNotReady {
+		t.Errorf("code = %q, want %q", env.Error.Code, bridge.CodeNotReady)
+	}
+	if env.Data != nil {
+		t.Error("a not-ready failure carried a result payload")
+	}
+
+	// The readiness entry point says so too, rather than returning nothing.
+	var ready bridge.Envelope
+	if err := json.Unmarshal([]byte(m.CallJSON("ready", "")), &ready); err != nil {
+		t.Fatal(err)
+	}
+	if ready.OK || ready.Error.Code != bridge.CodeNotReady {
+		t.Errorf("ready reported %+v before loading", ready)
+	}
+
+	// And after loading, it is ready and resolve works.
+	if env := m.Load(fixtureJSON(t)); !env.OK {
+		t.Fatalf("load failed: %+v", env.Error)
+	}
+	if !m.Ready() {
+		t.Error("the module is not ready after a successful load")
+	}
+	if env := m.Resolve(`{"target":"sd","quantity":"1"}`); !env.OK {
+		t.Errorf("resolve failed after loading: %+v", env.Error)
+	}
+}
+
+// SPEC-0002 REQ "Module Lifecycle and Readiness":
+// WHEN the module instantiates successfully but the supplied Tier 1 artifact
+// fails validation THEN the failure is reported as an invalid-artifact
+// error, not as a module load failure.
+func TestBadArtifactIsNotAModuleFailure(t *testing.T) {
+	m := bridge.NewModule()
+
+	cases := map[string]string{
+		"not json":        `{ this is not json`,
+		"wrong schema":    `{"schema_version":1,"game_version":"x","items":[],"recipes":[]}`,
+		"no game version": `{"schema_version":2,"game_version":"","items":[],"recipes":[]}`,
+		"dangling recipe": `{"schema_version":2,"game_version":"x","items":[],"recipes":[{"id":"r","output":"nope","method":"craft","inputs":[{"item":"x","quantity":1}]}]}`,
+	}
+	for name, artifact := range cases {
+		t.Run(name, func(t *testing.T) {
+			env := m.Load(artifact)
+			if env.OK {
+				t.Fatal("an invalid artifact loaded successfully")
+			}
+			if env.Error.Code != bridge.CodeInvalidArtifact {
+				t.Errorf("code = %q, want %q — the module instantiated fine, the data is what is wrong",
+					env.Error.Code, bridge.CodeInvalidArtifact)
+			}
+			// The module is still usable: it just has no data.
+			if m.Ready() {
+				t.Error("the module reports ready after a failed load")
+			}
+		})
+	}
+
+	// A good artifact still loads after a bad one, so a failed load does
+	// not poison the module.
+	if env := m.Load(fixtureJSON(t)); !env.OK {
+		t.Errorf("a valid artifact failed to load after an invalid one: %+v", env.Error)
+	}
+}
+
+// SPEC-0002 REQ "Boundary Surface":
+// WHEN rollup or power is added in a later stage THEN it accepts and returns
+// the same envelope shape, with no bespoke calling convention.
+//
+// RESERVED means the shape is fixed now. Both are declared with Resolve's
+// signature and return a well-formed envelope today, so a view can wire them
+// before they compute anything — and a reserved name that returned undefined
+// would be indistinguishable from a typo.
+func TestReservedStagesShareTheEnvelopeShape(t *testing.T) {
+	m := loadedModule(t)
+
+	for _, name := range []string{"rollup", "power"} {
+		var env bridge.Envelope
+		if err := json.Unmarshal([]byte(m.CallJSON(name, `{"target":"sd","quantity":"1"}`)), &env); err != nil {
+			t.Fatalf("%s returned unparseable output: %v", name, err)
+		}
+		if env.OK {
+			t.Errorf("%s reported success before its stage exists", name)
+		}
+		if env.Error == nil {
+			t.Fatalf("%s returned no error payload — indistinguishable from a typo", name)
+		}
+		if env.Error.Code != bridge.CodeNotReady {
+			t.Errorf("%s code = %q, want %q", name, env.Error.Code, bridge.CodeNotReady)
+		}
+		if !strings.Contains(env.Error.Message, name) {
+			t.Errorf("%s message %q does not name the stage", name, env.Error.Message)
+		}
+		if env.ContractVersion != bridge.ContractVersion {
+			t.Errorf("%s returned a different contract version", name)
+		}
+	}
+}
+
+// A malformed plan reaching an entry point is the caller's problem, and says
+// so rather than crashing the module.
+func TestMalformedPlanAtTheEntryPoint(t *testing.T) {
+	m := loadedModule(t)
+
+	for _, arg := range []string{`not json`, `{"quantity":"1"}`, `{"target":"sd","quantity":"0"}`} {
+		var env bridge.Envelope
+		if err := json.Unmarshal([]byte(m.CallJSON("resolve", arg)), &env); err != nil {
+			t.Fatalf("the module returned unparseable output for %q: %v", arg, err)
+		}
+		if env.OK {
+			t.Errorf("resolve accepted %q", arg)
+		}
+		if env.Error.Code != bridge.CodeMalformedInput {
+			t.Errorf("%q: code = %q, want %q", arg, env.Error.Code, bridge.CodeMalformedInput)
+		}
+		if env.Data != nil {
+			t.Errorf("%q: a malformed input produced a payload", arg)
+		}
+	}
+
+	// The module still works afterwards.
+	if env := m.Resolve(`{"target":"sd","quantity":"2"}`); !env.OK {
+		t.Errorf("the module broke after a malformed call: %+v", env.Error)
+	}
+}

--- a/internal/bridge/purity_test.go
+++ b/internal/bridge/purity_test.go
@@ -1,0 +1,313 @@
+package bridge_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jonstump/nms-base-planner/internal/bridge"
+)
+
+// SPEC-0002 REQ "Domain Purity Preservation":
+// WHEN the module's dependency graph is inspected
+// THEN syscall/js is reachable only through the adapter package.
+//
+// The issue asked for this to stop being an honour-system comment. It is
+// checked with the command the note itself names, run under the build that
+// could actually contain syscall/js — GOOS=js GOARCH=wasm. On any other
+// GOOS the dependency cannot appear, so a check without those variables
+// would pass for the wrong reason and prove nothing.
+func TestSyscallJSIsReachableOnlyThroughTheAdapter(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("the go tool is not on PATH")
+	}
+
+	// Direct imports, not the transitive closure.
+	//
+	// Under GOOS=js every package reaches syscall/js transitively, because
+	// the standard library's own syscall package imports it — so a
+	// `go list -deps | grep` check reports every package as impure and
+	// distinguishes nothing. It was the first thing I wrote here and it
+	// failed for exactly that reason.
+	//
+	// What ADR-0003 actually forbids is a package of ours importing it, so
+	// that is what is checked: the direct import list of every package in
+	// this module.
+	imports := directImports(t)
+	if len(imports) < 5 {
+		t.Fatalf("go list found only %d packages, so this proves nothing", len(imports))
+	}
+
+	const adapter = "github.com/jonstump/nms-base-planner/cmd/planner"
+	var importers []string
+	for pkg, deps := range imports {
+		for _, dep := range deps {
+			if dep != "syscall/js" {
+				continue
+			}
+			importers = append(importers, pkg)
+			if pkg != adapter {
+				t.Errorf("%s imports syscall/js; ADR-0003 confines it to the adapter", pkg)
+			}
+		}
+	}
+
+	// And the check has teeth: the adapter really does import it, so a pass
+	// is the absence of a dependency that exists elsewhere in this module
+	// rather than a query that never finds anything.
+	if len(importers) == 0 {
+		t.Error("no package in this module imports syscall/js, so the checks above " +
+			"cannot distinguish a pure package from a broken query")
+	}
+}
+
+// directImports lists each package in this module against its direct
+// imports, under the build where syscall/js can appear at all.
+func directImports(t *testing.T) map[string][]string {
+	t.Helper()
+	cmd := exec.Command("go", "list", "-f", "{{.ImportPath}} {{join .Imports \" \"}}", "./...")
+	cmd.Env = append(os.Environ(), "GOOS=js", "GOARCH=wasm")
+	// The repository root: this test runs in internal/bridge, and ./...
+	// from anywhere shallower would miss cmd/planner — which is the one
+	// package the check needs to find.
+	cmd.Dir = "../.."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list: %v\n%s", err, out)
+	}
+	result := map[string][]string{}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		result[fields[0]] = fields[1:]
+	}
+	return result
+}
+
+// SPEC-0002 REQ "Domain Purity Preservation":
+// WHEN the adapter is inspected for quantity arithmetic, graph traversal, or
+// provenance rules THEN none are present; it delegates every such
+// determination to the domain package.
+//
+// design.md names the concrete temptation: rounding a rational to something
+// display-friendly on the way out. SPEC-0001 enumerates which physical
+// boundaries round and in which direction, and none of them is "on the way
+// to the view".
+func TestAdapterHoldsNoDomainLogic(t *testing.T) {
+	sources, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Arithmetic on quantities, rounding, and traversal all have
+	// recognisable shapes. The adapter formats and dispatches; it does not
+	// compute.
+	banned := map[string]string{
+		"Add":         "quantity arithmetic belongs to the domain",
+		"Sub":         "quantity arithmetic belongs to the domain",
+		"Mul":         "quantity arithmetic belongs to the domain",
+		"Quo":         "quantity arithmetic belongs to the domain",
+		"QuoRem":      "rounding belongs to the domain's enumerated boundaries",
+		"Ceil":        "rounding belongs to the domain's enumerated boundaries",
+		"Floor":       "rounding belongs to the domain's enumerated boundaries",
+		"FloatString": "formatting a rational with fixed places truncates it",
+	}
+
+	var checked int
+	for _, path := range sources {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		checked++
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if why, bad := banned[sel.Sel.Name]; bad {
+				t.Errorf("%s: %s() in the adapter — %s",
+					fset.Position(call.Pos()), sel.Sel.Name, why)
+			}
+			return true
+		})
+	}
+	if checked == 0 {
+		t.Fatal("no adapter sources were checked")
+	}
+}
+
+// SPEC-0002 REQ "Domain Purity Preservation":
+// WHEN the encoding and decoding paths are exercised THEN they run under
+// plain go test with no browser and no WASM build.
+//
+// Asserted by this file existing and passing: every other test in this
+// package exercises encoding and decoding, and none of them needs a build
+// tag. What is worth checking mechanically is that no adapter source has
+// acquired one, which would move that behaviour out of reach.
+func TestEncodingPathsNeedNoBuildTag(t *testing.T) {
+	sources, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var checked int
+	for _, path := range sources {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		checked++
+		blob, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, line := range strings.Split(string(blob), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "//go:build") {
+				t.Errorf("%s carries %q; the encoding paths must build everywhere", path, strings.TrimSpace(line))
+			}
+			if strings.Contains(line, `"syscall/js"`) {
+				t.Errorf("%s imports syscall/js; that belongs in cmd/planner alone", path)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no non-test adapter sources were checked")
+	}
+}
+
+// SPEC-0002 REQ "Event Loop Safety":
+// WHEN a resolve call executes THEN the page does not become unresponsive,
+// and no deadlock occurs between the Go runtime and the JavaScript event
+// loop.
+//
+// The issue flagged this as the requirement with the least specified
+// acceptance, and asked for an operational definition before a test that
+// asserts nothing. Here it is, in two parts:
+//
+//  1. BOUNDED. A single resolve on the largest plan the app supports returns
+//     in under 50 ms. A frame is 16.7 ms at 60 Hz; three dropped frames is
+//     a visible stutter and the point at which "unresponsive" starts to
+//     mean something. Measured in Go rather than in a browser, because the
+//     work being timed is Go's.
+//
+//  2. NON-BLOCKING. No entry point contains a construct that can wait on
+//     the event loop: no channel operation, no select, no sleep, no
+//     WaitGroup, no goroutine. A synchronous call that blocks waiting for
+//     JavaScript is the standard Go/WASM deadlock, and the only way to
+//     deadlock against a single-threaded event loop is to wait inside a
+//     call it is making. Checked mechanically, because it is a property of
+//     the code rather than of a run.
+//
+// The `select {}` that parks main is outside every entry point, which is
+// why it is permitted and why the check is scoped to the call paths.
+func TestResolveIsBoundedAndNonBlocking(t *testing.T) {
+	t.Run("bounded", func(t *testing.T) {
+		m := loadedModule(t)
+		// Warm the path so the measurement is steady-state rather than
+		// first-call parsing.
+		m.Resolve(`{"target":"sd","quantity":"1"}`)
+
+		const budget = 50 * time.Millisecond
+		start := time.Now()
+		env := m.Resolve(`{"target":"sd","quantity":"1000000"}`)
+		elapsed := time.Since(start)
+
+		if !env.OK {
+			t.Fatalf("resolve failed: %+v", env.Error)
+		}
+		if elapsed > budget {
+			t.Errorf("resolve took %v, over the %v budget — three frames at 60 Hz", elapsed, budget)
+		}
+		t.Logf("resolve of the 34-node plan at quantity 1,000,000 took %v", elapsed)
+	})
+
+	t.Run("non-blocking", func(t *testing.T) {
+		assertNoBlockingConstructs(t, "module.go")
+		assertNoBlockingConstructs(t, "../../cmd/planner/main.go", "main")
+	})
+}
+
+// assertNoBlockingConstructs fails if any function in the file — other than
+// those named in exempt — contains a construct that can wait.
+func assertNoBlockingConstructs(t *testing.T, path string, exempt ...string) {
+	t.Helper()
+	skip := map[string]bool{}
+	for _, name := range exempt {
+		skip[name] = true
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+
+	var checked int
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || skip[fn.Name.Name] || fn.Body == nil {
+			continue
+		}
+		checked++
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.SelectStmt:
+				t.Errorf("%s: select in %s — an entry point must not wait on the event loop",
+					fset.Position(node.Pos()), fn.Name.Name)
+			case *ast.GoStmt:
+				t.Errorf("%s: goroutine in %s — a call must be straight-line",
+					fset.Position(node.Pos()), fn.Name.Name)
+			case *ast.UnaryExpr:
+				if node.Op == token.ARROW {
+					t.Errorf("%s: channel receive in %s", fset.Position(node.Pos()), fn.Name.Name)
+				}
+			case *ast.SendStmt:
+				t.Errorf("%s: channel send in %s", fset.Position(node.Pos()), fn.Name.Name)
+			case *ast.CallExpr:
+				if sel, ok := node.Fun.(*ast.SelectorExpr); ok {
+					switch sel.Sel.Name {
+					case "Sleep", "Wait", "Lock":
+						// RWMutex.RLock and Lock are not event-loop waits —
+						// they are uncontended in a single-threaded runtime.
+						// Sleep and WaitGroup.Wait are.
+						if sel.Sel.Name != "Lock" {
+							t.Errorf("%s: %s() in %s — an entry point must not block",
+								fset.Position(node.Pos()), sel.Sel.Name, fn.Name.Name)
+						}
+					}
+				}
+			}
+			return true
+		})
+	}
+	if checked == 0 {
+		t.Fatalf("no functions were checked in %s, so this proves nothing", path)
+	}
+}
+
+// The contract version is reported on every envelope, which is what the
+// consumer's version check reads.
+func TestEveryEnvelopeCarriesTheContractVersion(t *testing.T) {
+	m := loadedModule(t)
+	for _, name := range bridge.EntryPoints {
+		out := m.CallJSON(name, `{"target":"sd","quantity":"1"}`)
+		if !strings.Contains(out, `"contractVersion":"`+bridge.ContractVersion+`"`) {
+			t.Errorf("%s returned an envelope without the contract version: %s", name, out)
+		}
+	}
+}


### PR DESCRIPTION
## What

Implements #45, the last story in the WASM epic. `cmd/planner` is the only place in the tree that touches `syscall/js`, and it does one thing: hand strings between JavaScript and `bridge.Module`. Everything the boundary *decides* — what the entry points are, when they are callable, what comes back — lives in `internal/bridge` and tests under plain `go test`.

44 passing test cases. The WASM half builds and vets under `GOOS=js GOARCH=wasm`.

## Two things the tests found

**1. A load failure was classified by the wrong context.** A recipe naming an item no table defines is wrapped as *both* `ErrInvalidArtifact` and `ErrUnknownItem`, and `CodeFor` returned the more specific one.

That is right when a **plan** names a missing item — the caller's problem. It is wrong when loading **our own artifact**: a view told `UNKNOWN_ITEM` sends the user looking at their plan for our data bug. `Load` now classifies by context, because anything failing there is our artifact being inconsistent whatever else it wraps.

**2. My first purity check proved nothing.** The ADR-0003 note suggests `go list -deps ./internal/domain | grep syscall/js`, so that is what I wrote. **Every package fails it** — under `GOOS=js` the standard library's own `syscall` package imports `syscall/js`, so it is in every transitive closure.

The check now compares **direct imports**, which is what the ADR actually forbids, and asserts that `cmd/planner` *does* import it — so a pass is the absence of a dependency that exists elsewhere in the module, not a query that never finds anything. (Belt and braces: importing it into a non-adapter package also breaks the host build outright.)

## Event-loop safety: the operational definition the story asked for

The issue flagged this as "the requirement with the least specified acceptance — worth settling what counts as a pass rather than shipping a test that asserts nothing". Two parts:

**Bounded.** A resolve on the largest supported plan returns in **under 50 ms** — three frames at 60 Hz, which is where "unresponsive" starts to mean something. Measured in Go, because the work being timed is Go's. It runs in **141 µs** at quantity 1,000,000.

**Non-blocking.** No entry point may contain a channel operation, `select`, goroutine, sleep, or wait — checked by parsing the call paths. Deadlocking against a single-threaded event loop requires *waiting inside a call it is making*, so this is a property of the code rather than of a run. The `select {}` that parks `main` is outside every entry point, which is why it is exempt and why the check is scoped to the call paths.

## Surface

One namespace (`nmsPlanner`), five entry points enumerated in `bridge.EntryPoints` so the surface is listable from a plain test rather than scattered through registration code.

`rollup` and `power` are declared **now** with `resolve`'s signature, returning a well-formed not-ready envelope. RESERVED means the shape is fixed before there is an implementation to bend it around — and a reserved name returning `undefined` would be indistinguishable from a typo on the view's side.

## Tests worth calling out

- **Not-ready does not hang**: the test races the call against a 5-second timeout, so a deadlock fails by timing out rather than being assumed away.
- **One crossing**: resolving the 34-node plan returns everything in a single value, and the test walks every node asserting no field is missing that would force a second call.
- **Adapter holds no domain logic**: parses the adapter's AST and fails on `Add`/`Sub`/`Mul`/`Quo`/`QuoRem`/`Ceil`/`Floor`/`FloatString`. `design.md` names the concrete temptation — rounding a rational to something display-friendly on the way out — and SPEC-0001 says none of its rounding boundaries is "on the way to the view".
- **Encoding paths need no build tag**: fails if any non-test adapter source acquires one, which would move that behaviour out of reach of plain `go test`.
- **A failed load does not poison the module**: a valid artifact still loads afterwards.

`go vet` (host and WASM), `staticcheck v0.8.0-rc.1`, `gofmt -l` clean.

Closes #45
Part of #42

Implements SPEC-0002 REQ "Boundary Surface", REQ "Module Lifecycle and Readiness", REQ "Event Loop Safety", REQ "Domain Purity Preservation".

🤖 Generated with [Claude Code](https://claude.com/claude-code)