### PR TITLE
feat(bridge): wire rollup and power into the boundary

### DIFF
--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -31,7 +31,14 @@ import (
 // whenever the envelope shape, the encoding of quantities, or the sentinel
 // code set changes." The consuming view checks it and refuses a mismatch
 // rather than parsing an unexpected shape.
-const ContractVersion = "1.0.0"
+//
+// 1.1.0 added the build and power result payloads when stages 2 and 3 were
+// wired. The envelope's four keys, the exactly-one-of invariant, the
+// quantity encoding and the code set are all unchanged, so the addition is
+// backward compatible in shape — but the result payload is part of what a
+// consumer parses, and leaving two different payloads claiming one version
+// is the drift the requirement exists to prevent.
+const ContractVersion = "1.1.0"
 
 // Quantity is an exact quantity on the wire.
 //
@@ -90,8 +97,14 @@ type Envelope struct {
 }
 
 // ResultPayload is the success half.
+//
+// One field per stage, each omitempty, so a stage's result is present or
+// absent rather than present-and-empty. Exactly one is set by any entry
+// point this package exposes.
 type ResultPayload struct {
 	Graph *Graph `json:"graph,omitempty"`
+	Build *Build `json:"build,omitempty"`
+	Power *Power `json:"power,omitempty"`
 }
 
 // ErrorPayload is the failure half.

--- a/internal/bridge/module.go
+++ b/internal/bridge/module.go
@@ -105,24 +105,112 @@ func (m *Module) Resolve(planJSON string) Envelope {
 	return Success(ResultPayload{Graph: wire})
 }
 
-// Rollup and Power are RESERVED for stages 2 and 3.
+// Rollup runs stage 2 and returns one envelope carrying every base's
+// construction instructions.
 //
 // Governing: SPEC-0002 REQ "Boundary Surface" — "WHEN rollup or power is
 // added in a later stage THEN it accepts and returns the same envelope
 // shape defined by REQ 'Result Envelope', with no bespoke calling
-// convention."
+// convention." The signature, the envelope and the error vocabulary are
+// Resolve's, unchanged.
 //
-// Declared now, with the same signature as Resolve, so the shape is fixed
-// before there is an implementation to bend it around. Each returns a
-// not-ready failure until its stage is wired: a reserved name that returns
-// undefined would be indistinguishable from a typo on the view's side.
-func (m *Module) Rollup(planJSON string) Envelope { return m.reserved("rollup") }
+// The stage resolves the plan itself rather than accepting a graph the
+// caller hands back. REQ "Boundary Surface" requires one call to perform
+// one complete stage, and a caller obliged to return a previous result
+// would be assembling this one out of two crossings.
+func (m *Module) Rollup(requestJSON string) Envelope {
+	artifact, ok := m.loaded()
+	if !ok {
+		return FailureFrom(fmt.Errorf("rollup: %w", ErrNotReady))
+	}
 
-// Power is RESERVED for stage 3. See Rollup.
-func (m *Module) Power(planJSON string) Envelope { return m.reserved("power") }
+	var req RollupRequest
+	if err := json.Unmarshal([]byte(requestJSON), &req); err != nil {
+		return FailureFrom(fmt.Errorf("%w: %v", ErrMalformedInput, err))
+	}
+	plan, err := DecodePlanStrict(req.Plan)
+	if err != nil {
+		return FailureFrom(err)
+	}
+	curated, err := DecodeCurated(req.Constants)
+	if err != nil {
+		return FailureFrom(err)
+	}
+	grouping, err := DecodeRollupInput(req)
+	if err != nil {
+		return FailureFrom(err)
+	}
+	producers, err := DecodeProducerInput(req)
+	if err != nil {
+		return FailureFrom(err)
+	}
 
-func (m *Module) reserved(name string) Envelope {
-	return FailureFrom(fmt.Errorf("%s is reserved and not yet wired: %w", name, ErrNotReady))
+	constants, err := domain.NewConstants(artifact, curated)
+	if err != nil {
+		return FailureFrom(err)
+	}
+	graph, err := domain.Resolve(artifact, plan)
+	if err != nil {
+		return FailureFrom(err)
+	}
+	grouped, err := domain.GroupLeaves(graph, grouping)
+	if err != nil {
+		return FailureFrom(err)
+	}
+	build, err := domain.RollupProducers(grouped, artifact, constants, producers)
+	if err != nil {
+		return FailureFrom(err)
+	}
+	wire, err := EncodeBuild(build, grouped)
+	if err != nil {
+		return FailureFrom(err)
+	}
+	return Success(ResultPayload{Build: wire})
+}
+
+// Power runs stage 3 and returns one envelope carrying every base's power
+// position.
+//
+// Governing: SPEC-0002 REQ "Boundary Surface"
+//
+// It takes no plan. The domain's power stage costs a set of counts, not a
+// resolved graph — the same figures whether they came from a rollup or from
+// a caller sketching a base by hand — so requiring a plan here would invent
+// a coupling the engine does not have. It still requires a loaded artifact,
+// because the parts and hotspot strengths it reads live in the artifact's
+// economy section.
+func (m *Module) Power(requestJSON string) Envelope {
+	artifact, ok := m.loaded()
+	if !ok {
+		return FailureFrom(fmt.Errorf("power: %w", ErrNotReady))
+	}
+
+	var req PowerRequest
+	if err := json.Unmarshal([]byte(requestJSON), &req); err != nil {
+		return FailureFrom(fmt.Errorf("%w: %v", ErrMalformedInput, err))
+	}
+	curated, err := DecodeCurated(req.Constants)
+	if err != nil {
+		return FailureFrom(err)
+	}
+	in, err := DecodePowerInput(req)
+	if err != nil {
+		return FailureFrom(err)
+	}
+
+	constants, err := domain.NewConstants(artifact, curated)
+	if err != nil {
+		return FailureFrom(err)
+	}
+	budgets, err := domain.ComputePower(constants, in)
+	if err != nil {
+		return FailureFrom(err)
+	}
+	wire, err := EncodePower(budgets)
+	if err != nil {
+		return FailureFrom(err)
+	}
+	return Success(ResultPayload{Power: wire})
 }
 
 // loaded returns the artifact under a read lock.

--- a/internal/bridge/module_test.go
+++ b/internal/bridge/module_test.go
@@ -215,40 +215,6 @@ func TestBadArtifactIsNotAModuleFailure(t *testing.T) {
 	}
 }
 
-// SPEC-0002 REQ "Boundary Surface":
-// WHEN rollup or power is added in a later stage THEN it accepts and returns
-// the same envelope shape, with no bespoke calling convention.
-//
-// RESERVED means the shape is fixed now. Both are declared with Resolve's
-// signature and return a well-formed envelope today, so a view can wire them
-// before they compute anything — and a reserved name that returned undefined
-// would be indistinguishable from a typo.
-func TestReservedStagesShareTheEnvelopeShape(t *testing.T) {
-	m := loadedModule(t)
-
-	for _, name := range []string{"rollup", "power"} {
-		var env bridge.Envelope
-		if err := json.Unmarshal([]byte(m.CallJSON(name, `{"target":"sd","quantity":"1"}`)), &env); err != nil {
-			t.Fatalf("%s returned unparseable output: %v", name, err)
-		}
-		if env.OK {
-			t.Errorf("%s reported success before its stage exists", name)
-		}
-		if env.Error == nil {
-			t.Fatalf("%s returned no error payload — indistinguishable from a typo", name)
-		}
-		if env.Error.Code != bridge.CodeNotReady {
-			t.Errorf("%s code = %q, want %q", name, env.Error.Code, bridge.CodeNotReady)
-		}
-		if !strings.Contains(env.Error.Message, name) {
-			t.Errorf("%s message %q does not name the stage", name, env.Error.Message)
-		}
-		if env.ContractVersion != bridge.ContractVersion {
-			t.Errorf("%s returned a different contract version", name)
-		}
-	}
-}
-
 // A malformed plan reaching an entry point is the caller's problem, and says
 // so rather than crashing the module.
 func TestMalformedPlanAtTheEntryPoint(t *testing.T) {

--- a/internal/bridge/stages.go
+++ b/internal/bridge/stages.go
@@ -1,0 +1,575 @@
+package bridge
+
+import (
+	"fmt"
+
+	"github.com/jonstump/nms-base-planner/internal/domain"
+)
+
+// Stages 2 and 3 on the wire: what a plan builds at each base, and what it
+// costs in power.
+//
+// Governing: ADR-0003 (Go domain, thin adapter), SPEC-0002 REQ "Boundary
+// Surface", REQ "Exact Quantity Encoding", REQ "Result Envelope",
+// REQ "Determinism Across the Boundary"
+//
+// Every rule stage 1 established holds here unchanged, and one of them is
+// load-bearing in a way it was not before. Stages 2 and 3 round: plants,
+// biodomes, extractors, depots, fauna, processors, batteries and the
+// additional-generator fix are all counts that round up at a physical
+// boundary. SPEC-0001 enumerates those boundaries and the domain owns every
+// one of them, so this file reads already-rounded int64s and renders them.
+// It performs no arithmetic at all — not even the subtraction that turns
+// generation and draw into a balance, which is why PowerBudget.Balance()
+// and .Deficit() are called rather than computed here.
+
+// Site is one base's configuration. It crosses inbound as part of a rollup
+// request and outbound on each base's build, so a caller can read back the
+// configuration a result was computed under.
+type Site struct {
+	ExtractorClass string   `json:"extractorClass"`
+	FillSeconds    Quantity `json:"fillSeconds"`
+}
+
+// Curated is the Tier 2 constant set on the wire.
+//
+// Governing: SPEC-0001 design.md "Tier 2 constants injected, never
+// hardcoded" — the engine refuses to default any of these, so they cross
+// with the request rather than living in the module.
+//
+// Every scalar is a Quantity for the same reason node totals are: a count
+// that crosses as a JSON number has left the exactness contract, and a
+// uniform rule is checkable where a per-field judgement is not.
+type Curated struct {
+	BiodomeCropSlots   Quantity `json:"biodomeCropSlots"`
+	FaunaYieldPerCycle Quantity `json:"faunaYieldPerCycle"`
+	FaunaCycleSeconds  Quantity `json:"faunaCycleSeconds"`
+	StepsPerProcessor  Quantity `json:"stepsPerProcessor"`
+	DepotThreshold     Quantity `json:"depotThreshold"`
+	ProcessSeconds     Quantity `json:"processSeconds"`
+	PanelsPerBattery   Quantity `json:"panelsPerBattery"`
+
+	// FaunaProducts and ResourceHotspots are classification rather than
+	// scalars — which leaves come from creatures, and which hotspot
+	// category each extracted resource sits on.
+	FaunaProducts    []string          `json:"faunaProducts,omitempty"`
+	ResourceHotspots map[string]string `json:"resourceHotspots,omitempty"`
+}
+
+// Byproduct declares that one producer's output covers another item's
+// demand at the same base.
+type Byproduct struct {
+	Item string `json:"item"`
+	From string `json:"from"`
+}
+
+// KitchenStepRequest names one processing step the plan calls for.
+type KitchenStepRequest struct {
+	ItemID   string   `json:"itemId"`
+	Recipe   string   `json:"recipe"`
+	Quantity Quantity `json:"quantity"`
+}
+
+// RollupRequest is stage 2's input.
+//
+// It carries the plan rather than a resolved graph: REQ "Boundary Surface"
+// requires one call to perform one complete stage, and a caller obliged to
+// hand back a graph it received would be assembling the stage out of two
+// crossings.
+type RollupRequest struct {
+	Plan        Plan                            `json:"plan"`
+	Assignments map[string]string               `json:"assignments,omitempty"`
+	Sites       map[string]Site                 `json:"sites,omitempty"`
+	Byproducts  map[string][]Byproduct          `json:"byproducts,omitempty"`
+	Kitchen     map[string][]KitchenStepRequest `json:"kitchen,omitempty"`
+	Constants   Curated                         `json:"constants"`
+}
+
+// PowerGeneration is one base's generation setup.
+//
+// Electromagnetic generators and solar panels are independent counts rather
+// than a choice between two modes, because the domain models them that way:
+// a base may run both, and PowerConfig carries all three values at once.
+type PowerGeneration struct {
+	EMGenerators Quantity `json:"emGenerators,omitempty"`
+	EMClass      string   `json:"emClass,omitempty"`
+	SolarPanels  Quantity `json:"solarPanels,omitempty"`
+}
+
+// PowerUnit is a count of one buildable drawing power at a base.
+type PowerUnit struct {
+	PartID string   `json:"partId"`
+	Count  Quantity `json:"count"`
+}
+
+// PowerRequest is stage 3's input.
+//
+// It carries no plan. The domain's power stage takes counts rather than
+// producer rows, so it costs a base sketched by hand exactly as it costs
+// one a rollup produced, and requiring a plan here would invent a coupling
+// the engine does not have.
+type PowerRequest struct {
+	// Sources, not "generation": the response's generation field is a
+	// quantity, and one word meaning a configuration inbound and a figure
+	// outbound is a needless thing for a consumer to hold in mind.
+	Sources map[string]PowerGeneration `json:"sources,omitempty"`
+	Draws   map[string][]PowerUnit     `json:"draws,omitempty"`
+
+	// Unverified names the bases whose contributing figures are not
+	// verified. A list rather than a map to bool: the set is what is meant,
+	// and a map with false values would encode a distinction that is not one.
+	Unverified []string `json:"unverified,omitempty"`
+
+	Constants Curated `json:"constants"`
+}
+
+// Demand is one leaf's requirement on the wire.
+type Demand struct {
+	ItemID   string   `json:"itemId"`
+	Name     string   `json:"name"`
+	Total    Quantity `json:"total"`
+	Verified bool     `json:"verified"`
+}
+
+// YieldRange is a crop's per-plant yield range.
+//
+// Both bounds cross. The domain sizes plant counts on the pessimistic
+// bound, and a view given only that number could not show why.
+type YieldRange struct {
+	Min Quantity `json:"min"`
+	Max Quantity `json:"max"`
+}
+
+// FarmRow is one crop at one base.
+type FarmRow struct {
+	ItemID        string     `json:"itemId"`
+	Name          string     `json:"name"`
+	Required      Quantity   `json:"required"`
+	Plants        Quantity   `json:"plants"`
+	Biodomes      Quantity   `json:"biodomes"`
+	YieldPerPlant YieldRange `json:"yieldPerPlant"`
+	GrowthSeconds Quantity   `json:"growthSeconds"`
+}
+
+// ExtractorRow is one extracted resource at one base.
+type ExtractorRow struct {
+	ItemID   string   `json:"itemId"`
+	Name     string   `json:"name"`
+	Class    string   `json:"class"`
+	Required Quantity `json:"required"`
+	// ExtractorCount is qualified where Plants and Depots are not, because
+	// the unqualified name is already the section holding this row: a
+	// consumer reading bases[0].extractors[0].extractors twice in one path
+	// has to work out which is the array.
+	ExtractorCount Quantity `json:"extractorCount"`
+	Depots         Quantity `json:"depots"`
+
+	// RatePerSecond is one extractor's output at the site's class, and
+	// FillSeconds how long the built extractors actually take — at most the
+	// configured duration, and usually less because the count rounded up.
+	RatePerSecond Quantity `json:"ratePerSecond"`
+	FillSeconds   Quantity `json:"fillSeconds"`
+}
+
+// RanchRow is one fauna product at one base.
+type RanchRow struct {
+	ItemID       string   `json:"itemId"`
+	Name         string   `json:"name"`
+	Required     Quantity `json:"required"`
+	Fauna        Quantity `json:"fauna"`
+	CycleSeconds Quantity `json:"cycleSeconds"`
+}
+
+// KitchenInput is one ingredient of a processing step.
+type KitchenInput struct {
+	ItemID    string   `json:"itemId"`
+	PerOutput Quantity `json:"perOutput"`
+}
+
+// KitchenStep is one nutrient processor step.
+type KitchenStep struct {
+	ItemID         string         `json:"itemId"`
+	Name           string         `json:"name"`
+	Recipe         string         `json:"recipe"`
+	Required       Quantity       `json:"required"`
+	ProcessSeconds Quantity       `json:"processSeconds"`
+	Final          bool           `json:"final"`
+	Inputs         []KitchenInput `json:"inputs,omitempty"`
+}
+
+// NoBuildRow is an item a byproduct at the same base already covers.
+//
+// Carried explicitly rather than omitted: a demand met without construction
+// is a planning result, and an absent row is indistinguishable from an
+// overlooked requirement.
+type NoBuildRow struct {
+	ItemID   string   `json:"itemId"`
+	Name     string   `json:"name"`
+	From     string   `json:"from"`
+	Required Quantity `json:"required"`
+}
+
+// BaseBuild is one base's construction instructions.
+type BaseBuild struct {
+	Base string `json:"base"`
+	Site Site   `json:"site"`
+
+	Farms      []FarmRow      `json:"farms,omitempty"`
+	Extractors []ExtractorRow `json:"extractors,omitempty"`
+	Ranches    []RanchRow     `json:"ranches,omitempty"`
+	Kitchen    []KitchenStep  `json:"kitchen,omitempty"`
+
+	// NutrientProcessors and PelletFeeders are per base, not per row.
+	NutrientProcessors Quantity `json:"nutrientProcessors"`
+	PelletFeeders      Quantity `json:"pelletFeeders"`
+
+	NoBuild []NoBuildRow `json:"noBuild,omitempty"`
+}
+
+// Build is stage 2's output.
+type Build struct {
+	Bases []BaseBuild `json:"bases"`
+
+	// Unassigned are the leaves the plan places nowhere. The producer stage
+	// skips them — there is no site to build them at — but the grouping
+	// keeps them so this can report them rather than losing them silently.
+	Unassigned []Demand `json:"unassigned,omitempty"`
+}
+
+// PowerBudget is one base's power position.
+type PowerBudget struct {
+	Base string `json:"base"`
+
+	Generation Quantity `json:"generation"`
+	Draw       Quantity `json:"draw"`
+
+	// Balance is generation minus draw and may be negative; Deficit is the
+	// shortfall as a positive figure, or zero. Both are the domain's own
+	// values — the adapter does not subtract.
+	Balance   Quantity `json:"balance"`
+	Deficit   Quantity `json:"deficit"`
+	InDeficit bool     `json:"inDeficit"`
+
+	PerGenerator Quantity `json:"perGenerator"`
+	Batteries    Quantity `json:"batteries"`
+
+	// AdditionalGenerators is how many more electromagnetic generators at
+	// this base's class would clear a deficit, and FixUnsized reports that
+	// a deficit exists but no class is configured to size the fix with.
+	//
+	// A deficit is therefore always visible even when it cannot be costed,
+	// which is the distinction the domain makes deliberately.
+	AdditionalGenerators Quantity `json:"additionalGenerators"`
+	FixUnsized           bool     `json:"fixUnsized"`
+
+	Verified bool `json:"verified"`
+}
+
+// Power is stage 3's output.
+type Power struct {
+	Bases []PowerBudget `json:"bases"`
+}
+
+// quantityToInt reads an inbound Quantity as a whole number.
+//
+// An absent field decodes as zero rather than as an error, because absence
+// is the caller declining to configure something and the domain refuses
+// unsupplied constants itself, naming which one. Rejecting "" here would
+// replace that specific message with a generic parse failure.
+func quantityToInt(q Quantity, what string) (int64, error) {
+	if q == "" {
+		return 0, nil
+	}
+	r, ok := q.Rat()
+	if !ok {
+		return 0, fmt.Errorf("%w: %s %q is not a number", ErrMalformedInput, what, q)
+	}
+	if !r.IsInt() || !r.Num().IsInt64() {
+		return 0, fmt.Errorf("%w: %s %q is not a whole number", ErrMalformedInput, what, q)
+	}
+	return r.Num().Int64(), nil
+}
+
+// DecodeCurated turns the wire constant set into the domain's.
+//
+// Governing: SPEC-0002 REQ "Error Handling Standards" — "Decoding failures
+// MUST name what could not be decoded and MUST NOT attempt computation."
+//
+// Values are not checked for being positive here. The domain validates the
+// set as a whole and names the offending constant, and duplicating that
+// check would give two places for the rule to drift.
+func DecodeCurated(c Curated) (domain.Curated, error) {
+	out := domain.Curated{}
+	for _, f := range []struct {
+		name string
+		src  Quantity
+		dst  *int64
+	}{
+		{"biodomeCropSlots", c.BiodomeCropSlots, &out.BiodomeCropSlots},
+		{"faunaYieldPerCycle", c.FaunaYieldPerCycle, &out.FaunaYieldPerCycle},
+		{"faunaCycleSeconds", c.FaunaCycleSeconds, &out.FaunaCycleSeconds},
+		{"stepsPerProcessor", c.StepsPerProcessor, &out.StepsPerProcessor},
+		{"depotThreshold", c.DepotThreshold, &out.DepotThreshold},
+		{"processSeconds", c.ProcessSeconds, &out.ProcessSeconds},
+		{"panelsPerBattery", c.PanelsPerBattery, &out.PanelsPerBattery},
+	} {
+		v, err := quantityToInt(f.src, "curated constant "+f.name)
+		if err != nil {
+			return domain.Curated{}, err
+		}
+		*f.dst = v
+	}
+	if len(c.FaunaProducts) > 0 {
+		out.FaunaProducts = make(map[string]bool, len(c.FaunaProducts))
+		for _, item := range c.FaunaProducts {
+			out.FaunaProducts[item] = true
+		}
+	}
+	if len(c.ResourceHotspots) > 0 {
+		out.ResourceHotspots = make(map[string]string, len(c.ResourceHotspots))
+		for item, category := range c.ResourceHotspots {
+			out.ResourceHotspots[item] = category
+		}
+	}
+	return out, nil
+}
+
+// DecodeRollupInput turns a rollup request's assignments and sites into the
+// grouping stage's input.
+func DecodeRollupInput(req RollupRequest) (domain.RollupInput, error) {
+	out := domain.RollupInput{}
+	if len(req.Assignments) > 0 {
+		out.Assignments = make(map[string]domain.BaseID, len(req.Assignments))
+		for item, base := range req.Assignments {
+			out.Assignments[item] = domain.BaseID(base)
+		}
+	}
+	if len(req.Sites) > 0 {
+		out.Sites = make(map[domain.BaseID]domain.SiteConfig, len(req.Sites))
+		for base, site := range req.Sites {
+			fill, err := quantityToInt(site.FillSeconds, "fill duration for base "+base)
+			if err != nil {
+				return domain.RollupInput{}, err
+			}
+			out.Sites[domain.BaseID(base)] = domain.SiteConfig{
+				ExtractorClass: domain.HotspotClass(site.ExtractorClass),
+				FillSeconds:    fill,
+			}
+		}
+	}
+	return out, nil
+}
+
+// DecodeProducerInput turns a rollup request's byproducts and kitchen steps
+// into the producer stage's input.
+func DecodeProducerInput(req RollupRequest) (domain.ProducerInput, error) {
+	out := domain.ProducerInput{}
+	if len(req.Byproducts) > 0 {
+		out.Byproducts = make(map[domain.BaseID][]domain.ByproductSource, len(req.Byproducts))
+		for base, sources := range req.Byproducts {
+			list := make([]domain.ByproductSource, 0, len(sources))
+			for _, s := range sources {
+				list = append(list, domain.ByproductSource{Item: s.Item, From: s.From})
+			}
+			out.Byproducts[domain.BaseID(base)] = list
+		}
+	}
+	if len(req.Kitchen) > 0 {
+		out.Kitchen = make(map[domain.BaseID][]domain.KitchenStepInput, len(req.Kitchen))
+		for base, steps := range req.Kitchen {
+			list := make([]domain.KitchenStepInput, 0, len(steps))
+			for _, s := range steps {
+				qty, err := quantityToInt(s.Quantity, "kitchen step quantity for "+s.ItemID)
+				if err != nil {
+					return domain.ProducerInput{}, err
+				}
+				list = append(list, domain.KitchenStepInput{
+					ItemID:   s.ItemID,
+					Recipe:   s.Recipe,
+					Quantity: qty,
+				})
+			}
+			out.Kitchen[domain.BaseID(base)] = list
+		}
+	}
+	return out, nil
+}
+
+// DecodePowerInput turns a power request into the power stage's input.
+func DecodePowerInput(req PowerRequest) (domain.PowerInput, error) {
+	out := domain.PowerInput{}
+	if len(req.Sources) > 0 {
+		out.Config = make(map[domain.BaseID]domain.PowerConfig, len(req.Sources))
+		for base, gen := range req.Sources {
+			ems, err := quantityToInt(gen.EMGenerators, "generator count for base "+base)
+			if err != nil {
+				return domain.PowerInput{}, err
+			}
+			panels, err := quantityToInt(gen.SolarPanels, "panel count for base "+base)
+			if err != nil {
+				return domain.PowerInput{}, err
+			}
+			out.Config[domain.BaseID(base)] = domain.PowerConfig{
+				EMGenerators: ems,
+				EMClass:      domain.HotspotClass(gen.EMClass),
+				SolarPanels:  panels,
+			}
+		}
+	}
+	if len(req.Draws) > 0 {
+		out.Draws = make(map[domain.BaseID][]domain.PowerUnit, len(req.Draws))
+		for base, units := range req.Draws {
+			list := make([]domain.PowerUnit, 0, len(units))
+			for _, u := range units {
+				count, err := quantityToInt(u.Count, "draw count for "+u.PartID+" at base "+base)
+				if err != nil {
+					return domain.PowerInput{}, err
+				}
+				list = append(list, domain.PowerUnit{PartID: u.PartID, Count: count})
+			}
+			out.Draws[domain.BaseID(base)] = list
+		}
+	}
+	if len(req.Unverified) > 0 {
+		out.Unverified = make(map[domain.BaseID]bool, len(req.Unverified))
+		for _, base := range req.Unverified {
+			out.Unverified[domain.BaseID(base)] = true
+		}
+	}
+	return out, nil
+}
+
+// EncodeBuild renders stage 2's output for the boundary.
+//
+// Governing: SPEC-0002 REQ "Exact Quantity Encoding", REQ "Determinism
+// Across the Boundary"
+//
+// Order is the domain's throughout — bases sorted by ID, rows sorted within
+// each base — and nothing here re-sorts, for the same reason EncodeGraph
+// does not: an order re-derived in the adapter is a second place for it to
+// drift from the engine's.
+func EncodeBuild(b *domain.Build, g *domain.Grouping) (*Build, error) {
+	if b == nil {
+		return nil, fmt.Errorf("encoding build: nil build")
+	}
+	out := &Build{Bases: make([]BaseBuild, 0, len(b.Bases))}
+	for _, base := range b.Bases {
+		out.Bases = append(out.Bases, encodeBaseBuild(base))
+	}
+	if g != nil {
+		if unassigned, ok := g.Unassigned(); ok {
+			out.Unassigned = make([]Demand, 0, len(unassigned.Demands))
+			for _, d := range unassigned.Demands {
+				out.Unassigned = append(out.Unassigned, Demand{
+					ItemID:   d.ItemID,
+					Name:     d.Name,
+					Total:    QuantityOf(d.Total()),
+					Verified: d.Verified,
+				})
+			}
+		}
+	}
+	return out, nil
+}
+
+func encodeBaseBuild(b domain.BaseBuild) BaseBuild {
+	out := BaseBuild{
+		Base: string(b.Base),
+		Site: Site{
+			ExtractorClass: string(b.Site.ExtractorClass),
+			FillSeconds:    QuantityOfInt(b.Site.FillSeconds),
+		},
+		NutrientProcessors: QuantityOfInt(b.NutrientProcessors),
+		PelletFeeders:      QuantityOfInt(b.PelletFeeders),
+	}
+	for _, r := range b.Farms {
+		out.Farms = append(out.Farms, FarmRow{
+			ItemID:   r.ItemID,
+			Name:     r.Name,
+			Required: QuantityOf(r.Required()),
+			Plants:   QuantityOfInt(r.Plants),
+			Biodomes: QuantityOfInt(r.Biodomes),
+			YieldPerPlant: YieldRange{
+				Min: QuantityOfInt(r.YieldPerPlant.Min),
+				Max: QuantityOfInt(r.YieldPerPlant.Max),
+			},
+			GrowthSeconds: QuantityOfInt(r.GrowthSeconds),
+		})
+	}
+	for _, r := range b.Extractors {
+		out.Extractors = append(out.Extractors, ExtractorRow{
+			ItemID:         r.ItemID,
+			Name:           r.Name,
+			Class:          string(r.Class),
+			Required:       QuantityOf(r.Required()),
+			ExtractorCount: QuantityOfInt(r.Extractors),
+			Depots:         QuantityOfInt(r.Depots),
+			RatePerSecond:  QuantityOf(r.RatePerSecond()),
+			FillSeconds:    QuantityOf(r.FillSeconds()),
+		})
+	}
+	for _, r := range b.Ranches {
+		out.Ranches = append(out.Ranches, RanchRow{
+			ItemID:       r.ItemID,
+			Name:         r.Name,
+			Required:     QuantityOf(r.Required()),
+			Fauna:        QuantityOfInt(r.Fauna),
+			CycleSeconds: QuantityOfInt(r.CycleSeconds),
+		})
+	}
+	for _, s := range b.Kitchen {
+		step := KitchenStep{
+			ItemID:         s.ItemID,
+			Name:           s.Name,
+			Recipe:         s.Recipe,
+			Required:       QuantityOf(s.Required()),
+			ProcessSeconds: QuantityOfInt(s.ProcessSeconds),
+			Final:          s.Final,
+		}
+		for _, i := range s.Inputs {
+			step.Inputs = append(step.Inputs, KitchenInput{
+				ItemID:    i.ItemID,
+				PerOutput: QuantityOf(i.PerOutput()),
+			})
+		}
+		out.Kitchen = append(out.Kitchen, step)
+	}
+	for _, n := range b.NoBuild {
+		out.NoBuild = append(out.NoBuild, NoBuildRow{
+			ItemID:   n.ItemID,
+			Name:     n.Name,
+			From:     n.From,
+			Required: QuantityOf(n.Required()),
+		})
+	}
+	return out
+}
+
+// EncodePower renders stage 3's output for the boundary.
+//
+// Governing: SPEC-0002 REQ "Exact Quantity Encoding", REQ "Determinism
+// Across the Boundary"
+//
+// Balance and Deficit are read from the domain rather than derived from the
+// generation and draw beside them. Recomputing either here would be
+// arithmetic in the adapter, and would give the boundary its own opinion
+// about a figure the engine already reports.
+func EncodePower(budgets []domain.PowerBudget) (*Power, error) {
+	out := &Power{Bases: make([]PowerBudget, 0, len(budgets))}
+	for _, b := range budgets {
+		out.Bases = append(out.Bases, PowerBudget{
+			Base:                 string(b.Base),
+			Generation:           QuantityOf(b.Generation()),
+			Draw:                 QuantityOf(b.Draw()),
+			Balance:              QuantityOf(b.Balance()),
+			Deficit:              QuantityOf(b.Deficit()),
+			InDeficit:            b.InDeficit(),
+			PerGenerator:         QuantityOf(b.PerGenerator()),
+			Batteries:            QuantityOfInt(b.Batteries),
+			AdditionalGenerators: QuantityOfInt(b.AdditionalGenerators),
+			FixUnsized:           b.FixUnsized,
+			Verified:             b.Verified,
+		})
+	}
+	return out, nil
+}

--- a/internal/bridge/stages_test.go
+++ b/internal/bridge/stages_test.go
@@ -1,0 +1,503 @@
+package bridge_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jonstump/nms-base-planner/internal/bridge"
+)
+
+// A self-contained artifact carrying both a recipe graph and an economy
+// section, so one module can serve all three stages.
+//
+// The domain fixtures cover stage 1 only — neither carries an economy
+// section — and the generated artifact is not a test dependency. Building
+// one here keeps the boundary's tests readable: every number below is
+// visible in this file, so an assertion that fails names a value the reader
+// can see.
+//
+// widget = 2 crop_a + 3 gas_a. At quantity 10 that is 20 crop_a and 30
+// gas_a, which is the arithmetic every rollup assertion rests on.
+const stagesArtifact = `{
+  "schema_version":2,
+  "game_version":"test-stages",
+  "items":[
+    {"id":"crop_a","name":"Crop A","raw_obtainable":true,"default_method":"raw"},
+    {"id":"gas_a","name":"Gas A","raw_obtainable":true,"default_method":"raw"},
+    {"id":"widget","name":"Widget","default_method":"craft"}
+  ],
+  "recipes":[
+    {"id":"widget_craft","output":"widget","method":"craft",
+     "inputs":[{"item":"crop_a","quantity":2},{"item":"gas_a","quantity":3}]}
+  ],
+  "economy":{
+    "parts":[
+      {"id":"U_EXTRACTOR_S","primary":{"network":"resources","rate":100,"storage":360000},
+       "dependencies":[{"network":"power","rate":-50,"effect":"EnablesRate"}],"hotspot":"Mineral"},
+      {"id":"U_GASEXTRACTOR","primary":{"network":"resources","rate":100,"storage":360000},
+       "dependencies":[{"network":"power","rate":-50,"effect":"EnablesRate"}],"hotspot":"Gas"},
+      {"id":"U_SILO_S","primary":{"network":"resources","rate":0,"storage":720}},
+      {"id":"U_BATTERY_S","primary":{"network":"power","rate":0,"storage":45000}},
+      {"id":"U_GENERATOR_S","primary":{"network":"power","rate":1},"hotspot":"Power"},
+      {"id":"U_SOLAR_S","primary":{"network":"power","rate":50}}
+    ],
+    "hotspots":[
+      {"category":"Gas","strengths":{"c":1,"b":1,"a":2,"s":2.5},"weightings":{"c":1,"b":1,"a":1,"s":1}},
+      {"category":"Mineral","strengths":{"c":1,"b":1,"a":2,"s":2.5},"weightings":{"c":1,"b":1,"a":1,"s":1}},
+      {"category":"Power","strengths":{"c":150,"b":220,"a":250,"s":300},"weightings":{"c":1,"b":1,"a":1,"s":1}}
+    ],
+    "crops":[{"id":"PLANT_A","substance":"crop_a","yield":{"min":25,"max":25},"growth_seconds":1800}]
+  }
+}`
+
+// curatedJSON is a complete Tier 2 set. The engine refuses a partial one,
+// so every scalar is present even where a scenario does not read it.
+const curatedJSON = `{
+  "biodomeCropSlots":"16","faunaYieldPerCycle":"12","faunaCycleSeconds":"1800",
+  "stepsPerProcessor":"2","depotThreshold":"1000","processSeconds":"30",
+  "panelsPerBattery":"2",
+  "resourceHotspots":{"gas_a":"Gas"}
+}`
+
+func stagesModule(t *testing.T) *bridge.Module {
+	t.Helper()
+	m := bridge.NewModule()
+	if env := m.Load(stagesArtifact); !env.OK {
+		t.Fatalf("loading the stages artifact: %+v", env.Error)
+	}
+	return m
+}
+
+// rollupRequest builds a request placing both leaves at one base.
+func rollupRequest(constants string) string {
+	return `{
+	  "plan":{"target":"widget","quantity":"10"},
+	  "assignments":{"crop_a":"base1","gas_a":"base1"},
+	  "sites":{"base1":{"extractorClass":"B","fillSeconds":"3600"}},
+	  "constants":` + constants + `}`
+}
+
+func powerRequest(constants string) string {
+	return `{
+	  "sources":{"base1":{"emGenerators":"1","emClass":"B"}},
+	  "draws":{"base1":[{"partId":"U_GASEXTRACTOR","count":"2"}]},
+	  "constants":` + constants + `}`
+}
+
+func callOK(t *testing.T, m *bridge.Module, name, arg string) ([]byte, bridge.Envelope) {
+	t.Helper()
+	blob := []byte(m.CallJSON(name, arg))
+	var env bridge.Envelope
+	if err := json.Unmarshal(blob, &env); err != nil {
+		t.Fatalf("%s returned unparseable output: %v", name, err)
+	}
+	if !env.OK {
+		t.Fatalf("%s failed: %s — %s", name, env.Error.Code, env.Error.Message)
+	}
+	return blob, env
+}
+
+// SPEC-0002 REQ "Boundary Surface":
+// WHEN rollup or power is added in a later stage THEN it accepts and returns
+// the same envelope shape defined by REQ "Result Envelope", with no bespoke
+// calling convention.
+func TestWiredStagesShareTheEnvelopeShape(t *testing.T) {
+	m := stagesModule(t)
+
+	for _, tc := range []struct {
+		stage string
+		arg   string
+	}{
+		{"rollup", rollupRequest(curatedJSON)},
+		{"power", powerRequest(curatedJSON)},
+	} {
+		_, env := callOK(t, m, tc.stage, tc.arg)
+		if env.Data == nil {
+			t.Fatalf("%s returned no result payload", tc.stage)
+		}
+		if env.Error != nil {
+			t.Errorf("%s carried both a payload and an error", tc.stage)
+		}
+		if env.ContractVersion != bridge.ContractVersion {
+			t.Errorf("%s contract version = %q, want %q",
+				tc.stage, env.ContractVersion, bridge.ContractVersion)
+		}
+	}
+}
+
+// The stages fill the payload field that belongs to them and no other, so a
+// consumer can tell which stage answered without tracking what it asked.
+func TestEachStageFillsItsOwnPayloadField(t *testing.T) {
+	m := stagesModule(t)
+
+	_, resolved := callOK(t, m, "resolve", `{"target":"widget","quantity":"10"}`)
+	if resolved.Data.Graph == nil {
+		t.Error("resolve returned no graph")
+	}
+	if resolved.Data.Build != nil || resolved.Data.Power != nil {
+		t.Error("resolve returned a stage-2 or stage-3 payload")
+	}
+
+	_, rolled := callOK(t, m, "rollup", rollupRequest(curatedJSON))
+	if rolled.Data.Build == nil {
+		t.Error("rollup returned no build")
+	}
+	if rolled.Data.Graph != nil || rolled.Data.Power != nil {
+		t.Error("rollup returned a stage-1 or stage-3 payload")
+	}
+
+	_, powered := callOK(t, m, "power", powerRequest(curatedJSON))
+	if powered.Data.Power == nil {
+		t.Error("power returned no power budget")
+	}
+	if powered.Data.Graph != nil || powered.Data.Build != nil {
+		t.Error("power returned a stage-1 or stage-2 payload")
+	}
+}
+
+// SPEC-0002 REQ "Exact Quantity Encoding":
+// WHEN a total crosses the boundary THEN it is a JSON string.
+//
+// The structural walk stage 1 established, extended to every quantity key
+// the new payloads introduce. Checking by key name rather than by field
+// means a quantity added later is covered the moment it reuses a name, and
+// visible as an omission when it does not.
+func TestEveryStageQuantityCrossesAsAString(t *testing.T) {
+	m := stagesModule(t)
+
+	buildBlob, _ := callOK(t, m, "rollup", rollupRequest(curatedJSON))
+	for _, key := range []string{
+		"required", "plants", "biodomes", "growthSeconds", "min", "max",
+		"extractorCount", "depots", "ratePerSecond", "fillSeconds",
+		"fauna", "cycleSeconds", "processSeconds", "perOutput",
+		"nutrientProcessors", "pelletFeeders", "total",
+	} {
+		assertAllStrings(t, buildBlob, key)
+	}
+
+	powerBlob, _ := callOK(t, m, "power", powerRequest(curatedJSON))
+	for _, key := range []string{
+		"generation", "draw", "balance", "deficit",
+		"perGenerator", "batteries", "additionalGenerators",
+	} {
+		assertAllStrings(t, powerBlob, key)
+	}
+}
+
+// SPEC-0002 REQ "Boundary Surface":
+// WHEN the view resolves a plan and renders 36 nodes THEN exactly one
+// boundary crossing occurred.
+//
+// The coarse-grained rule, applied across stages: three stages cost three
+// calls, not three per base or three per row. Counted rather than asserted
+// in prose — a stage that grew a per-row accessor would fail here.
+func TestThreeStagesCostThreeCrossings(t *testing.T) {
+	m := stagesModule(t)
+	counter := &countingModule{m: m}
+
+	_, _ = counter.call(t, "resolve", `{"target":"widget","quantity":"10"}`)
+	_, rolled := counter.call(t, "rollup", rollupRequest(curatedJSON))
+	_, _ = counter.call(t, "power", powerRequest(curatedJSON))
+
+	if counter.calls != 3 {
+		t.Errorf("crossings = %d, want 3", counter.calls)
+	}
+
+	// And the one rollup crossing carried every base, not one of them.
+	if got := len(rolled.Data.Build.Bases); got != 1 {
+		t.Fatalf("bases in one crossing = %d, want 1", got)
+	}
+	base := rolled.Data.Build.Bases[0]
+	if len(base.Farms) != 1 || len(base.Extractors) != 1 {
+		t.Errorf("one crossing carried %d farm and %d extractor rows, want 1 and 1",
+			len(base.Farms), len(base.Extractors))
+	}
+}
+
+type countingModule struct {
+	m     *bridge.Module
+	calls int
+}
+
+func (c *countingModule) call(t *testing.T, name, arg string) ([]byte, bridge.Envelope) {
+	t.Helper()
+	c.calls++
+	return callOK(t, c.m, name, arg)
+}
+
+// SPEC-0001 REQ "Producer Rollup", crossing the boundary intact:
+// 20 crop_a at 25 per plant is 1 plant in 1 biodome; 30 gas_a is one
+// extractor's work well inside an hour.
+func TestProducerCountsSurviveTheCrossing(t *testing.T) {
+	m := stagesModule(t)
+	_, env := callOK(t, m, "rollup", rollupRequest(curatedJSON))
+
+	base := env.Data.Build.Bases[0]
+	if base.Base != "base1" {
+		t.Errorf("base = %q, want base1", base.Base)
+	}
+	if base.Site.ExtractorClass != "B" {
+		t.Errorf("site class = %q, want B — the configuration a result was computed under should read back", base.Site.ExtractorClass)
+	}
+
+	farm := base.Farms[0]
+	if farm.ItemID != "crop_a" || farm.Required != "20" || farm.Plants != "1" || farm.Biodomes != "1" {
+		t.Errorf("farm row = %+v, want crop_a required 20, 1 plant, 1 biodome", farm)
+	}
+	if farm.YieldPerPlant.Min != "25" || farm.YieldPerPlant.Max != "25" {
+		t.Errorf("yield range = %+v, want 25..25", farm.YieldPerPlant)
+	}
+
+	ext := base.Extractors[0]
+	if ext.ItemID != "gas_a" || ext.Required != "30" || ext.Class != "B" {
+		t.Errorf("extractor row = %+v, want gas_a required 30 at class B", ext)
+	}
+	if ext.ExtractorCount != "1" {
+		t.Errorf("extractor count = %q, want 1", ext.ExtractorCount)
+	}
+}
+
+// SPEC-0001 REQ "Power Computation", crossing intact:
+// one class-B generator at rate 1 against a 220 class strength generates
+// 220; two gas extractors drawing 50 each draw 100.
+func TestPowerPositionSurvivesTheCrossing(t *testing.T) {
+	m := stagesModule(t)
+	_, env := callOK(t, m, "power", powerRequest(curatedJSON))
+
+	if got := len(env.Data.Power.Bases); got != 1 {
+		t.Fatalf("bases = %d, want 1", got)
+	}
+	b := env.Data.Power.Bases[0]
+	if b.Generation != "220" {
+		t.Errorf("generation = %q, want 220", b.Generation)
+	}
+	if b.Draw != "100" {
+		t.Errorf("draw = %q, want 100", b.Draw)
+	}
+	if b.Balance != "120" {
+		t.Errorf("balance = %q, want 120", b.Balance)
+	}
+	if b.Deficit != "0" || b.InDeficit {
+		t.Errorf("deficit = %q inDeficit = %v, want 0 and false", b.Deficit, b.InDeficit)
+	}
+}
+
+// SPEC-0001 REQ "Power Computation" — Scenario "Deficit reports the fix".
+//
+// A deficit crosses as an action rather than as a warning: the count of
+// additional generators is the domain's, and the adapter neither sizes nor
+// second-guesses it.
+func TestDeficitCrossesWithItsFix(t *testing.T) {
+	m := stagesModule(t)
+	req := `{
+	  "sources":{"base1":{"emGenerators":"1","emClass":"C"}},
+	  "draws":{"base1":[{"partId":"U_GASEXTRACTOR","count":"10"}]},
+	  "constants":` + curatedJSON + `}`
+
+	_, env := callOK(t, m, "power", req)
+	b := env.Data.Power.Bases[0]
+
+	if !b.InDeficit {
+		t.Fatalf("base is not in deficit: generation %q draw %q", b.Generation, b.Draw)
+	}
+	if b.Deficit != "350" {
+		t.Errorf("deficit = %q, want 350 (500 draw less 150 generation)", b.Deficit)
+	}
+	if b.AdditionalGenerators != "3" {
+		t.Errorf("additional generators = %q, want 3 at 150 each", b.AdditionalGenerators)
+	}
+	if b.FixUnsized {
+		t.Error("fix reported unsized when a class was configured")
+	}
+}
+
+// A deficit with no configured class is still a deficit.
+//
+// The domain reports it with an unsized fix rather than refusing the base,
+// and that distinction has to survive the crossing — a view told only
+// "additional generators: 0" would render a base in deficit as healthy.
+func TestUnsizedFixCrossesAsItsOwnState(t *testing.T) {
+	m := stagesModule(t)
+	req := `{
+	  "draws":{"base1":[{"partId":"U_GASEXTRACTOR","count":"2"}]},
+	  "constants":` + curatedJSON + `}`
+
+	_, env := callOK(t, m, "power", req)
+	b := env.Data.Power.Bases[0]
+
+	if !b.InDeficit {
+		t.Fatal("a base drawing power with no generation is not in deficit")
+	}
+	if !b.FixUnsized {
+		t.Error("fix was not reported unsized with no generator class configured")
+	}
+	if b.AdditionalGenerators != "0" {
+		t.Errorf("additional generators = %q, want 0 when the fix has no size", b.AdditionalGenerators)
+	}
+	if b.Deficit != "100" {
+		t.Errorf("deficit = %q, want 100 — a deficit that cannot be costed is still reported", b.Deficit)
+	}
+}
+
+// The domain models generation as independent counts rather than a choice
+// between two source types, and the boundary must not narrow that: a base
+// running both generators and panels is a configuration the engine accepts.
+func TestMixedGenerationSourcesCross(t *testing.T) {
+	m := stagesModule(t)
+	req := `{
+	  "sources":{"base1":{"emGenerators":"1","emClass":"B","solarPanels":"4"}},
+	  "constants":` + curatedJSON + `}`
+
+	_, env := callOK(t, m, "power", req)
+	b := env.Data.Power.Bases[0]
+
+	if b.Generation != "420" {
+		t.Errorf("generation = %q, want 420 (220 electromagnetic + 200 solar)", b.Generation)
+	}
+	if b.Batteries != "2" {
+		t.Errorf("batteries = %q, want 2 for 4 panels at 2 panels per battery", b.Batteries)
+	}
+}
+
+// SPEC-0002 REQ "Sentinel Error Preservation":
+// a missing curated constant crosses with a stable code, not UNCLASSIFIED.
+//
+// The code is INVALID_ARTIFACT rather than MISSING_CONSTANT because that is
+// the sentinel the engine raises — see the note in the PR. What this asserts
+// is the property the requirement states: a distinct, stable code, and a
+// message naming the constant so the caller can act on it.
+func TestMissingCuratedConstantCrossesWithAStableCode(t *testing.T) {
+	m := stagesModule(t)
+	incomplete := `{"biodomeCropSlots":"16","faunaYieldPerCycle":"12"}`
+
+	var env bridge.Envelope
+	if err := json.Unmarshal([]byte(m.CallJSON("rollup", rollupRequest(incomplete))), &env); err != nil {
+		t.Fatalf("unparseable output: %v", err)
+	}
+	if env.OK {
+		t.Fatal("rollup succeeded against an incomplete constant set")
+	}
+	if env.Error.Code == bridge.CodeUnclassified {
+		t.Error("a missing constant crossed as UNCLASSIFIED")
+	}
+	if env.Error.Code != bridge.CodeInvalidArtifact {
+		t.Errorf("code = %q, want %q", env.Error.Code, bridge.CodeInvalidArtifact)
+	}
+	if !strings.Contains(env.Error.Message, "fauna cycle seconds") {
+		t.Errorf("message %q does not name the missing constant", env.Error.Message)
+	}
+}
+
+// A stage called before the artifact loads fails as not-ready and names
+// itself, so the failure is distinguishable from a typo in the entry point.
+func TestUnloadedStagesReportNotReadyAndNameThemselves(t *testing.T) {
+	m := bridge.NewModule()
+
+	for _, name := range []string{"rollup", "power"} {
+		var env bridge.Envelope
+		if err := json.Unmarshal([]byte(m.CallJSON(name, `{}`)), &env); err != nil {
+			t.Fatalf("%s returned unparseable output: %v", name, err)
+		}
+		if env.OK {
+			t.Errorf("%s succeeded before the artifact loaded", name)
+		}
+		if env.Error.Code != bridge.CodeNotReady {
+			t.Errorf("%s code = %q, want %q", name, env.Error.Code, bridge.CodeNotReady)
+		}
+		if !strings.Contains(env.Error.Message, name) {
+			t.Errorf("%s message %q does not name the stage", name, env.Error.Message)
+		}
+	}
+}
+
+// SPEC-0002 REQ "Error Handling Standards":
+// decoding failures name what could not be decoded and attempt no computation.
+func TestStageDecodingFailuresNameTheField(t *testing.T) {
+	m := stagesModule(t)
+
+	for _, tc := range []struct {
+		name  string
+		stage string
+		arg   string
+		names string
+	}{
+		{
+			name:  "fill duration is not a number",
+			stage: "rollup",
+			arg: `{"plan":{"target":"widget","quantity":"10"},
+			       "sites":{"base1":{"extractorClass":"B","fillSeconds":"soon"}},
+			       "constants":` + curatedJSON + `}`,
+			names: "fill duration for base base1",
+		},
+		{
+			name:  "generator count is fractional",
+			stage: "power",
+			arg:   `{"sources":{"base1":{"emGenerators":"3/2"}},"constants":` + curatedJSON + `}`,
+			names: "generator count for base base1",
+		},
+		{
+			name:  "draw count is not a number",
+			stage: "power",
+			arg: `{"draws":{"base1":[{"partId":"U_SOLAR_S","count":"lots"}]},
+			       "constants":` + curatedJSON + `}`,
+			names: "draw count for U_SOLAR_S at base base1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var env bridge.Envelope
+			if err := json.Unmarshal([]byte(m.CallJSON(tc.stage, tc.arg)), &env); err != nil {
+				t.Fatalf("unparseable output: %v", err)
+			}
+			if env.OK {
+				t.Fatal("the stage computed against an undecodable request")
+			}
+			if env.Error.Code != bridge.CodeMalformedInput {
+				t.Errorf("code = %q, want %q", env.Error.Code, bridge.CodeMalformedInput)
+			}
+			if !strings.Contains(env.Error.Message, tc.names) {
+				t.Errorf("message %q does not name %q", env.Error.Message, tc.names)
+			}
+		})
+	}
+}
+
+// SPEC-0002 REQ "Determinism Across the Boundary":
+// identical inputs produce byte-identical output.
+func TestStageEncodingIsByteIdentical(t *testing.T) {
+	m := stagesModule(t)
+
+	for _, tc := range []struct{ stage, arg string }{
+		{"rollup", rollupRequest(curatedJSON)},
+		{"power", powerRequest(curatedJSON)},
+	} {
+		first := m.CallJSON(tc.stage, tc.arg)
+		second := m.CallJSON(tc.stage, tc.arg)
+		if first != second {
+			t.Errorf("%s encoded two different payloads for one input:\n%s\n%s", tc.stage, first, second)
+		}
+	}
+}
+
+// A leaf the plan places nowhere is reported rather than dropped. The
+// producer stage skips it — there is no site to build it at — and losing it
+// here would make an unplaced requirement indistinguishable from one that
+// does not exist.
+func TestUnassignedLeavesAreReported(t *testing.T) {
+	m := stagesModule(t)
+	req := `{
+	  "plan":{"target":"widget","quantity":"10"},
+	  "assignments":{"crop_a":"base1"},
+	  "sites":{"base1":{"extractorClass":"B","fillSeconds":"3600"}},
+	  "constants":` + curatedJSON + `}`
+
+	_, env := callOK(t, m, "rollup", req)
+	build := env.Data.Build
+
+	if len(build.Unassigned) != 1 {
+		t.Fatalf("unassigned = %d entries, want 1", len(build.Unassigned))
+	}
+	if build.Unassigned[0].ItemID != "gas_a" || build.Unassigned[0].Total != "30" {
+		t.Errorf("unassigned = %+v, want gas_a totalling 30", build.Unassigned[0])
+	}
+}


### PR DESCRIPTION
Fills the two reserved slots in `internal/bridge`. Both stages now return real results using `resolve`'s signature, envelope and error vocabulary unchanged.

This unblocks the whole of SPEC-0007 (#67) and leaf assignment in SPEC-0006 (#66).

## What crosses

**`rollup`** takes a plan, assignments, per-site config, byproducts, kitchen steps and the curated constant set; resolves, groups leaves onto bases, rolls up producers, and returns every base's construction instructions in one crossing. It resolves the plan itself rather than accepting a graph the caller hands back — REQ "Boundary Surface" requires one call to perform one complete stage, and a caller obliged to return a previous result would be assembling this one out of two crossings.

**`power`** takes generation sources, draws and constants. **It takes no plan.** The domain's power stage costs a set of counts rather than producer rows — the same figures whether they came from a rollup or from a caller sketching a base by hand — so requiring one would invent a coupling the engine does not have. It still needs a loaded artifact, because the parts and hotspot strengths it reads live in the economy section.

## The adapter still performs no arithmetic

This mattered more here than for `resolve`, as the issue predicted. Stages 2 and 3 round at every physical boundary SPEC-0001 enumerates — plants, biodomes, extractors, depots, fauna, processors, batteries, the additional-generator fix — and all of it stays in the domain. This code reads already-rounded `int64`s and renders them.

The sharpest case is power: `Balance` and `Deficit` are read from `PowerBudget` rather than derived from the `generation` and `draw` sitting beside them in the same struct. Subtracting two numbers I already have would have been the natural thing to write, and it is exactly the arithmetic-in-the-adapter that `TestAdapterHoldsNoDomainLogic` exists to catch. `FixUnsized` crosses as its own field for the same reason — a view told only `additionalGenerators: 0` would render a base in deficit as healthy.

## Contract version 1.0.0 → 1.1.0

`ResultPayload` gains `build` and `power` alongside `graph`, all `omitempty`. The envelope's four keys, the exactly-one-of invariant, the quantity encoding and the sentinel code set are unchanged, so the addition is backward compatible in shape — but the result payload is part of what a consumer parses, and leaving two different payloads claiming one version is the drift REQ "Contract Versioning" exists to prevent.

**Worth knowing:** `CheckVersion` is exact string equality, so a minor bump behaves like a major one — there is no way for the contract to express a backward-compatible addition. No consumer exists yet so nothing breaks, but that is a real property of the versioning design rather than something this PR introduces. Flagged rather than changed; the issue puts contract changes out of scope.

## Finding: `ErrMissingConstant` is dead vocabulary

The issue's scope says failures map to stable codes, "`ErrMissingConstant` in particular, which stages 2 and 3 raise."

They don't. `grep -n ErrMissingConstant internal/domain/*.go` returns only its own definition — nothing raises it. Every missing-constant path in stages 2 and 3 uses `ErrInvalidArtifact`: `Curated.validate()`, the site fill duration, panels-per-battery, the hotspot category, part rates, storage buffers. The sentinel's own comment says "Stage 1 never returns it; it is defined here so the sentinel set is complete and stable across stages" — the stages arrived and kept using `ErrInvalidArtifact`.

The acceptance criterion still holds: a missing constant crosses as `INVALID_ARTIFACT`, which is distinct, stable, and not `UNCLASSIFIED`, with a message naming the constant. `TestMissingCuratedConstantCrossesWithAStableCode` asserts that.

But it means a view cannot distinguish *"you didn't configure panels-per-battery"* (the caller's problem) from *"our artifact is broken"* (ours) — and that is precisely the distinction the `Load` path went out of its way to preserve, with a long comment explaining why classifying by context beats classifying by whichever sentinel wraps first. Changing which sentinel the domain raises is a SPEC-0001 change and out of scope here, so this is reported rather than fixed.

## Two wire names diverge from the domain's

Both because a key meaning two things in one document is worse than a name that differs from its Go field:

- `ExtractorRow.Extractors` → `extractorCount`. `extractors` is already the array holding the row, so `bases[0].extractors[0].extractors` would make a reader work out which is which. (The structural walk caught this, which is a decent argument for checking by key name.)
- `PowerRequest.Generation` → `sources`. The response's `generation` is a quantity; one word meaning a configuration inbound and a figure outbound is a needless thing to hold in mind.

## Unassigned leaves are reported

`Build.unassigned` carries the leaves the plan places nowhere. The producer stage skips them — there is no site to build them at — but the grouping deliberately keeps them, and dropping them at the boundary would make an unplaced requirement indistinguishable from one that does not exist. Both view specs have an unassigned bin.

## Tests

New `stages_test.go` builds a self-contained artifact carrying both a recipe graph and an economy section — neither domain fixture has an economy section, and the generated artifact is not a test dependency. Every number an assertion rests on is visible in the file.

Against the acceptance criteria:

| Criterion | Test |
|---|---|
| Real results, not not-ready | `TestWiredStagesShareTheEnvelopeShape`, `TestEachStageFillsItsOwnPayloadField` |
| Every quantity a JSON string; structural walk extended | `TestEveryStageQuantityCrossesAsAString` — 17 build keys, 7 power keys |
| Three calls, not three per node | `TestThreeStagesCostThreeCrossings` |
| Missing constant gets a distinct code | `TestMissingCuratedConstantCrossesWithAStableCode` |
| Purity guards still pass | verified below |
| `EntryPoints` and one-namespace assertion unchanged | untouched |

Plus deficit-with-fix, the unsized-fix state, mixed EM+solar generation, decode failures naming the field, byte-identical re-encoding, and not-ready naming the stage.

`TestReservedStagesShareTheEnvelopeShape` asserted the behaviour this story removes; replaced by `TestWiredStagesShareTheEnvelopeShape`.

## Verification

```
gofmt -l .                     clean
go vet ./...                   clean
go test ./...                  all packages ok
go test -race ./...            all packages ok
GOOS=js GOARCH=wasm go build   ok
```

Purity guards run explicitly and passing: `TestSyscallJSIsReachableOnlyThroughTheAdapter`, `TestAdapterHoldsNoDomainLogic`, `TestEncodingPathsNeedNoBuildTag`, `TestResolveIsBoundedAndNonBlocking`, `TestEveryEnvelopeCarriesTheContractVersion`.

staticcheck is not installed locally — CI will run it.

No protected paths modified; no deferred design doc updates.

Closes #64

Implements SPEC-0002 REQ "Boundary Surface" reserved-stages scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)