### PR TITLE
docs: resolve SPEC-0005 check findings

### DIFF
--- a/docs/openspec/specs/view-foundations/design.md
+++ b/docs/openspec/specs/view-foundations/design.md
@@ -38,6 +38,7 @@ The design handoffs are the source for the visual rules: `docs/design/theme/hand
 **Alternatives considered**:
 - *Allow display rounding with a documented precision*: rejected. Every precision is wrong for some value, and the engine spent real effort keeping quantities exact through five stages. Discarding that at the last step is precisely the failure SPEC-0002's encoding requirement exists to prevent.
 - *Forbid all formatting*: rejected as unusable. Grouping separators and units are not computation.
+- *Require the rational's own string in every case*: rejected on re-reading. It contradicts the reversible-formatting allowance in the same decision — a grouping separator already changes the string — and it forces `3/2` to be set as a solidus where `1.5` is the same number, exactly recoverable, and the form the design's `tabular-nums` figures are built for. The line that survives is float and magnitude, not glyphs: an exact decimal is a representation, a rounded one is a computation.
 
 ### One boundary client, not per-surface module access
 
@@ -113,5 +114,6 @@ The surfaces follow in their own specs. Nothing here needs the tree canvas or th
 
 - **Client state management.** ADR-0004 records React as decided and leaves the state library open, recommending `useReducer` plus context or Zustand, and adopting Redux Toolkit only if a concrete need appears. The one argument for Redux worth keeping in view is that its devtools time-travel is useful precisely when debugging a boundary you cannot step through — which the JS/WASM boundary is. Settle after the first working slice.
 - **Whether the no-arithmetic rule can be enforced mechanically.** A branded type on values arriving from the boundary would make arithmetic on them a type error rather than a review finding. Worth trying once the payload shapes settle; premature before that.
+- **How the design sets a non-integer quantity.** The theme handoff specifies JetBrains Mono with `tabular-nums` for every figure, which aligns digits into columns and does nothing for a solidus, and no handoff or prototype has yet shown a fractional quantity — the reference was built entirely from integers. Terminating decimals fall out fine. A rational with no terminating decimal (`1/3` is reachable — a recipe yielding three units where one is needed) needs the design's answer, and the spec defers to it. Settle at the first quantity component rather than in the abstract.
 - **Where the save-file size limit is set.** The spec requires one; the number is not chosen. It should come from the largest real save observed rather than from a round figure, which means measuring before deciding.
 - **Whether the shell spec should own the URL hash codec or defer it.** Plan state in the hash is ADR-0002's decision and SPEC-0002 encodes it, but the decode-on-load path is view work and currently has no home.

--- a/docs/openspec/specs/view-foundations/spec.md
+++ b/docs/openspec/specs/view-foundations/spec.md
@@ -32,6 +32,13 @@ Component styles MUST reference those custom properties and MUST NOT contain har
 
 A token whose value the design reference does not state MUST NOT be invented in a component; it is added to the token file or the design is asked.
 
+Two tokens carry conditional constraints that the theme reference states and this requirement restates by name, so a surface inherits them rather than rediscovering them from a contrast table: `--text-muted` measures 4.17:1 against `--panel-raised`, below AA for normal text, so against that surface it MUST be restricted to text 17px or larger or replaced with `--text`; `--text-dim` MUST be used only for decorative text 18px or larger, and MUST NOT be the only styling carrying information available nowhere else.
+
+#### Scenario: A low-contrast token is used within its stated range
+
+- **WHEN** a component sets text in `--text-muted` on a `--panel-raised` surface, or in `--text-dim`
+- **THEN** the type size is at or above the size the token's contrast requires, and no information appears only in `--text-dim`
+
 #### Scenario: Tokens live in one place
 
 - **WHEN** the stylesheet is searched for colour literals outside the token file
@@ -75,9 +82,11 @@ Controls MUST use one scale: 40px default and 30px small. A row MUST NOT mix the
 
 The view MUST NOT perform arithmetic on quantities, power figures, producer counts, or any other value the domain produces. Every such figure MUST arrive from the boundary and be rendered as received.
 
-This includes rounding. SPEC-0001 enumerates exactly which physical boundaries round and in which direction, and none of them is on the way to a screen. A rational the domain reports as `3/2` MUST be displayed as the domain's own string, not converted to a number and formatted.
+This includes rounding. SPEC-0001 enumerates exactly which physical boundaries round and in which direction, and none of them is on the way to a screen. A rational the domain reports as `3/2` MUST NOT be converted through a floating-point number, and MUST NOT be rounded or truncated to a nearby value on the way to the screen.
 
-The view MAY format for presentation — grouping separators, units, truncation with a title attribute — provided the formatting is reversible to the value received and changes no magnitude.
+The view MAY format for presentation — grouping separators, units, an exact decimal expansion, a truncation that carries the exact value on the same element — provided the formatting is reversible to the value received and changes no magnitude. `3/2` MAY therefore be set as `1.5`: the decimal terminates, so the figure displayed is the same number and the rational is recoverable from it. SPEC-0002 permits the boundary to send either form, so the received value may already be `1.5`. A rational with no terminating decimal MUST NOT be set as a decimal alone, because no such decimal is the value; it is set as the rational, or as a truncated decimal whose exact value is available on the element that carries it.
+
+Which of those forms a surface uses is a design question rather than a view author's choice. `docs/design/theme/handoff.md` sets every quantity in JetBrains Mono with `tabular-nums`, a figure style that aligns digits into columns and has nothing to say about a solidus, and no design reference has yet shown a non-integer quantity. A surface spec that introduces one MUST state how the design sets it rather than leaving the choice to the component.
 
 #### Scenario: A displayed total is the domain's
 
@@ -87,7 +96,17 @@ The view MAY format for presentation — grouping separators, units, truncation 
 #### Scenario: A fractional value is not rounded for display
 
 - **WHEN** the boundary reports a quantity as an exact rational that is not an integer
-- **THEN** the view displays the exact value, and does not round, truncate, or convert it through a floating-point number
+- **THEN** the view displays the exact value, and does not round it to a nearby value or convert it through a floating-point number
+
+#### Scenario: An exact decimal is a representation, not a computation
+
+- **WHEN** the boundary reports a quantity whose rational has a terminating decimal expansion
+- **THEN** the view MAY set it as that decimal, and a reader can recover the rational from what is shown
+
+#### Scenario: A repeating rational keeps its exact value on the element
+
+- **WHEN** the boundary reports a quantity whose rational has no terminating decimal expansion
+- **THEN** the view sets the rational itself, or a truncated decimal whose exact value is carried on the same element, and never a bare decimal
 
 #### Scenario: Changing an input recomputes through the core
 


### PR DESCRIPTION
Resolves two of the three findings from `/sdd:check SPEC-0005`. The third turned out to be my error and is documented below rather than fixed.

## The View Computes No Domain Values

The requirement contained two clauses that contradicted each other:

- MUST: a rational the domain reports as `3/2` "MUST be displayed as the domain's own string, not converted to a number and formatted"
- MAY: the view "MAY format for presentation — grouping separators, units, truncation" provided it is reversible and changes no magnitude

A grouping separator already changes the string, so the MAY violates the MUST on its own terms.

It was also in tension with the spec it depends on. SPEC-0002 REQ "Encoding" (`wasm-boundary/spec.md:47`) requires that a non-integer total "MUST be encoded as an exact decimal **or rational string** that round-trips without loss" — so the domain's own string for `3/2` may already be `1.5`. The original MUST was unsatisfiable against the boundary that feeds it.

The rule is redrawn where it was actually load-bearing:

- no conversion through a floating-point number
- no rounding or truncation to a nearby value
- the exact value always recoverable from what is displayed

An exact decimal expansion is a representation and is permitted — `3/2` may be set as `1.5`, which is the same number. A rational with no terminating decimal MUST NOT be set as a bare decimal, because no such decimal is the value; it is set as the rational, or as a truncated decimal carrying its exact value on the same element. Two scenarios added; the rejected alternative recorded in `design.md`.

**What this PR deliberately does not decide.** The theme handoff sets every quantity in JetBrains Mono with `tabular-nums`, a figure style that aligns digits into columns and does nothing for a solidus — and no handoff or prototype has ever shown a fractional quantity. The reference was built entirely from integers. Choosing the glyphs is the design's call, not mine, so the spec now requires a surface spec introducing a fraction to carry the design's answer, and `design.md` records it as an open question. `1/3` is reachable — a recipe yielding three units where one is needed.

## Token Discipline

The theme handoff states two conditional token constraints that SPEC-0005 did not carry:

- `--text-muted` measures 4.17:1 on `--panel-raised`, below AA for normal text — restrict to ≥17px there or use `--text`
- `--text-dim` is decorative ≥18px only, never unique information

Both were already implied by the spec's general WCAG 2.1 AA requirement, so this is not a correctness fix. It matters because the spec declares itself "the baseline every view surface inherits — the tree canvas and base planner specs add to these rather than restating them." If that is the contract, conditional constraints belong in it by name. The failure mode is quiet: `--text-muted` at 14px on a base card uses a token, passes Token Discipline as written, and fails AA.

## The finding I withdrew

I flagged `design.md:97` ("not a performance problem at 34 nodes") as stale against the 34→36 node correction from #47, and made the edit. Checking the rest of the repo afterwards: 15 other places say "34 nodes," and ADR-0001's own correction table explains why — 34 is the hand-authored fixture and design prototype, 36 is the generated artifact. Every one of those 15 is a scale aside about the prototype, used consistently. `design.md:97` is the same usage. Changing only that one would have made SPEC-0005 the outlier, so I reverted it.

The honest version is repo-wide and much weaker: scale asides cite the prototype's count while the shipping artifact is 36. Nothing depends on the number in any of them — the one place it was load-bearing, ADR-0001's Confirmation, is already corrected. Not worth a sweep.

## Reviewer notes

- Docs only. No code changes, nothing to run.
- SPEC-0005 remains `draft` and has no epic. These edits are the read-through before `/sdd:plan`.
- The substantive question for a reviewer is the first section: whether permitting an exact decimal expansion weakens the no-arithmetic guarantee. The argument that it does not is that `1.5` and `3/2` are the same number and each is recoverable from the other, and that SPEC-0002 already permits the boundary to send either — but that is the claim worth pushing on.

Part of SPEC-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)