### PR TITLE
docs: add SPEC-0005 view foundations

### DIFF
--- a/docs/openspec/specs/view-foundations/design.md
+++ b/docs/openspec/specs/view-foundations/design.md
@@ -1,0 +1,117 @@
+# Design: View Foundations
+
+## Context
+
+ADR-0003 moved the dependency graph, rollup engine, power math, save parsing and plan serialization into a Go/WASM core. ADR-0004 chose React with TypeScript and Vite for what remains, and recorded openly that the choice was made on familiarity rather than on merit in isolation — Svelte 5 was the stronger recommendation, and its advantages were knowingly declined so the learning budget could go to Go.
+
+That trade is only cheap if the boundary holds. If domain logic leaks into the view, a framework change stops costing the views and starts costing the parts of the system that were supposed to be safe from it. SPEC-0005 is where the boundary becomes checkable.
+
+Three of ADR-0004's four Confirmation criteria are requirements in the paired spec; the fourth is its Accessibility section. That is not a coincidence — the ADR wrote its confirmation criteria as things a reviewer could check, and this spec is those criteria given scenarios.
+
+The design handoffs are the source for the visual rules: `docs/design/theme/handoff.md` for tokens, border discipline and the control scale, and `docs/design/tree-canvas/handoff.md` for the accessibility behaviour the surfaces inherit.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Make "the view recomputes nothing" a reviewable property rather than an intention
+- Fix the token and border rules once, so each surface inherits rather than restates them
+- Define the boundary client so no surface talks to the module directly
+- Establish the accessibility baseline every surface builds on
+- Keep the spec small enough to plan into a handful of stories
+
+### Non-Goals
+
+- The tree canvas — React Flow, elkjs layout, node buttons in topological order, the method popover. A separate capability that requires this one.
+- The base planner cards — card anatomy, the class picker, the deficit action.
+- Choosing a client state library. ADR-0004 defers this deliberately; see Open Questions.
+- Visual design decisions. The handoffs are final and measured; this spec says how they are expressed in code, not what they are.
+
+## Decisions
+
+### The view holds no domain value, and formatting is the boundary of what it may do
+
+**Choice**: The view performs no arithmetic on quantities, power figures or counts, and does not round. It may format for presentation only where the formatting is reversible and changes no magnitude.
+
+**Rationale**: ADR-0004's Confirmation names this as the criterion that any arithmetic in the React tree is a defect. The temptation `design.md` for SPEC-0002 already identified is rounding — a rational like `3/2` is awkward to show, and rounding it on the way out looks like presentation rather than computation. SPEC-0001 enumerates which physical boundaries round and in which direction; none is "on the way to a screen". Drawing the line at *reversible* formatting gives a reviewer a test rather than a judgement call: if you cannot recover the received value from what is displayed, the view computed something.
+
+**Alternatives considered**:
+- *Allow display rounding with a documented precision*: rejected. Every precision is wrong for some value, and the engine spent real effort keeping quantities exact through five stages. Discarding that at the last step is precisely the failure SPEC-0002's encoding requirement exists to prevent.
+- *Forbid all formatting*: rejected as unusable. Grouping separators and units are not computation.
+
+### One boundary client, not per-surface module access
+
+**Choice**: A single client owns the module handle, the version check, readiness, and error-code branching. Surfaces call the client.
+
+**Rationale**: The version check and the not-ready state are easy to get right once and easy to forget in the third place they are needed. Concentrating them also means a surface cannot accidentally reach the Tier 1 artifact — there is nothing in a surface's reach that could.
+
+**Trade-off**: An indirection between a surface and its data. Accepted because the alternative distributes the boundary contract across every surface that touches it, which is how a contract drifts.
+
+### Not-ready is a state, not an error
+
+**Choice**: The client distinguishes "the module has not loaded" from "the call failed", and the view renders a pending state rather than a failure or a zero.
+
+**Rationale**: SPEC-0002 already separates these on the wire, with distinct codes, precisely so the consumer can. Showing zero while the module loads is the worse failure of the two available: an empty result and a not-yet result look identical to a user, and one of them is a lie about the plan.
+
+### The security section is written out even where the answer is "there is no surface"
+
+**Choice**: All six security topics appear, with the absent ones stating why they are absent rather than being omitted.
+
+**Rationale**: Three of the six are real here — a CSP that must permit WebAssembly, a size limit on user-supplied save files, and validation of plan state arriving from the URL hash. The other three are absent because there is no server. Recording that is more useful than silence, because "there is no server" is a fact that stops being true the day someone adds one, and a heading that was never there gives that change nothing to trip over.
+
+**Trade-off**: Three paragraphs that say a control is unnecessary. Cheaper than a future reader having to work out whether authentication was considered and dismissed or simply forgotten.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph GO["Go / WASM core (ADR-0003)"]
+        MOD["bridge.Module<br/>load · ready · resolve"]
+    end
+
+    subgraph VIEW["React + TypeScript + Vite (ADR-0004)"]
+        CLIENT["Boundary client<br/>version check · readiness<br/>error-code branching"]
+        STATE["View state<br/>selection · collapse<br/>inputs · focus"]
+        TOKENS["Global stylesheet<br/>CSS custom properties"]
+        A11Y["Live regions · focus<br/>management · tab order"]
+
+        subgraph SURFACES["Surfaces — separate specs"]
+            TC["Tree canvas"]
+            BP["Base planner cards"]
+        end
+    end
+
+    CLIENT -->|"one envelope per call<br/>(SPEC-0002)"| MOD
+    CLIENT -->|"domain figures,<br/>rendered as received"| SURFACES
+    STATE --> SURFACES
+    TOKENS --> SURFACES
+    A11Y --> SURFACES
+    SURFACES -->|"user intent"| CLIENT
+
+    style SURFACES stroke-dasharray: 5 5
+```
+
+## Risks / Trade-offs
+
+- **Arithmetic creeps into the view.** The likeliest breach, and it will look reasonable each time — a percentage for a progress bar, a sum for a section header. Mitigated by making the rule specific enough to check: any arithmetic on a domain figure, including rounding. A lint rule over the view's data types would make it mechanical, which is worth doing once the shapes settle.
+- **React's re-render model is the weaker fit for the recompute pattern.** ADR-0004 names this as an accepted cost requiring memoization discipline on the quantity path. Not a performance problem at 34 nodes and three base cards, but ongoing authoring attention rather than something the framework gives structurally.
+- **The token file drifts from the design reference.** The reference computes its own contrast and colour-blindness tables from its hexes, so it cannot drift from its own math — but a copy in another repo can drift from it. Mitigated by recreating rather than reinterpreting, and by keeping every value in one file where a diff is legible.
+- **The accessibility baseline is inherited but not enforced.** A surface spec can add requirements; nothing stops one omitting a live region. Mitigated by the surfaces requiring this spec, so a reviewer has something to check against — but the real enforcement is tests in the surface stories.
+
+## Migration Plan
+
+Greenfield: no view layer exists. The build order that follows from the dependencies:
+
+1. Vite project, TypeScript configuration, and the token stylesheet recreated from the theme handoff.
+2. The boundary client against the module SPEC-0002 defines, including the version check and the not-ready state.
+3. The shell — landmarks, live region, focus management primitives — with no surface in it yet.
+4. Lazy loading for the module and, when the tree canvas arrives, elkjs.
+
+The surfaces follow in their own specs. Nothing here needs the tree canvas or the base planner to exist, which is the point of splitting them out.
+
+## Open Questions
+
+- **Client state management.** ADR-0004 records React as decided and leaves the state library open, recommending `useReducer` plus context or Zustand, and adopting Redux Toolkit only if a concrete need appears. The one argument for Redux worth keeping in view is that its devtools time-travel is useful precisely when debugging a boundary you cannot step through — which the JS/WASM boundary is. Settle after the first working slice.
+- **Whether the no-arithmetic rule can be enforced mechanically.** A branded type on values arriving from the boundary would make arithmetic on them a type error rather than a review finding. Worth trying once the payload shapes settle; premature before that.
+- **Where the save-file size limit is set.** The spec requires one; the number is not chosen. It should come from the largest real save observed rather than from a round figure, which means measuring before deciding.
+- **Whether the shell spec should own the URL hash codec or defer it.** Plan state in the hash is ADR-0002's decision and SPEC-0002 encodes it, but the decode-on-load path is view work and currently has no home.

--- a/docs/openspec/specs/view-foundations/spec.md
+++ b/docs/openspec/specs/view-foundations/spec.md
@@ -1,0 +1,227 @@
+---
+status: draft
+date: 2026-08-19
+implements: [ADR-0004]
+requires: [SPEC-0002]
+---
+
+# SPEC-0005: View Foundations
+
+## Graph Edges
+
+- **Implements:** [ADR-0004](../../../adrs/ADR-0004-react-view-layer.md) — React with TypeScript and Vite for the view layer
+- **Requires:** [SPEC-0002](../wasm-boundary/spec.md) — the boundary the view consumes, and the only route to domain values
+
+## Overview
+
+The floor the view surfaces are built on: how tokens and borders are expressed, what the view is allowed to hold, how it talks to the Go core, and the accessibility behaviour every surface inherits.
+
+ADR-0004 chose React on familiarity rather than on merit-in-isolation, and recorded that trade openly. What makes the trade cheap is ADR-0003's package boundary — a framework change costs the views and not the domain. This spec is where that separation stops being an intention and becomes something a reviewer can check: the view holds selection, collapse, form inputs and focus, and it derives no quantity of its own.
+
+Scope is deliberately the foundations. The tree canvas (React Flow, elkjs, the method popover) and the base planner cards are separate capabilities that depend on this one; splitting them keeps each spec small enough to plan into stories and keeps a change to one surface from touching the other's requirements.
+
+Three of ADR-0004's four Confirmation criteria are requirements below — tokens as custom properties, border discipline, and the view recomputing nothing. The fourth, accessibility being tested rather than assumed, is the Accessibility Requirements section.
+
+## Requirements
+
+### Requirement: Token Discipline
+
+All colour, spacing, type and control-size values MUST be declared as CSS custom properties in a single global stylesheet, recreated from `docs/design/theme/handoff.md`.
+
+Component styles MUST reference those custom properties and MUST NOT contain hardcoded colour literals. The theme reference computes its own contrast and colour-blindness validation tables from the token hexes at render time, so a value duplicated into a component is a value that has escaped that validation.
+
+A token whose value the design reference does not state MUST NOT be invented in a component; it is added to the token file or the design is asked.
+
+#### Scenario: Tokens live in one place
+
+- **WHEN** the stylesheet is searched for colour literals outside the token file
+- **THEN** none is found, and every component colour resolves through a custom property
+
+#### Scenario: A new value is added to the token file
+
+- **WHEN** a component needs a colour or spacing step the token file does not define
+- **THEN** the value is added to the token file with its design provenance, rather than written inline
+
+### Requirement: Component Styling Discipline
+
+Borders MUST carry identity only. A 3px frame denotes identity; nothing else may write to a border.
+
+The three interaction states MUST be expressed as the design specifies, because each was chosen to avoid a rendering defect rather than for appearance:
+
+- Hover MUST be `filter: brightness(1.12)`
+- Focus MUST be a 2px `--ok` outline, outboard
+- Selection MUST be a 2px `--ok` ring, inboard, drawn by an overlay element
+
+`inset box-shadow` MUST NOT be used for any of them. It paints under positioned children, which is the defect the overlay element exists to avoid.
+
+Controls MUST use one scale: 40px default and 30px small. A row MUST NOT mix the two. Where the pointer is coarse, square targets MUST grow to at least 44px.
+
+#### Scenario: Selection does not paint under children
+
+- **WHEN** a selected element contains positioned children
+- **THEN** the selection ring is drawn by an overlay element and remains visible over them
+
+#### Scenario: A row keeps one control scale
+
+- **WHEN** a row contains more than one control
+- **THEN** every control in it is the same scale
+
+#### Scenario: Coarse pointers get larger targets
+
+- **WHEN** the primary pointer is coarse
+- **THEN** square targets are at least 44px
+
+### Requirement: The View Computes No Domain Values
+
+The view MUST NOT perform arithmetic on quantities, power figures, producer counts, or any other value the domain produces. Every such figure MUST arrive from the boundary and be rendered as received.
+
+This includes rounding. SPEC-0001 enumerates exactly which physical boundaries round and in which direction, and none of them is on the way to a screen. A rational the domain reports as `3/2` MUST be displayed as the domain's own string, not converted to a number and formatted.
+
+The view MAY format for presentation — grouping separators, units, truncation with a title attribute — provided the formatting is reversible to the value received and changes no magnitude.
+
+#### Scenario: A displayed total is the domain's
+
+- **WHEN** the view renders a node total
+- **THEN** the value came from the boundary payload, and no arithmetic produced it
+
+#### Scenario: A fractional value is not rounded for display
+
+- **WHEN** the boundary reports a quantity as an exact rational that is not an integer
+- **THEN** the view displays the exact value, and does not round, truncate, or convert it through a floating-point number
+
+#### Scenario: Changing an input recomputes through the core
+
+- **WHEN** the user changes target quantity, a method, a recipe, or a base assignment
+- **THEN** the new figures come from a boundary call, and none is derived in the view from the previous figures
+
+### Requirement: Boundary Client
+
+The view MUST reach the domain only through the module surface SPEC-0002 defines, and MUST NOT read the Tier 1 artifact directly.
+
+The client MUST verify the module's contract version against the version it was built for before consuming any payload, and MUST report a mismatch naming both versions rather than proceeding.
+
+The client MUST treat the envelope as SPEC-0002 defines it: exactly one of a result payload or an error payload. It MUST branch on the error payload's stable code and MUST NOT parse the human-readable message to determine failure kind.
+
+The client MUST distinguish the module not yet being ready from a call having failed, and MUST NOT present a not-ready state as an error.
+
+#### Scenario: Version mismatch is refused, not consumed
+
+- **WHEN** the module reports a contract version the view was not built against
+- **THEN** the view reports the mismatch naming both versions and does not consume the payload
+
+#### Scenario: Failure kind comes from the code
+
+- **WHEN** a call returns a failure envelope
+- **THEN** the view selects its handling from the error code alone, and the message is displayed as diagnostic text only
+
+#### Scenario: Not ready is not an error
+
+- **WHEN** a call is made before the module has loaded its artifact
+- **THEN** the view presents a loading state rather than a failure, and retries once readiness resolves
+
+### Requirement: View State Boundaries
+
+The view MUST hold only interface state: selection, section collapse, form inputs, focus, and view-local preferences.
+
+The view MUST NOT hold the plan, the resolved graph, or any derived quantity as its own source of truth. Where a boundary result is cached to avoid a redundant call, the cache MUST be invalidated by the inputs that produced it, and MUST NOT be edited in place.
+
+Plan state that persists MUST be carried as SPEC-0002 encodes it, so that a plan in a URL and a plan in the view are the same value.
+
+#### Scenario: The view holds no plan of its own
+
+- **WHEN** the view's state is inspected after a plan is resolved
+- **THEN** it holds selection, collapse, inputs and focus, and no independent copy of the plan or its derived figures
+
+#### Scenario: A cached result is invalidated by its inputs
+
+- **WHEN** an input contributing to a cached boundary result changes
+- **THEN** the cached result is discarded rather than adjusted
+
+### Requirement: Module Loading
+
+The WASM module and the layout engine MUST be loaded lazily rather than on first paint, because both are large enough to dominate load time and neither is needed to render the shell.
+
+While the module is loading the view MUST remain interactive and MUST indicate that domain figures are not yet available, rather than presenting empty or zero values as though they were results.
+
+A module that fails to load MUST be reported distinctly from an artifact that fails to validate, per SPEC-0002's separation of the two.
+
+#### Scenario: The shell renders before the module
+
+- **WHEN** the application first paints
+- **THEN** the shell is interactive and the WASM module has not been fetched
+
+#### Scenario: Absent figures are not shown as zero
+
+- **WHEN** the module has not finished loading
+- **THEN** figures dependent on it are shown as pending, not as zero
+
+## Security Requirements
+
+This spec covers a browser-rendered application. It has no server: the deployment is static hosting, the Go core runs in the page, and ADR-0002 keeps save-file parsing client-side. Several topics below are therefore satisfied by the absence of a surface rather than by a control — stated explicitly, because "there is no server" is a fact a future reader needs, and a heading quietly dropped is indistinguishable from a topic nobody considered.
+
+### Authentication
+
+There are no accounts and no server session. The application MUST NOT collect credentials, and MUST NOT transmit save-file contents, plan state, or any user data off the device.
+
+### Rate Limiting
+
+There are no application endpoints to rate-limit; the only requests are for static assets, which are the host's concern. The application MUST NOT introduce a network call that a user action can drive in an unbounded loop.
+
+### Security Headers
+
+The deployment MUST serve a Content Security Policy. The policy MUST permit WebAssembly compilation, MUST NOT permit `unsafe-eval` beyond that, and MUST NOT permit inline script. It MUST restrict `connect-src` to the origin, since no cross-origin call is legitimate for this application.
+
+### Request Body Size Limits
+
+Save-file import is untrusted input from the user's disk. The view MUST enforce a maximum accepted file size before reading a file into memory, and MUST report a file over that limit as a refusal rather than attempting to parse it.
+
+### CSRF Protection
+
+There are no state-changing server routes, so there is no cross-site request forgery surface. Should a server route ever be added, this section MUST be revisited before it ships.
+
+### Redirect Validation
+
+Plan state is carried in the URL hash. The view MUST treat URL-derived state as untrusted input: it MUST validate it through the same decoding path as any other plan input, and a hash it cannot decode MUST produce an empty plan and a diagnostic rather than a partially-applied one. The application MUST NOT navigate to a URL taken from decoded state.
+
+## Accessibility Requirements
+
+This spec covers user-facing UI. The following are MANDATORY per WCAG 2.1 AA, and they are the baseline every view surface inherits — the tree canvas and base planner specs add to these rather than restating them.
+
+### WCAG 2.1 AA Compliance
+
+All UI components produced under this spec MUST meet WCAG 2.1 Level AA as the minimum conformance target. Colour MUST NOT be the sole carrier of any distinction: every state that colour marks MUST also carry a glyph, a label, or text.
+
+### ARIA Landmarks
+
+Page structure MUST include ARIA landmark roles: `role="banner"` on the header, `role="navigation"` on navigation regions, `role="main"` on the primary content area, and `role="contentinfo"` on the footer.
+
+### Icon-Only Controls
+
+Every icon-only control with no visible text label MUST carry an `aria-label` describing its purpose.
+
+### Dynamic Content Regions
+
+Every recompute MUST announce through an `aria-live="polite"` region, naming what changed and that totals updated. Critical status changes MUST use `aria-live="assertive"`.
+
+### Keyboard Navigation
+
+All interactive elements MUST be keyboard operable: a logical tab order following the visual layout, Enter and Space to activate controls, Escape to dismiss popovers and dialogs, and arrow keys within composite widgets.
+
+### Focus Management
+
+Popovers and dialogs MUST trap focus while open, MUST move focus to the first focusable element on open, and MUST return focus to the invoking element on close.
+
+#### Scenario: A recompute is announced
+
+- **WHEN** a user action causes domain figures to change
+- **THEN** a polite live region announces what changed and that totals updated
+
+#### Scenario: Focus returns to the invoking element
+
+- **WHEN** a popover opened from a control is closed by any means
+- **THEN** focus returns to that control
+
+#### Scenario: Colour is never the only signal
+
+- **WHEN** a state is distinguished by colour
+- **THEN** it also carries a glyph, label, or text conveying the same distinction


### PR DESCRIPTION
## What

SPEC-0005, the view layer's foundations, paired with its design doc. **6 requirements, 18 scenarios.**

- `implements: [ADR-0004]` — React with TypeScript and Vite
- `requires: [SPEC-0002]` — the boundary the view consumes, and its only route to domain values

## Why this scope

ADR-0004 chose React on familiarity rather than merit-in-isolation, and said so openly — Svelte 5 was the stronger recommendation and its advantages were knowingly declined. What makes that trade cheap is ADR-0003's package boundary: a framework change costs the views, not the domain.

That holds only if domain logic stays out of the view. **This spec is where the boundary stops being an intention and becomes something a reviewer can check.**

Three of ADR-0004's four Confirmation criteria became requirements almost verbatim, because the ADR had already written them as checkable statements — tokens as custom properties, border discipline, and the view recomputing nothing. This adds the scenarios. The fourth, accessibility being tested rather than assumed, is the Accessibility section.

**Foundations only**, as agreed. The tree canvas (React Flow, elkjs, the method popover with focus trap) and the base planner cards are separate capabilities that will `require` this one. Splitting them keeps each spec plannable and stops a change to one surface touching the other's requirements.

## Requirements

| Requirement | What it fixes |
|---|---|
| Token Discipline | Every colour and spacing value is a custom property; no literals in components |
| Component Styling Discipline | 3px identity frames only; hover/focus/selection as specified; no `inset box-shadow`; one control scale per row |
| The View Computes No Domain Values | No arithmetic on quantities, power or counts — **including rounding** |
| Boundary Client | One client owns the version check, readiness, and error-code branching |
| View State Boundaries | Selection, collapse, inputs and focus — never the plan or its derived figures |
| Module Loading | Lazy WASM and elkjs; pending is not zero |

Plus injected **Security Requirements** and **Accessibility Requirements** sections.

## Two judgement calls worth reviewing

**1. I drew a line on formatting.** "The view computes nothing" is unusable as literally stated — grouping separators are not computation. The rule is now: formatting is permitted where it is **reversible to the received value and changes no magnitude**.

That gives a reviewer a test instead of a judgement call, and makes display rounding an unambiguous violation. SPEC-0002's design already named rounding-on-the-way-out as the concrete temptation; SPEC-0001 enumerates which physical boundaries round, and none is "on the way to a screen".

**2. The Security section is written out despite there being no server.** I nearly skipped it as boilerplate — the deployment is static and ADR-0002 keeps save parsing client-side. Three of the six topics turn out to be real:

- **Security headers** — a CSP that must permit WebAssembly compilation and nothing more
- **Body size limits** — save-file import is untrusted input from the user's disk
- **Redirect validation** — plan state arrives in the URL hash and must decode through the same validated path as any other plan input

The other three state plainly that there is no server. That is a fact which stops being true the day someone adds one, and a heading that was never there gives that change nothing to trip over.

**Backend quality requirements are deliberately not injected.** `go.mod` is a detection signal and it is present, but this capability is pure frontend with no concurrency and no database — which the rule explicitly excludes.

## Validation

- H1 `SPEC-0005` is the next sequential number; no stale number anywhere in either file
- Both frontmatter edge targets resolve to existing artifacts
- Every relative link in both files resolves on disk
- Every requirement has at least one scenario, at `####` with WHEN/THEN
- `design.md` retains `## Open Questions` — four unresolved items, including whether the no-arithmetic rule can be enforced with a branded type rather than by review

## One inconsistency I noticed, not fixed here

**None of the four existing specs carries a `## Graph Edges` section**, though three declare frontmatter edges. This spec has one, per the current authoring rules. Backfilling the others is a `/sdd:graph backfill` job rather than something to fold into this PR.

Separately: SPEC-0002 already declares `implements: [ADR-0003, ADR-0004]`, so ADR-0004 now has two implementing specs. Legitimate, but worth knowing when reading the graph.

Part of #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)