### PR TITLE
docs: add SPEC-0006 tree canvas

### DIFF
--- a/docs/openspec/specs/tree-canvas/design.md
+++ b/docs/openspec/specs/tree-canvas/design.md
@@ -1,0 +1,145 @@
+# Design: Tree Canvas
+
+## Context
+
+SPEC-0006 specifies the first surface built on SPEC-0005. The view layer does not exist yet; SPEC-0005 established the rules it will be built under, and this spec is the first thing those rules have to hold for.
+
+The design reference is `docs/design/tree-canvas/handoff.md` and its prototype, `Tree Canvas.dc.html` — a high-fidelity HTML reference for node cards, edges, the popover, states and colours, with layout positions explicitly illustrative because elkjs decides them in production. The handoff carries a convention note that where it and a later spec disagree, the spec wins. This spec invokes that note twice.
+
+**The design predates ADR-0005 by one day.** The handoff was authored 2026-08-17; ADR-0005 was accepted 2026-08-18. The prototype's popover offers a binary craft|refine segmented control, which was the whole of the choice a node had when it was drawn. ADR-0005 changed that: a node now resolves to one *recipe* as well as one method, alternatives are common rather than exceptional — 261 of 403 refiner output/method pairs have more than one — and the ADR assigns the view the job of surfacing them. Nothing in the design covers this.
+
+The gap is not small. Sodium Nitrate carries 26 refine recipes; the largest cooked output carries 61. A segmented control is the correct affordance for two options and the wrong one for twenty-six. This spec therefore requires the capability and defers the form, in the same way SPEC-0005 deferred fractional typography rather than inventing it.
+
+The upstream half of this surface is ready. `internal/bridge` already encodes `legalMethods`, `legalRecipes`, `yield`, `applications`, `terminal`, `verified` and per-edge `perUnit`/`yield` on every node, and SPEC-0002 REQ "Recipe Selection Crossing" already requires the view be able to offer alternatives without reading the artifact. What the canvas needs from the boundary, the boundary sends.
+
+The downstream half is not. Leaf-to-base assignment reaches the domain through stage 2, and `Module.Rollup` is still a reserved stub returning a not-implemented envelope. Assignment is a core interaction of this surface and cannot be built until that entry point is wired.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Render the resolved graph faithfully from one boundary payload, with the domain's ordering intact
+- Give the player the two choices the domain accepts per node — method and recipe — and the leaf assignment
+- Keep every domain figure the domain's, including the fractional ones this surface is the first to display
+- Make the surface fully operable by keyboard, with tab order following build order
+- Name the places where the design has not yet decided, instead of deciding them here
+
+### Non-Goals
+
+- The base planner surface, the bases map, and the application shell — separate specs
+- The URL hash codec. Plan state is SPEC-0002's encoding and ADR-0002's decision; the decode-on-load path still has no home, which SPEC-0005 records as an open question
+- Save-file import — ADR-0002, unspecced
+- Phone layout. The brief makes phone view-only, so the method control's small-screen form is deferred to the shell surface
+- Choosing the state library. ADR-0004 leaves it open and SPEC-0005 records it as an open question to settle after the first working slice; this is that slice, but the choice belongs with the slice, not ahead of it
+
+## Decisions
+
+### The recipe control is required; its form is the design's to decide
+
+**Choice**: The spec requires that alternatives be offered, that they remain usable at 26 and 61 options, and that each be distinguishable by inputs and yield rather than by identifier. It does not specify the control.
+
+**Rationale**: This is the same judgement SPEC-0005 reached about fractional display, and for the same reason: specifying a visual form the design has never drawn is how a spec acquires a requirement no one validated. What can be specified without the design is the *shape of the problem* — the option counts are measured facts from ADR-0005, and "distinguishable by what it consumes and yields" follows from what an alternative recipe actually is. Those constrain the design's answer without substituting for it.
+
+**Alternatives considered**:
+- *Extend the segmented control*: rejected. It is drawn for two options and the data has up to 61.
+- *Specify a dropdown*: rejected. It would be a guess with a spec's authority behind it, and a bare `<select>` of 61 recipe identifiers fails the distinguishability requirement anyway.
+- *Leave recipe selection out of this spec*: rejected. ADR-0005 assigns the view this job explicitly, and a canvas that shows one route where the domain reports 26 is the failure the ADR was written to prevent.
+
+### Layout geometry is carved out of the no-arithmetic rule, explicitly
+
+**Choice**: The spec states that computing node positions is not a violation of SPEC-0005 REQ "The View Computes No Domain Values", and draws the line at what the computation reads: structure yes, quantities no.
+
+**Rationale**: A layout engine is arithmetic on the view side, performed on graph data, producing numbers. Read literally, SPEC-0005's rule appears to forbid it, and a reviewer would be right to raise it. Stating the carve-out is cheaper than having the argument at review time on every surface. The line is checkable: pass nodes and edges to the layout engine and never a total, and the question of whether a coordinate is a domain value never arises. The test in the spec — changing quantity must not move the graph — makes the rule observable rather than a matter of reading the layout code.
+
+**Trade-off**: A carve-out is a place where a rule has an exception, and exceptions get cited by analogy. Mitigated by making it narrow and by stating the prohibited cases directly: sizing a node by its total, or ordering a column by quantity, are named as violations.
+
+### Tab order is the payload's node order, not the layout's
+
+**Choice**: Each node is one tab stop, visited in the order the boundary payload lists them — terminals first, target last.
+
+**Rationale**: The handoff already asked for this ("nodes are `<button>`s in topological order (raws first, device last) = tab order"), and the boundary already guarantees it: SPEC-0002 REQ "Determinism Across the Boundary" requires node order to survive encoding, and `EncodeGraph`'s own comment says the adapter does not re-sort because "the tab order the view renders is a domain decision and re-deriving it here would be a second place for it to drift". So the canvas inherits an order that three layers have agreed on rather than computing a fourth.
+
+This also makes the accessibility requirement and the no-computation requirement the same requirement, which is a good sign for both. A canvas that sorted nodes for tab order would be deriving a view fact from domain data — the thing SPEC-0005 forbids — and would drift from the domain's order the moment the engine's ordering changed.
+
+**Trade-off**: Tab order will not follow visual position, because elkjs positions nodes and the domain orders them. For a dependency graph this is the right way round — build order is more useful than reading order — but it is a deliberate divergence from the usual "tab order follows visual layout" guidance, and worth stating so it is not later "fixed".
+
+### The border belongs to base identity, and nothing else
+
+**Choice**: The card's border conveys base assignment only. Hover, focus and selection use filter, outboard outline and inboard overlay ring.
+
+**Rationale**: Inherited from the design, which arrived at it the hard way and recorded the provenance — one rule from an outfitter issue, one from an outfitter PR after inset box-shadows were found painting under positioned children. SPEC-0005 already carries the inset-shadow prohibition as a general styling rule; what this spec adds is *why* the border was unavailable in the first place, which is that a leaf's base identity is a fact the player needs while hovering, focusing and selecting that same node.
+
+### Assignment depends on stage 2 being wired, and says so
+
+**Choice**: The spec requires leaf assignment and states that it reaches the domain through the reserved stage-2 entry point, explicitly forbidding a workaround that reads the domain's rollup types directly.
+
+**Rationale**: The prohibition is the useful half. An implementer meeting a not-implemented envelope has an obvious escape — reach past the boundary for the types, which are right there in the same repository — and it would work, and it would put domain knowledge in the render layer that ADR-0003 and ADR-0004 both exist to keep out. Naming the escape closes it.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph domain["Go domain core (SPEC-0001)"]
+        RES["Resolve<br/>method + recipe selection<br/>provenance propagation"]
+        ROL["GroupLeaves / rollup<br/>stage 2"]
+    end
+
+    subgraph bridge["WASM adapter (SPEC-0002)"]
+        EG["EncodeGraph<br/>quantities as decimal strings<br/>node order preserved"]
+        RSTUB["Rollup entry point<br/>RESERVED — not wired"]
+    end
+
+    subgraph view["React view (SPEC-0005)"]
+        BC["Boundary client<br/>version check · readiness · error codes"]
+        CV["Tree canvas (SPEC-0006)"]
+        LAY["Layout engine<br/>reads structure only"]
+        NODE["Node cards + edges"]
+        POP["Node control<br/>method · recipe · assignment"]
+    end
+
+    RES --> EG --> BC --> CV
+    CV --> LAY --> NODE
+    CV --> POP
+    POP -->|"plan: methods, recipes, assignments"| BC
+    BC -->|"resolve"| EG
+    BC -.->|"assignment needs this"| RSTUB
+    RSTUB -.->|"issue #64"| ROL
+
+    style RSTUB stroke-dasharray: 5 5
+    style ROL stroke-dasharray: 5 5
+```
+
+The plan travels back the way the payload came: a change in the node control produces new plan state, the client sends it, and the canvas renders whatever returns. No figure is adjusted in place on the way.
+
+## Risks / Trade-offs
+
+- **The recipe control is the hard part and is not designed yet.** 61 options with meaningful distinctions between them is a genuine interaction-design problem, not a styling exercise, and it sits on the critical path of the surface's core interaction. → Mitigated by specifying the constraints now so the design work starts from measured option counts rather than from the prototype's two. This should be resolved before the surface is planned into stories, not during implementation.
+
+- **The provenance marker cannot be validated against real data.** The generated artifact marks nothing unverified — resolving `ULTRAPROD2` against `data/tier1.json` returns 36 nodes, 0 of them unverified — because the normalizer never emits `"verified": false`. The domain supports the flag, the boundary carries it, the design drew the badge, and today nothing triggers it. → The marker must be built against a fixture rather than the real artifact, and its propagated form — a connected span up to the target, not isolated chips — is what the fixture should exercise. The design tuned "subtle, honest, non-alarming" against two instances in a prototype; propagation means the real count is a spine, not a pair.
+
+- **Edge label legibility does not scale with the tree.** The handoff records labels as legible at the prototype's 34 nodes and flags 60+ as needing hover-only. The real target already resolves to 36, and combined targets go further. → Flagged for layout spacing tests; the spec requires the per-unit quantity be present without fixing how it is revealed, so hover-only remains available without a spec change.
+
+- **Two substantial third-party dependencies enter the project here.** React Flow and elkjs are the first, and both sit directly under a surface whose spec forbids the view computing domain values. → The carve-out decision above draws the line at what the layout engine may read, which keeps the dependency inside the rule rather than beside it.
+
+- **This surface will find SPEC-0005's unfinished edges.** It is the first consumer of the boundary client, the first place the fraction rule renders, and the first test of the token constraints. → That is the point of building it first, but it means SPEC-0005 should be expected to take amendments rather than being treated as settled.
+
+## Migration Plan
+
+Greenfield. The dependency order:
+
+1. Issue #64 wires `rollup` and `power` into the boundary — a hard prerequisite for leaf assignment, and independent of everything else here.
+2. The SPEC-0005 foundations: Vite and TypeScript, the token stylesheet, the boundary client, module loading.
+3. Static rendering: payload → layout → node cards and edges, with no interaction. This exercises the ordering, the token discipline, and the no-arithmetic rule before any control exists.
+4. The method control, which the design has fully specified.
+5. The recipe control, once the design has answered.
+6. Leaf assignment, once step 1 has landed.
+
+Steps 4 and 6 are independent of each other; step 5 is blocked on design rather than on code.
+
+## Open Questions
+
+- **The recipe control's form.** The central one. Needs the design, given option counts up to 61 and the requirement that alternatives be told apart by inputs and yield rather than identifier.
+- **How a fractional application count is set.** This surface is where SPEC-0005's deferred fraction question becomes concrete: `applications` is exact and unrounded, and the theme handoff sets every figure in `tabular-nums`, which aligns digits and not a solidus. The two open questions should be answered together, since this is the first place either is visible.
+- **Whether the yield belongs on the card or in the control.** The spec requires a non-unit yield be visible on the node; the card as drawn has no room for it, and the design has not been asked. Putting it only in the control would mean the card shows a total whose derivation is hidden.
+- **Where target and quantity selection live.** The handoff puts device quantity in a tweaks panel, which is shell furniture rather than canvas. The boundary needs both on every call, so the canvas consumes them regardless — but which surface owns the control is unsettled, and the shell has no spec yet.
+- **Whether edge labels become hover-only, and at what node count.** Deferred to layout spacing tests rather than guessed at.

--- a/docs/openspec/specs/tree-canvas/spec.md
+++ b/docs/openspec/specs/tree-canvas/spec.md
@@ -1,0 +1,270 @@
+---
+status: draft
+date: 2026-08-19
+implements: [ADR-0004, ADR-0005]
+requires: [SPEC-0001, SPEC-0002, SPEC-0005]
+---
+
+# SPEC-0006: Tree Canvas
+
+## Graph Edges
+
+- **Implements:** [ADR-0004](../../../adrs/ADR-0004-react-view-layer.md) — the React view layer this surface is the first instance of
+- **Implements:** [ADR-0005](../../../adrs/ADR-0005-multiple-recipes-per-output.md) — "the view surfaces the alternatives per node and the player may pick another"
+- **Requires:** [SPEC-0001](../rollup-engine/spec.md) — node semantics, method and recipe resolution, provenance propagation
+- **Requires:** [SPEC-0002](../wasm-boundary/spec.md) — the payload this surface renders and the plan it sends back
+- **Requires:** [SPEC-0005](../view-foundations/spec.md) — tokens, styling discipline, the no-arithmetic rule, the boundary client, and state boundaries, all inherited rather than restated
+
+## Overview
+
+The dependency-tree surface: the player picks a target item and quantity and sees the full crafting and refining tree as a left-to-right flowchart, changes the method or recipe per node, and assigns leaf resources to bases.
+
+This is the first surface built on SPEC-0005. Everything SPEC-0005 requires of a view surface applies here and is **not restated** — tokens, component styling, the prohibition on computing domain values, the single boundary client, and view-state boundaries are inherited. This spec adds only what is specific to the tree.
+
+Two things this spec specifies have never been drawn. `docs/design/tree-canvas/handoff.md` and its prototype were authored on 2026-08-17, before ADR-0005 was accepted on 2026-08-18. The prototype's method popover offers a binary craft|refine choice; ADR-0005 requires the view to surface per-node **recipe** alternatives as well, of which one real item has 26 and another has 61. The prototype also predates the node's `yield` and `applications` fields. Where this spec requires a surface the design has not drawn, it says so and defers the visual form to the design rather than inventing it.
+
+The design handoff's own convention note reads: where it and a later spec disagree, the spec wins.
+
+## Requirements
+
+### Requirement: Graph Rendering From the Boundary Payload
+
+The canvas MUST render nodes and edges from a single `resolve` payload obtained through the SPEC-0005 boundary client. It MUST NOT assemble the graph from repeated boundary calls, and MUST NOT read the Tier 1 artifact.
+
+Node order in the payload is the domain's, terminals first and target last, and SPEC-0002 REQ "Determinism Across the Boundary" guarantees it survives encoding. The canvas MUST take that order as given. It MUST NOT sort, rank, or otherwise reorder nodes, because deriving an order in the view would be a second place for it to drift from the domain's.
+
+Each node's edges MUST be drawn from that node's own `children`. The canvas MUST NOT infer an edge that the payload does not contain.
+
+#### Scenario: One crossing renders the whole tree
+
+- **WHEN** the canvas renders a resolved plan of 36 nodes
+- **THEN** exactly one `resolve` crossing produced it, and every node and edge was read from that single returned value
+
+#### Scenario: The payload's order is the canvas's order
+
+- **WHEN** the canvas holds a resolved payload
+- **THEN** the node sequence it iterates matches the payload's sequence exactly, and no comparison function is applied to it
+
+### Requirement: Layout Geometry Is Not a Domain Value
+
+Node positions and edge paths MUST be computed by the layout engine from graph structure alone — which nodes exist and which edges connect them. Position MUST NOT be derived from any quantity, total, yield, application count, or producer figure.
+
+This is not an exception to SPEC-0005 REQ "The View Computes No Domain Values". A coordinate is not a domain figure and the domain reports none; computing one is presentation. A layout that scaled a node by its total, or ordered a column by quantity, would be deriving a visual fact from a domain value and is prohibited.
+
+#### Scenario: Layout reads structure, not quantities
+
+- **WHEN** the layout engine is invoked for a resolved graph
+- **THEN** its input is nodes and edges, and no node total, yield or application count is passed to it
+
+#### Scenario: Changing quantity does not move the graph
+
+- **WHEN** the target quantity changes and every total scales
+- **THEN** node positions are unchanged, because no position was derived from a total
+
+### Requirement: Node Card
+
+A node card MUST show the item's display name, its total quantity, and its resolved method as a badge carrying both a glyph and a text label.
+
+The card's border is reserved for one fact: **which base a leaf is assigned to**. A leaf assigned to a base MUST carry a 3px border in that base's colour token. An unassigned leaf MUST carry a 3px dashed border in the neutral border token **and** a warning dot, so the unassigned state is not conveyed by border style alone. A non-leaf node MUST carry a 1px neutral border.
+
+No other state MUST write to the border. Hover MUST be expressed as a brightness filter, focus as an outboard outline, and selection as an inboard ring rendered as an overlay element. SPEC-0005 REQ "Component Styling Discipline" already forbids the inset box-shadow that would paint under positioned children; this requirement is the reason the border is unavailable to those states in the first place.
+
+#### Scenario: Base identity owns the border
+
+- **WHEN** a leaf node is assigned to a base and is simultaneously hovered, focused and selected
+- **THEN** its border still shows the base's colour, and hover, focus and selection are shown by filter, outline and overlay ring respectively
+
+#### Scenario: Unassigned is not colour alone
+
+- **WHEN** a leaf node has no base assignment
+- **THEN** it shows a dashed border and a warning dot, and the state is legible without colour perception
+
+### Requirement: Method Selection
+
+Clicking or pressing Enter on a node MUST open a control offering that node's methods. The options offered MUST be the node's `legalMethods` from the payload; the canvas MUST NOT compute which methods are legal.
+
+A method that is not available for the node MUST be rendered and inert, with the reason stated, rather than hidden. A hidden option cannot be distinguished from one that does not exist.
+
+The control MUST state the consequence of a change before it is made, in the domain's own terms.
+
+#### Scenario: Legal methods come from the payload
+
+- **WHEN** the method control opens for a node
+- **THEN** the options shown are that node's `legalMethods`, and the canvas consulted no other source to determine them
+
+#### Scenario: An unavailable method is visible and inert
+
+- **WHEN** a node cannot be refined
+- **THEN** the refine option is rendered, is not activatable, and states why
+
+### Requirement: Recipe Selection
+
+Where a node's payload carries more than one entry in `legalRecipes`, the canvas MUST offer the alternatives and MUST allow the player to select one. A node presenting a single route where the domain reports several is the failure ADR-0005 exists to prevent.
+
+The selection surface MUST remain usable at the sizes the real data produces. The refiner tables carry 26 recipes for Sodium Nitrate and 61 for the largest cooked output, so a control whose legibility depends on a small fixed number of options MUST NOT be used.
+
+Each alternative MUST be distinguishable by what it consumes and what it yields, since alternatives for one output differ in exactly those terms. A recipe identifier alone MUST NOT be the only thing distinguishing two options.
+
+A node using its engine-default recipe MUST NOT record a selection in plan state, per SPEC-0002 REQ "Recipe Selection Crossing", so that only deliberate overrides reach the URL hash.
+
+**The design has not drawn this control.** The prototype's segmented craft|refine control predates ADR-0005 and addresses method only. A surface implementing this requirement MUST carry the design's answer for the recipe control rather than extending the segmented control past the size it was drawn for.
+
+#### Scenario: Alternatives are offered where they exist
+
+- **WHEN** a node's payload reports 26 legal recipes
+- **THEN** the canvas offers all 26 and the player may select any of them
+
+#### Scenario: Alternatives are told apart by inputs and yield
+
+- **WHEN** two recipes for one output are offered
+- **THEN** each is shown with what it consumes and how many units it produces
+
+#### Scenario: A default records nothing
+
+- **WHEN** every node in a plan uses its default recipe
+- **THEN** the plan state carries no recipe selections
+
+### Requirement: Yield and Application Display
+
+Where a node's resolved recipe has a yield other than 1, the canvas MUST make that yield visible on the node. A total of 300 reached through a recipe yielding 50 is a different build instruction from a total of 300 reached through a recipe yielding 1, and the node card as drawn shows only the total.
+
+Where the canvas shows a node's `applications` count, it MUST render it under SPEC-0005 REQ "The View Computes No Domain Values". The domain reports applications exactly and unrounded, so this is the first surface at which a non-integer domain figure reaches a screen, and SPEC-0005's rule governs how it is set. The canvas MUST NOT round an application count to a whole number of crafting operations; SPEC-0001 confines rounding to enumerated physical boundaries and this is not one of them.
+
+#### Scenario: A yield other than one is visible
+
+- **WHEN** a node resolves to a recipe producing 50 units per application
+- **THEN** the node shows that yield, and the total alone is not the only quantity displayed
+
+#### Scenario: A fractional application count is not rounded
+
+- **WHEN** a node's application count is an exact rational that is not an integer
+- **THEN** it is displayed under SPEC-0005's display rule, and is not rounded up to a whole number of operations
+
+### Requirement: Leaf Assignment to Bases
+
+The canvas MUST allow a leaf node to be assigned to a base, and the assignment MUST be operable without a pointing device.
+
+An assignment MUST be plan state carried as SPEC-0002 encodes it, not view-local state. Reassigning a leaf MUST cause the affected figures to be recomputed through the boundary; the canvas MUST NOT adjust any base's totals itself.
+
+Assignment reaches the domain through stage 2, whose boundary entry point is reserved and not yet wired. A canvas implementing this requirement MUST NOT read the domain's rollup types directly to work around that; the dependency is on the entry point being wired.
+
+#### Scenario: Assignment is keyboard-operable
+
+- **WHEN** a player navigates to a leaf node and opens its control using only the keyboard
+- **THEN** the base assignment can be changed and committed without a pointing device
+
+#### Scenario: Reassignment recomputes through the boundary
+
+- **WHEN** a leaf is moved from one base to another
+- **THEN** the new figures come from a boundary call, and no base total was adjusted in the view
+
+### Requirement: Provenance Display
+
+A node whose payload reports it as not verified MUST carry a visible provenance marker stating that the data is community-sourced and not verified in-game.
+
+The marker MUST be legible without alarm. Unverified data is the normal condition for parts of this dataset, not an error state, and MUST NOT be styled as one.
+
+Provenance propagates: SPEC-0001 REQ "Provenance Propagation" marks a figure unverified when **any** contributing node is unverified, so the marker appears on every ancestor of an unverified node up to and including the target. A canvas implementing this requirement MUST remain legible when the marker is present on a connected span of the graph rather than on isolated nodes.
+
+#### Scenario: The marker follows propagation
+
+- **WHEN** a node deep in the tree is unverified
+- **THEN** every node deriving a total from it, up to the target, also shows the marker
+
+#### Scenario: Unverified is not an error state
+
+- **WHEN** a node carries the provenance marker
+- **THEN** it is not styled with the error or warning treatment reserved for conditions the player must resolve
+
+### Requirement: Edge Rendering
+
+An edge MUST carry the per-unit quantity relating its two nodes, taken from the payload.
+
+The method of the node an edge feeds MUST be readable from the edge itself as well as from the node's badge, so the wiring reinforces the fact rather than the badge carrying it alone.
+
+Edge styling MUST be decorative reinforcement only. Every fact an edge's appearance conveys MUST also be available as text on the node it connects to.
+
+#### Scenario: Method is readable from the wiring
+
+- **WHEN** a node's method is refine
+- **THEN** the edges feeding it are visually distinguished from those feeding a crafted node
+
+#### Scenario: No fact lives only in an edge
+
+- **WHEN** edge styling is disregarded entirely
+- **THEN** every fact it conveyed remains available as text on the connected nodes
+
+## Security Requirements
+
+This capability is a browser-rendered client application. It ships as static assets and a WASM module, has no server component, no accounts, no session, and no HTTP endpoints of its own — so several of the topics below have no surface in this spec rather than an unstated answer. Each is recorded with its applicability so an uncovered topic is visible rather than absent.
+
+### Authentication
+
+Not applicable. This capability defines no endpoints and no protected resources; there is nothing to authenticate to. Introducing any server-side surface to this capability would require this topic to be answered, not inherited.
+
+### Rate Limiting
+
+Not applicable. All computation is local, invoked by the player against their own machine. There is no shared resource to exhaust and no remote call to throttle.
+
+### Security Headers
+
+Deferred to the application shell, which owns document delivery. This capability contributes no headers and MUST NOT weaken any the shell sets — in particular, this spec introduces no requirement for inline script or `eval`, so a strict script CSP remains available to the shell.
+
+### Request Body Size Limits
+
+Not applicable to this capability. The canvas accepts no uploads. Save-file import is ADR-0002's surface; SPEC-0005 § Security Requirements → Request Body Size Limits already requires a maximum accepted size be enforced before a file is read into memory, and records the number itself as unchosen.
+
+### CSRF Protection
+
+Not applicable. There are no state-changing requests; plan changes are local recomputation through the WASM boundary, which is an in-process call and not a request.
+
+### Redirect Validation
+
+Plan state arrives in the URL hash, which is untrusted input. [SPEC-0005](../view-foundations/spec.md) § Security Requirements → Redirect Validation already governs this: URL-derived state is validated through the same decoding path as any other plan input, a hash that cannot be decoded produces an empty plan and a diagnostic rather than a partially-applied one, and the application MUST NOT navigate to a URL taken from decoded state. This capability inherits all three and adds no redirect of its own.
+
+Item names and identifiers rendered by this capability come from the committed Tier 1 artifact rather than from player input, and MUST be rendered as text. This capability MUST NOT introduce a path that renders any payload field as markup.
+
+## Accessibility Requirements
+
+This spec involves user-facing UI. The following accessibility requirements are MANDATORY per WCAG 2.1 AA. They add to SPEC-0005's baseline, which already requires WCAG 2.1 AA conformance and the token contrast constraints, and are not restated here.
+
+### WCAG 2.1 AA Compliance
+
+All UI components produced by this spec MUST meet WCAG 2.1 Level AA conformance as the minimum accessibility target.
+
+### ARIA Landmarks
+
+The canvas region MUST be exposed as a landmark distinguishable from the surrounding application shell, so a screen-reader user can move to and past the graph without traversing every node.
+
+### Icon-Only Controls
+
+Every icon-only control MUST carry an `aria-label` describing its purpose. The method badge glyph MUST NOT be the sole accessible name of anything; it is accompanied by its text label.
+
+### Dynamic Content Regions
+
+A method change, recipe change, assignment change or quantity change MUST be announced through an `aria-live="polite"` region naming what changed and that totals updated. Announcements MUST NOT be `assertive`: a recompute is the expected result of the player's own action, not a critical status change.
+
+### Keyboard Navigation
+
+Each node MUST be a single tab stop, in the payload's node order — terminals first, target last — so that tab order follows the build order rather than the layout's visual arrangement.
+
+Enter or Space MUST open a node's control. Escape MUST close it. All controls within it MUST be reachable and operable by keyboard, including the base assignment.
+
+### Focus Management
+
+The node control MUST trap focus while open, MUST move focus into itself on open, and MUST return focus to the node that opened it on close.
+
+#### Scenario: Tab order is the domain's order
+
+- **WHEN** a player tabs through the canvas from the first node
+- **THEN** focus visits nodes in the payload's order, terminals first and target last
+
+#### Scenario: Focus returns to its origin
+
+- **WHEN** a node's control is opened and then dismissed with Escape
+- **THEN** focus returns to that node
+
+#### Scenario: A recompute is announced politely
+
+- **WHEN** a method change causes totals to update
+- **THEN** a polite live region announces the change and that totals updated


### PR DESCRIPTION
The dependency-tree surface, and the first spec built on SPEC-0005. Nine requirements, 22 scenarios.

**Stacked on #65** — it references the fractional-display rule that PR clarifies. Review order: #65 → this → #67.

Everything SPEC-0005 requires of a view surface is inherited rather than restated. This spec adds only what is specific to the tree.

## The design predates ADR-0005 by one day

`docs/design/tree-canvas/handoff.md` was authored 2026-08-17; ADR-0005 was accepted 2026-08-18. The prototype's popover offers a binary craft|refine segmented control — which was the whole of a node's choice when it was drawn.

ADR-0005 changed that. A node now resolves to one *recipe* as well as one method, alternatives are the common case (261 of 403 refiner output/method pairs have more than one), and the ADR assigns the view the job of surfacing them: *"The view surfaces the alternatives per node and the player may pick another."* Nothing in the design covers this.

The gap is not small. Sodium Nitrate carries 26 refine recipes; the largest cooked output carries 61. A segmented control is right for two options and wrong for twenty-six.

So REQ "Recipe Selection" requires the capability and the constraints it must hold under — usable at the sizes the real data produces, alternatives distinguishable by what they consume and yield rather than by identifier — and **defers the control's form to the design**. Same judgement SPEC-0005 made on fractional typography, for the same reason: specifying a visual form the design has never drawn is how a spec acquires a requirement no one validated.

REQ "Yield and Application Display" has the same shape. The node's `yield` and `applications` fields also postdate the prototype, and `applications` is exact and unrounded — making this the first surface where a non-integer domain figure reaches a screen, which is exactly the question #65 defers.

## What the boundary already provides

Checked before writing, and it is more complete than the design assumes. `internal/bridge` already encodes `legalMethods`, `legalRecipes`, `yield`, `applications`, `terminal`, `verified` and per-edge `perUnit`/`yield` on every node, and SPEC-0002 REQ "Recipe Selection Crossing" already requires the view be able to offer alternatives without reading the artifact. What the canvas needs, the boundary sends.

## Two things worth a reviewer's attention

**Layout geometry is carved out of the no-arithmetic rule, explicitly.** A layout engine is arithmetic on the view side producing numbers, and read literally SPEC-0005 appears to forbid it. The carve-out draws the line at what the computation *reads* — structure yes, quantities no — with an observable test: changing target quantity must not move the graph. Stating it costs less than having the argument at review time on every surface, but it is a place where a rule gains an exception, so it is worth pushing on.

**Tab order is the payload's node order, not the layout's.** This turned out to be already agreed three layers deep: the handoff asked for topological order, SPEC-0002 REQ "Determinism Across the Boundary" guarantees it survives encoding, and `EncodeGraph`'s own comment says the adapter deliberately does not re-sort because re-deriving it "would be a second place for it to drift." So the accessibility requirement and the no-computation requirement turn out to be the same requirement. The trade-off: tab order will not follow visual position. For a dependency graph that is the right way round, but it is a deliberate divergence from usual guidance and is stated so it is not later "fixed".

## Two dependencies recorded rather than worked around

**Leaf assignment is blocked on #64.** Assignment reaches the domain through stage 2, and `Module.Rollup` is still a reserved stub. The spec forbids the obvious escape — reaching past the boundary for the domain's rollup types, which are in the same repository and would work, and would put domain knowledge in the render layer that ADR-0003 and ADR-0004 both exist to keep out.

**The provenance badge cannot be validated against real data.** I probed it: resolving `ULTRAPROD2` against `data/tier1.json` returns **36 nodes, 0 unverified**, because the normalizer never emits `"verified": false`. The domain supports the flag, the boundary carries it, the design drew the badge, and nothing triggers it today. It must be built against a fixture — and the fixture should exercise the *propagated* form, because SPEC-0001 REQ "Provenance Propagation" taints every ancestor. The design tuned "subtle, honest, non-alarming" against two chips in a prototype; the real shape is a connected span up to the target.

## Reviewer notes

- Docs only. No code changes, nothing to run.
- Status `draft`, no epic. `/sdd:plan` would produce a story for the recipe control that nobody can start — it is design-blocked, not code-blocked.
- Structural checks run: 9 requirements each with ≥1 scenario, 22 scenarios all at `####`, all five frontmatter edge targets resolve, all relative links resolve.

Part of SPEC-0006

🤖 Generated with [Claude Code](https://claude.com/claude-code)
