### PR TITLE
docs: add SPEC-0007 base planner card

### DIFF
--- a/docs/openspec/specs/base-planner-card/design.md
+++ b/docs/openspec/specs/base-planner-card/design.md
@@ -1,0 +1,172 @@
+# Design: Base Planner Card
+
+## Context
+
+The base planner card is where the plan stops being a graph and becomes instructions: this many plants in this many biodomes, this many extractors at this class, this much power short and this many generators to fix it.
+
+Its upstream is unusually complete. SPEC-0001's stages 2 and 3 are merged and cover every producer type the design draws — farm, extractor, ranch and kitchen — along with byproduct offsets, supply depots, per-base nutrient processors and pellet feeders, growth and cycle and fill durations, generation and draw, batteries for solar night coverage, and the additional-generator count that turns a deficit into an action. Very little of what this card displays needs new domain work.
+
+What it needs is a boundary. `Module.Rollup` and `Module.Power` are reserved stubs returning a not-implemented envelope, so none of stage 2 or stage 3 currently crosses into JavaScript. Issue #64 covers wiring them. Unlike the tree canvas, where the dependency blocks one interaction, here it blocks the entire surface: a card with no rollup payload has nothing to show.
+
+The design references are two prototypes rather than one. `Base Planner.dc.html` is the checklist, power and environment reference. `Base Planner v2.dc.html` is a manager view, adding a checkable build list with a progress bar, a storage tracker, an environment strip with biome and sentinel and economy detail, collapsible sections, a mini power-grid diagram, notes with tags, a screenshot slot, a target switcher, and an 8-bit restyle that squares every corner and swaps the display font. The handoff is explicit that its numbers are illustrative and production reads game data, so no figure in it is treated as normative here.
+
+**The gap this spec is mostly about is not in the design or the domain, but between them.** The card as drawn shows three kinds of information, and only one of them has a source.
+
+*Plan output* — every count, quantity, duration and power figure — comes from stages 2 and 3, and exists.
+
+*Base identity and environment* — the base's name, its planet type and biome, its hazards, its sentinel level and economy and star class, its portal address — comes from nowhere. `BaseID` is a bare string. The Tier 1 artifact carries recipes, items and economy constants and nothing about a place. This is save-file data, which ADR-0002 decided would be imported client-side and which has no specification.
+
+*Durable player data* — which construction items have been ticked off, how much of each resource is already stocked, notes and tags, a screenshot, a player-chosen base name — also comes from nowhere, and is a genuinely new category. It is not plan state: it is not derived from the graph, and a screenshot does not belong in a URL hash. It is not the interface state SPEC-0005 permits the view to hold, which is enumerated as selection, section collapse, form inputs, focus and view-local preferences. It needs a decision about where it lives before any of it can be built.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Render one base's construction instructions faithfully from the stage 2 and stage 3 payloads
+- Give the player the configuration the domain accepts — extractor class and fill duration per site, generator count and class, panel count — and recompute through the domain for all of it
+- Make a power deficit an action, including the case where it cannot yet be sized
+- Keep every figure the domain's, including the durations whose unit is not yet confirmed
+- Draw the line at data with no source, so the card cannot quietly invent it
+
+### Non-Goals
+
+- The panel around the cards: header strip, route bar, target switcher, unassigned bin, atlas link. Shell furniture, and the shell has no spec
+- The base atlas surface, and the tree canvas (SPEC-0006)
+- Save-file import (ADR-0002), which is where base environment data would come from
+- Deciding where durable player data lives. This spec establishes that it has no home and constrains the card accordingly; choosing one is an architectural decision, not a view requirement
+- Choosing between the v1 and v2 visual treatments
+
+## Decisions
+
+### The card is the unit; the panel is not
+
+**Choice**: Specify the per-base card and name the chrome around it as shell.
+
+**Rationale**: The card is the part with a domain payload behind it — one base, one `BaseBuild`, one `PowerBudget`. The panel's contents are a different kind of thing: a route between bases, a switcher between whole plans, a bin of unplaced leaves. They arrange cards and coordinate with other surfaces, which is what a shell does. Splitting here means this spec can be complete while the shell is still unspecified, rather than becoming partly a shell spec and blocking on questions the card does not need answered.
+
+**Trade-off**: The unassigned bin sits awkwardly on the line — visually a peer of the cards, structurally the grouping's leftovers rather than a base. Left to the shell because it is about what the plan has *not* placed, which is a panel-level fact.
+
+### Absent data is absent
+
+**Choice**: The card must render completely from the plan payloads and the base identifier alone. Environment metadata is omitted when unavailable rather than shown as a placeholder, and no control may imply persistence that does not exist.
+
+**Rationale**: This is the central decision, and it is a refusal rather than a feature. The prototype is populated: every card has a planet type, a hazard note, a portal address, notes, a screenshot slot, and stocked-versus-needed bars. None of it has a source, and all of it is convincing. A card built to match the prototype will acquire sample values, and sample values that survive into a build are indistinguishable from real ones — which is the failure mode this project has recorded repeatedly, in the PSARC label, in the Tier 2 "confirmed absent" finding, and in ADR-0001's node counts that turned out to be the fixture's.
+
+The persistence half matters more than it first appears. A checkbox that ticks and a note that types are trivial to build and feel finished, and the data evaporates on reload. That is worse than the feature's absence: it teaches the player their work is saved. Forbidding the control until a store exists keeps the gap visible instead of shipping something that quietly loses data.
+
+**Alternatives considered**:
+- *Show placeholders and mark them clearly*: rejected. A marked placeholder is still a value on screen, and the mark is the first thing lost in a later restyle.
+- *Hold the durable data in view state for the session*: rejected as the failure above.
+- *Specify a store here*: rejected as out of scope. Where durable player data lives is an architectural decision with consequences beyond this card, and deciding it inside a view spec is how a decision ends up with no ADR.
+
+### Power sources are counts, not a mode
+
+**Choice**: The card configures electromagnetic generator count, generator class, and solar panel count independently, rather than offering a source-type toggle.
+
+**Rationale**: The domain already answered this. `PowerConfig` carries `EMGenerators`, `EMClass` and `SolarPanels` as three independent values on one base, so a base running both is a configuration the engine accepts and computes. The prototype's EM|SOLAR toggle cannot express it, and the handoff's own open questions say as much — "production likely needs a generator list instead of a type toggle." The design guessed, the domain decided, and they agree.
+
+Solar's classlessness follows from the same place: the domain scales electromagnetic output by hotspot class and does not scale solar at all, so a class control beside the panel count would imply arithmetic the engine does not perform.
+
+### A deficit that cannot be sized is still a deficit
+
+**Choice**: The card presents the unsized-fix state explicitly — deficit shown, fix stated as needing a generator class — rather than treating it as either a normal deficit or an absence of one.
+
+**Rationale**: The domain models this state deliberately. `PowerBudget.FixUnsized` exists with the comment that a base you cannot yet cost is not a base you should be unable to see. The design has no such state: its deficit is always a sized, clickable fix. An implementer working from the prototype alone would meet a budget in deficit with `AdditionalGenerators` of zero and reasonably conclude there was nothing to show.
+
+The related prohibition — that the card must not compute a solar fix — closes the other end. `AdditionalGenerators` is electromagnetic only, while the prototype's fix button offers panels as well. The panel count the design implies is not a number the domain reports, and computing it in the view would be exactly the arithmetic SPEC-0005 forbids.
+
+### Durations are estimates, because the unit is not confirmed
+
+**Choice**: Every duration on the card is presented as an estimate, and the card performs no unit conversion.
+
+**Rationale**: `Constants.ExtractorRate` records the problem in its own comment: the extractor part carries a rate of 100 against a storage of 360,000, which fills in 3,600 of whatever those units are — an hour if the rate is per second, and the artifact does not say. The engine is internally consistent either way because callers supply the fill duration in the same unit, but the absolute number is only as right as that reading, and the comment ends by saying it is worth confirming in game before any duration is shown to a user.
+
+This card is where that happens. Fill times, growth times, collection cycles, processing steps and a readiness estimate are all on it, and the prototype shows them as confident figures. Presenting them as estimates costs nothing if the reading turns out right, and avoids stating a wrong hour count as fact if it does not. The conversion prohibition follows: a card that turned seconds into hours would be putting the unconfirmed assumption into the view, where it is furthest from the comment that documents it.
+
+### Provenance is required of the card, and is not yet available to it
+
+**Choice**: The card must mark unverified figures where the payload reports provenance, and must not imply a verified/unverified distinction has been checked where it has not.
+
+**Rationale**: The awkward version of this requirement is the honest one, because stage 2's provenance is incomplete. `PowerBudget` carries `Verified`. No producer row does — not `FarmRow`, `ExtractorRow`, `RanchRow`, `KitchenStep`, `NoBuild`, nor `BaseBuild` — even though `LeafDemand` carries stage 1's provenance into the grouping the producer stage reads. And `Curated` carries no verified dates at all, so SPEC-0001's scenario "a Tier 2 constant used in a producer calculation lacks a verified date" has nothing to evaluate.
+
+That matters here more than anywhere else, because this card is built almost entirely on curated constants: biodome capacity, fauna yield and cycle length, steps per processor, the depot threshold, panels per battery, and processing time are all planner policy or community-sourced rather than read from the tables. A card that marked its power budget while showing every producer count unmarked would be asserting a distinction that was never computed. Stating the requirement as a prohibition on implying the check keeps the card honest until the domain can support the positive form.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph domain["Go domain core (SPEC-0001)"]
+        G["GroupLeaves<br/>leaf → base"]
+        P2["RollupProducers<br/>farm · extractor · ranch · kitchen<br/>byproducts · depots · processors"]
+        P3["ComputePower<br/>generation · draw · batteries<br/>AdditionalGenerators · FixUnsized"]
+    end
+
+    subgraph bridge["WASM adapter (SPEC-0002)"]
+        RB["rollup — RESERVED"]
+        PB["power — RESERVED"]
+    end
+
+    subgraph view["React view (SPEC-0005)"]
+        BC["Boundary client"]
+        CARD["Base planner card (SPEC-0007)"]
+        SEC["Producer sections<br/>+ site config"]
+        POW["Power block<br/>+ deficit action"]
+        FOOT["Build rollup footer"]
+    end
+
+    subgraph nosource["No source exists"]
+        META["Base identity + environment<br/>name · biome · hazards · portal<br/>→ save import, ADR-0002, unspecced"]
+        DUR["Durable player data<br/>ticked items · stock · notes · screenshot<br/>→ no home: not plan state, not view state"]
+    end
+
+    G --> P2 --> RB
+    G --> P3 --> PB
+    RB --> BC
+    PB --> BC
+    BC --> CARD
+    CARD --> SEC
+    CARD --> POW
+    CARD --> FOOT
+    SEC -->|"class · fill duration"| BC
+    POW -->|"generators · class · panels"| BC
+
+    META -.->|"omitted, never faked"| CARD
+    DUR -.->|"no control offered"| CARD
+
+    style RB stroke-dasharray: 5 5
+    style PB stroke-dasharray: 5 5
+    style META stroke-dasharray: 5 5
+    style DUR stroke-dasharray: 5 5
+```
+
+## Risks / Trade-offs
+
+- **The whole surface is blocked on issue #64.** Both payloads it renders cross reserved entry points. Unlike the tree canvas, where the dependency blocks one interaction, here nothing can be built first. → #64 is small and well-scoped, and should land before this spec is planned into stories.
+
+- **The prototype is more finished than the data.** v2 is a convincing manager view, and most of what makes it convincing has no source. The pressure during implementation will be to fill the gaps with something plausible. → REQ "Absent Data Is Absent" is written as a prohibition for that reason, and its scenarios test for the placeholder rather than for the feature.
+
+- **Producer provenance cannot be shown because the domain does not carry it.** Stage 2 drops the provenance stage 1 computed, and no curated constant has a verified date, so SPEC-0001 REQ "Provenance Propagation" has a scenario nothing can satisfy. → The requirement here is written so the card stays honest in the meantime; the domain fix belongs to SPEC-0001 and its implementation, not to this spec.
+
+- **Two design references disagree visually.** v1 and v2 differ in display font, corner treatment, meter rendering and button shadows, and the handoff presents the 8-bit restyle as v2-only with v1 kept as the earlier reference. Neither is marked normative. → Recorded as an open question. Token discipline holds under either, so the ambiguity does not block structural work; it blocks final styling.
+
+- **The card carries a lot of controls.** Class, fill duration, generator count and class, panel count, section collapse, selection, and a deficit action, times however many bases. Each recompute is a boundary crossing. → The focus-stability requirement exists because this is where a naive re-render will be most obviously wrong; a card that loses focus on every configuration change is unusable by keyboard.
+
+## Migration Plan
+
+Greenfield, and gated on one prerequisite.
+
+1. Issue #64 wires `rollup` and `power` into the boundary. Nothing here starts without it.
+2. Static card: identity, producer sections, byproduct rows, and the build footer, rendered from a payload with no controls. This exercises the composition and the no-arithmetic rule first.
+3. The power block, including the deficit action and both the unsized and solar-deficit cases, which are the states most easily missed.
+4. Site and power configuration controls, with recompute through the boundary and the focus-stability behaviour.
+5. Section collapse and card selection.
+
+Steps deferred until a governing decision exists: the checkable build list, storage tracking, notes, the screenshot slot, and base renaming. Steps deferred until save import exists: the environment strip and portal address.
+
+## Open Questions
+
+- **Where durable per-base player data lives.** Ticked items, stocked quantities, notes, tags, screenshots and player-chosen base names are none of plan state, view state, or domain output. This is the largest unanswered question on the surface and probably wants an ADR rather than a spec requirement, since it touches persistence, sharing and save import together.
+- **Which visual treatment is normative, v1 or v2.** Also whether the 8-bit restyle is a theme variant the token layer can express or a separate treatment.
+- **Whether the readiness estimate should account for refining time.** The handoff raises it as an open question and assigns it to the shell, but the figure is displayed on the card, so the card is where a wrong answer is visible.
+- **Whether extractor fill duration is a per-site control or a plan-wide default with per-site override.** The domain models it per site; the design exposes it only through a global tweak, which is a third arrangement that matches neither.
+- **How a base with no configured power source should read.** The domain reports zero generation and a deficit equal to draw. Whether that is a deficit to fix or an unconfigured base to set up is a presentation question the design did not face, because every prototype base was configured.

--- a/docs/openspec/specs/base-planner-card/spec.md
+++ b/docs/openspec/specs/base-planner-card/spec.md
@@ -1,0 +1,313 @@
+---
+status: draft
+date: 2026-08-20
+implements: [ADR-0004]
+requires: [SPEC-0001, SPEC-0002, SPEC-0005]
+---
+
+# SPEC-0007: Base Planner Card
+
+## Graph Edges
+
+- **Implements:** [ADR-0004](../../../adrs/ADR-0004-react-view-layer.md) — the React view layer this surface belongs to
+- **Requires:** [SPEC-0001](../rollup-engine/spec.md) — producer rollup and power computation, stages 2 and 3
+- **Requires:** [SPEC-0002](../wasm-boundary/spec.md) — the payloads this card renders and the configuration it sends back
+- **Requires:** [SPEC-0005](../view-foundations/spec.md) — tokens, styling discipline, the no-arithmetic rule, the boundary client, and state boundaries, inherited rather than restated
+
+## Overview
+
+One card per base, turning the tree's leaf assignments into construction instructions: what to plant, extract, ranch, cook, build and power at that base.
+
+This spec covers **the card**. The panel that arranges cards — the header strip, the harvest-run route bar, the target switcher, the unassigned bin, and the link to the base atlas — is application-shell furniture and belongs with the shell surface, which has no spec yet. Where the card needs something from that chrome, this spec names the dependency rather than absorbing the chrome.
+
+Everything SPEC-0005 requires of a view surface is inherited and not restated. This spec adds what is specific to the card.
+
+The design references are `docs/design/base-planner/handoff.md` with two prototypes: v1, the checklist/power/environment reference, and v2, a manager view adding a checkable build list, storage tracking, notes, a screenshot slot, collapsible sections and an 8-bit restyle. The handoff marks its own quantities illustrative — "production reads game data" — so no numeric value in it is treated here as normative.
+
+Three things this card displays have no source in anything built or specified: base identity metadata, durable per-base user data, and provenance on producer figures. Each is specified below as a constraint on what the card may do without them, rather than as a feature waiting on them.
+
+## Requirements
+
+### Requirement: Card Composition From the Build Payload
+
+Each card MUST be composed from the stage 2 and stage 3 payloads for its base, obtained through the SPEC-0005 boundary client. The card MUST NOT aggregate, total, or reconcile figures across bases, and MUST NOT derive one base's figures from another's.
+
+Where a figure the card displays is a count the domain reports — plants, biodomes, extractors, depots, fauna, nutrient processors, pellet feeders, additional generators, batteries — the card MUST render the domain's value. It MUST NOT compute a count from a quantity and a rate, even where both are present in the payload.
+
+Counts the domain reports per base MUST NOT be re-derived per row. Nutrient processors and pellet feeders are base-level figures; summing per-row values would overcount whenever a base carries more than one step or more than one fed fauna row.
+
+#### Scenario: Every count is the domain's
+
+- **WHEN** a card renders a farm row showing plants and biodomes
+- **THEN** both numbers came from the payload, and neither was computed in the view from a quantity and a yield
+
+#### Scenario: Base-level counts stay base-level
+
+- **WHEN** a base carries three kitchen steps
+- **THEN** the card shows the base's reported nutrient processor count once, and does not sum a per-step figure
+
+### Requirement: Base Identity and Selection
+
+A card MUST identify its base by name as the primary identifier, with the base's colour as reinforcement rather than as the sole carrier of identity.
+
+The card's frame is reserved for base identity. Selection MUST be rendered as an inboard ring using an overlay element, leaving the identity frame intact — SPEC-0005 REQ "Component Styling Discipline" already forbids the inset box-shadow this rules out.
+
+A card MUST be selectable using a control with the correct semantics for a selection, operable by keyboard. A generic element given a tab index MUST NOT be used.
+
+#### Scenario: Identity survives selection
+
+- **WHEN** a card is selected
+- **THEN** its base-colour frame is unchanged and the selection is shown by an inboard ring
+
+#### Scenario: Colour is not the only identity
+
+- **WHEN** base colours are not perceivable
+- **THEN** each card remains identifiable by its name
+
+### Requirement: Producer Sections
+
+A card MUST present its construction rows grouped by producer type, covering every producer type the payload reports for that base: farm, extractor, ranch and kitchen.
+
+Each row MUST state what is built and how much is required. A row MUST NOT present only the required quantity, since the quantity is the demand and the count is the instruction.
+
+Where the payload reports a range rather than a single value — a crop's yield per plant is a range, and counts are sized on its pessimistic bound — the card MUST NOT present the optimistic bound as the planning figure.
+
+#### Scenario: Every reported producer type appears
+
+- **WHEN** a base's payload carries farm, extractor, ranch and kitchen rows
+- **THEN** the card presents all four groups
+
+#### Scenario: The instruction is shown, not just the demand
+
+- **WHEN** a farm row requires a quantity of a crop
+- **THEN** the card shows the plants and biodomes to build, not the required quantity alone
+
+### Requirement: Site Configuration
+
+A card MUST expose the site's extractor class as a per-site control, not a per-row one. Extractors at one base share a hotspot, so a per-row class would express a configuration the domain does not model.
+
+A card MUST expose the site's fill duration, since extractor counts are sized to it and a count shown without the patience it assumes is not interpretable.
+
+Changing either MUST recompute through the boundary. The card MUST NOT adjust counts, fill times or power draw itself.
+
+#### Scenario: Class is a site control
+
+- **WHEN** a base has three extractor rows
+- **THEN** one class control governs all three, and no row carries its own
+
+#### Scenario: Reconfiguration recomputes through the domain
+
+- **WHEN** the extractor class changes
+- **THEN** new counts, fill times and draw figures come from a boundary call
+
+### Requirement: Byproducts Are Shown, Not Omitted
+
+Where the payload reports an item's demand as covered by another producer's byproduct at the same base, the card MUST show that item with its demand and what covers it, marked as requiring no construction.
+
+Such an item MUST NOT be omitted from the card. An absent row is indistinguishable from an overlooked requirement, and the fact that a demand is already met is a planning result rather than the absence of one.
+
+#### Scenario: A covered demand is visible
+
+- **WHEN** condensed carbon demand at a base is covered by a gas refine's byproduct
+- **THEN** the card shows the item, its demand, and the producer covering it, marked as needing nothing built
+
+### Requirement: Power Position
+
+A card MUST show its base's generation and draw, and MUST make the relationship between them legible — whether the base is in surplus or deficit, and by how much.
+
+Generation, draw and the resulting balance MUST be rendered from the payload's exact values under SPEC-0005 REQ "The View Computes No Domain Values". The card MUST NOT compute a balance, a percentage, or a meter proportion from the two figures as displayed; where a proportional indicator is drawn, it is presentation of values the domain reported, and any numeric figure shown alongside it MUST be the domain's.
+
+A deficit MUST be conveyed by more than colour, carrying a symbol and the shortfall as a stated quantity.
+
+#### Scenario: The balance is the domain's
+
+- **WHEN** a card shows a base in deficit
+- **THEN** the shortfall figure came from the payload and was not computed in the view
+
+#### Scenario: Deficit is not colour alone
+
+- **WHEN** a base is in deficit
+- **THEN** the state carries a symbol and the shortfall as text alongside any colour treatment
+
+### Requirement: Power Configuration Supports Mixed Sources
+
+A card MUST allow a base's electromagnetic generator count, its generator class, and its solar panel count to be configured independently. The domain models all three as separate values on one base, so a control admitting only one source type at a time cannot express a configuration the domain accepts.
+
+Solar MUST NOT be presented as carrying a class. The domain's solar output is classless, and offering a class control for it would imply a computation the domain does not perform.
+
+Where solar panels are configured, the card MUST show the batteries the domain reports for night coverage.
+
+#### Scenario: A base runs both sources
+
+- **WHEN** a base is configured with electromagnetic generators and solar panels together
+- **THEN** the card accepts the configuration and shows the resulting generation
+
+#### Scenario: Solar carries no class
+
+- **WHEN** the solar panel count is configured
+- **THEN** no class control is offered for it
+
+### Requirement: Deficit Is an Action, Including When It Cannot Be Sized
+
+Where the payload reports additional generators that would clear a deficit, the card MUST present that fix as an action stating the count, the unit type, and the resulting position, rather than as a warning to interpret.
+
+Where the payload reports that the fix cannot be sized because no generator class is configured, the card MUST still present the deficit and MUST state that the fix needs a class before it can be costed. It MUST NOT hide the deficit, and MUST NOT present an unsized fix as an actionable count.
+
+The card MUST NOT size a fix the domain did not report. Where a deficit exists at a base whose generation is solar, and the payload reports no sized fix, the card MUST NOT compute a panel count of its own.
+
+#### Scenario: A sized fix is an action
+
+- **WHEN** the payload reports additional generators clearing a deficit
+- **THEN** the card offers an action naming the count and type, and states the position it produces
+
+#### Scenario: An unsized fix is still a visible deficit
+
+- **WHEN** a base is in deficit and no generator class is configured
+- **THEN** the deficit is shown, and the fix is stated as needing a class rather than offered as a count
+
+#### Scenario: No fix is invented
+
+- **WHEN** a solar base is in deficit and the payload reports no sized fix
+- **THEN** the card offers no computed panel count
+
+### Requirement: Build Rollup Footer
+
+A card MUST carry a rollup of everything to be constructed at that base, drawn from the same payload as the sections above it.
+
+Items pending because of an unresolved deficit MUST be distinguished from items that are simply not yet built.
+
+The card MUST NOT present a completion figure it cannot source. A count of built versus total requires durable per-base state this project does not yet have, and a footer showing a fraction of items complete MUST NOT be rendered against state the card invented for the session.
+
+#### Scenario: The footer agrees with the sections
+
+- **WHEN** the footer lists constructed items
+- **THEN** every item corresponds to a row in the card's sections, and no item was added by the footer
+
+#### Scenario: A pending deficit is distinguishable
+
+- **WHEN** a base has an unresolved power deficit
+- **THEN** the generators it implies are shown as pending, distinct from unbuilt items
+
+### Requirement: Duration Display
+
+Where the card shows a duration — a fill time, a growth time, a collection cycle, a processing step, or a base's readiness estimate — it MUST present it as an estimate rather than as a precise figure.
+
+The domain's own rate constants do not state their time unit; the artifact does not record it, and the engine's arithmetic is consistent under either reading while its absolute durations are not. This card is the first surface at which those durations become visible to a player, so it MUST NOT present them with a precision the underlying data does not support.
+
+The card MUST NOT convert a duration into a different unit by arithmetic of its own. Where a duration is displayed in a unit other than the payload's, the conversion is a domain concern.
+
+#### Scenario: A duration reads as an estimate
+
+- **WHEN** a card shows an extractor fill time
+- **THEN** it is presented as an estimate, not as an exact figure
+
+#### Scenario: No unit conversion in the view
+
+- **WHEN** a duration crosses the boundary in one unit and is displayed in another
+- **THEN** the converted value came from the domain, not from arithmetic in the card
+
+### Requirement: Provenance on Displayed Figures
+
+Where a figure the card displays is reported as not verified, the card MUST mark it, using the same treatment as elsewhere in the view and without styling it as an error.
+
+Several of this card's figures rest on constants that are planner policy or community-sourced rather than read from the game tables. Where the payload reports provenance for such a figure, the card MUST surface it. Where the payload reports no provenance for a figure whose derivation includes such a constant, the card MUST NOT present that figure as verified by displaying it unmarked alongside marked ones in a way that implies the distinction was checked.
+
+#### Scenario: An unverified figure is marked
+
+- **WHEN** the payload reports a base's power budget as not verified
+- **THEN** the card marks it, and does not style it as an error condition
+
+### Requirement: Absent Data Is Absent
+
+A card MUST render completely and correctly using only the plan payloads and the base identifier.
+
+Base environment and location details — planet type, biome, hazards, sentinel level, economy, star class, and portal address — have no source in the Tier 1 artifact, the domain, or any accepted specification. The card MUST NOT display placeholder, sample, or invented values for any of them. Where such a detail is not available, the card MUST omit it rather than showing a stand-in.
+
+Durable per-base user data — construction items ticked off, stocked quantities, notes, tags, screenshots, and player-assigned base names — is neither plan state nor the interface state SPEC-0005 REQ "View State Boundaries" permits the view to hold. The card MUST NOT persist such data, and MUST NOT present a control implying persistence, until a governing decision establishes where it lives.
+
+#### Scenario: Missing metadata is omitted, not faked
+
+- **WHEN** no environment data is available for a base
+- **THEN** the card renders without the environment details and shows no placeholder values
+
+#### Scenario: No control implies unavailable persistence
+
+- **WHEN** the card is rendered
+- **THEN** it offers no control whose effect would be to persist per-base user data, since no store for it exists
+
+## Security Requirements
+
+This capability is part of a browser-rendered client application. It ships as static assets and a WASM module, with no server component, no accounts, and no HTTP endpoints of its own. Each topic below is recorded with its applicability so an uncovered topic is visible rather than absent.
+
+### Authentication
+
+Not applicable. This capability defines no endpoints and no protected resources.
+
+### Rate Limiting
+
+Not applicable. All computation is local and player-invoked; there is no shared resource to exhaust.
+
+### Security Headers
+
+Deferred to the application shell, which owns document delivery. This capability contributes no headers, introduces no requirement for inline script or `eval`, and MUST NOT weaken any policy the shell sets.
+
+### Request Body Size Limits
+
+Applicable if and only if the screenshot slot is built. An image accepted by drag-and-drop is untrusted input from the player's disk, and a size limit MUST be enforced before the file is read into memory, with an over-limit file refused rather than partially processed — the same discipline SPEC-0005 requires of save-file import. REQ "Absent Data Is Absent" defers the feature until a store exists; this requirement governs it when it arrives.
+
+An accepted image MUST NOT be rendered by interpreting its contents as markup, and MUST NOT be carried in plan state or the URL hash.
+
+### CSRF Protection
+
+Not applicable. There are no state-changing requests; recomputation is an in-process call across the WASM boundary.
+
+### Redirect Validation
+
+Plan state arrives in the URL hash, which is untrusted input. [SPEC-0005](../view-foundations/spec.md) § Security Requirements → Redirect Validation already governs it, and this capability inherits those rules and adds no redirect of its own.
+
+Base names, notes and tags, if a store for them is ever established, are player-authored text and MUST be rendered as text. This capability MUST NOT introduce a path that renders any such value as markup.
+
+## Accessibility Requirements
+
+This spec involves user-facing UI. The following are MANDATORY per WCAG 2.1 AA, and add to SPEC-0005's baseline — including its token contrast constraints — which is not restated here.
+
+### WCAG 2.1 AA Compliance
+
+All UI components produced by this spec MUST meet WCAG 2.1 Level AA conformance as the minimum accessibility target.
+
+### ARIA Landmarks
+
+The set of cards MUST be exposed as a single navigable region, so a screen-reader user can move past the whole build list without traversing every row of every base.
+
+### Icon-Only Controls
+
+Every icon-only control MUST carry an `aria-label`. Producer-type and status glyphs MUST NOT be the sole accessible name of anything; each is accompanied by its text label.
+
+### Dynamic Content Regions
+
+A configuration change — extractor class, fill duration, generator count or class, panel count — and any deficit fix MUST be announced through an `aria-live="polite"` region naming what changed and that figures updated. Announcements MUST NOT be `assertive`: a recompute is the expected result of the player's own action.
+
+Where a copy-to-clipboard control exists, its success MUST be announced politely.
+
+### Keyboard Navigation
+
+Card selection, every configuration control, every collapsible section, and the deficit fix MUST be reachable and operable by keyboard. A collapsed section MUST expose its state to assistive technology, and its one-line summary MUST be available without expanding it.
+
+### Focus Management
+
+Focus MUST remain stable across a recompute: a control that triggers new figures MUST retain focus once they arrive, so a change does not send focus to the top of the card. Where a recompute removes the focused control, focus MUST move to a documented, predictable destination rather than being lost to the document body.
+
+#### Scenario: Focus survives a recompute
+
+- **WHEN** the extractor class is changed and new figures arrive
+- **THEN** focus remains on the class control
+
+#### Scenario: A collapsed section is legible when closed
+
+- **WHEN** a producer section is collapsed
+- **THEN** its summary and its collapsed state are available to assistive technology without expanding it
+
+#### Scenario: A fix is announced politely
+
+- **WHEN** the deficit fix is applied
+- **THEN** a polite live region states the generators added and the resulting power position


### PR DESCRIPTION
The per-base build-checklist card — what to plant, extract, ranch, cook, build and power at one base. Twelve requirements, 26 scenarios.

**Stacked on #65** — it inherits the token contrast constraints that PR adds. Sibling of #66, not dependent on it (the only mention of SPEC-0006 is one Non-Goals line).

## Scope: the card, not the panel

The header strip, harvest-run route bar, target switcher, unassigned bin and atlas link are shell furniture, and the shell has no spec. The card is the part with a domain payload behind it — one base, one `BaseBuild`, one `PowerBudget`. Splitting there means this spec can be complete while the shell is still unspecified, rather than becoming half a shell spec and blocking on questions the card does not need answered.

## The upstream is in better shape than the design assumes

SPEC-0001 stages 2 and 3 already cover every producer type the design draws — farm, extractor, ranch, kitchen — plus byproduct offsets, supply depots, per-base nutrient processors and pellet feeders, growth and cycle and fill durations, generation and draw, batteries for solar night coverage, and the additional-generator count that turns a deficit into an action. Very little here needs new domain work.

What it needs is a boundary. `Module.Rollup` and `Module.Power` are reserved stubs, so neither payload crosses into JavaScript. **Unlike #66, where #64 blocks one interaction, here it blocks the whole surface** — a card with no rollup payload has nothing to show.

## Three places the design and the domain disagree

All resolved toward the domain, all verified against the code:

**Power sources are counts, not a mode.** `PowerConfig` carries `EMGenerators`, `EMClass` and `SolarPanels` as three independent values on one base, so a base running both is a configuration the engine accepts and computes. The prototype's EM|SOLAR toggle cannot express it — and the handoff's own open questions already guessed this: *"production likely needs a generator list instead of a type toggle."* The design guessed, the domain decided, they agree.

**`FixUnsized` is a state the design never drew.** In deficit with no generator class configured, the domain reports the deficit with an uncostable fix, deliberately — the field's comment reads that a base you cannot yet cost is not a base you should be unable to see. The design's deficit is always a sized, clickable button. An implementer working from the prototype alone would meet `AdditionalGenerators: 0` and reasonably conclude there was nothing to show.

**The solar fix is not computed.** `AdditionalGenerators` is electromagnetic only, while the prototype's fix button offers `+ n × Solar Panel`. That panel count is not a number the domain reports, and computing it in the view is exactly the arithmetic SPEC-0005 forbids.

## The central requirement is a refusal

The card shows three kinds of information and only one has a source.

*Plan output* — every count, quantity, duration and power figure — comes from stages 2 and 3 and exists.

*Base identity and environment* — name, planet type, biome, hazards, sentinel level, economy, star class, portal address — comes from nowhere. `BaseID` is a bare string; the Tier 1 artifact carries recipes, items and economy constants and nothing about a place. That is save data (ADR-0002, unspecced).

*Durable player data* — ticked construction items, stocked quantities, notes, tags, screenshots, player-chosen base names — is a genuinely new category. Not plan state: not derived from the graph, and a screenshot does not belong in a URL hash. Not the interface state SPEC-0005 REQ "View State Boundaries" permits, which is enumerated as selection, section collapse, form inputs, focus and view-local preferences.

REQ "Absent Data Is Absent" prohibits both: omit rather than placeholder, and offer no control implying persistence that does not exist. The persistence half matters more than it first appears — a checkbox that ticks and a note that types are trivial to build, feel finished, and evaporate on reload. That is worse than the feature's absence, because it teaches the player their work is saved.

The prototype is populated and convincing, and none of it has a source. The scenarios test for the placeholder rather than for the feature, deliberately.

## Durations are specified as estimates

`Constants.ExtractorRate` records the problem in its own comment: the extractor part carries rate 100 against storage 360,000, which fills in 3,600 of whatever those units are — an hour if the rate is per second, and the artifact does not say. The engine is consistent either way because callers supply the fill duration in the same unit, but the absolute number is only as right as that reading, and the comment ends by saying it is worth confirming in game *before any duration is shown to a user*. This card is where that happens.

## One finding filed separately, not fixed here

SPEC-0001 REQ "Provenance Propagation" carries a scenario nothing can satisfy:

> **WHEN** a Tier 2 constant used in a producer calculation lacks a verified date
> **THEN** the resulting producer count is marked unverified

Neither half is implementable. No producer-stage type carries provenance — `grep -n Verified internal/domain/producer.go` returns nothing, so `FarmRow`, `ExtractorRow`, `RanchRow`, `KitchenStep`, `NoBuild` and `BaseBuild` all lack it — even though `LeafDemand` carries stage 1's provenance forward into the grouping the producer stage reads. And `Curated` carries no verified dates at all, so "lacks a verified date" has nothing to evaluate. `PowerBudget.Verified` works, so stage 3 is fine and stage 2 is the gap.

It lands hardest here, because this card is built almost entirely on curated constants — biodome capacity, fauna yield and cycle, steps per processor, depot threshold, panels per battery, processing time — none of which come from the game tables. A card that marked its power budget while showing every producer count unmarked would assert a distinction that was never computed. So REQ "Provenance on Displayed Figures" is phrased as a prohibition on *implying the check was made*, which is the honest form until the domain can support the positive one.

That is drift on a spec marked `implemented`, and it is a domain fix rather than a view one, so it is filed rather than folded in.

## Reviewer notes

- Docs only. No code changes, nothing to run.
- Status `draft`, no epic. Blocked on #64 for the entire surface, so `/sdd:plan` is premature.
- The two design references (v1, and v2's 8-bit restyle) disagree on display font, corner treatment, meter rendering and button shadows, and neither is marked normative. Recorded as an open question — token discipline holds under either, so it blocks final styling rather than structural work.
- Structural checks run: 12 requirements each with ≥1 scenario, 26 scenarios all at `####`, all four frontmatter edge targets resolve, all relative links resolve.

Part of SPEC-0007

🤖 Generated with [Claude Code](https://claude.com/claude-code)