### PR TITLE
fix(domain): raise the missing-constant sentinel for absent Tier 2 constants

### DIFF
--- a/internal/bridge/stages_test.go
+++ b/internal/bridge/stages_test.go
@@ -363,10 +363,12 @@ func TestMixedGenerationSourcesCross(t *testing.T) {
 // SPEC-0002 REQ "Sentinel Error Preservation":
 // a missing curated constant crosses with a stable code, not UNCLASSIFIED.
 //
-// The code is INVALID_ARTIFACT rather than MISSING_CONSTANT because that is
-// the sentinel the engine raises — see the note in the PR. What this asserts
-// is the property the requirement states: a distinct, stable code, and a
-// message naming the constant so the caller can act on it.
+// MISSING_CONSTANT specifically. When this test was written the engine
+// raised ErrInvalidArtifact for an absent constant and the assertion said
+// so; SPEC-0001 REQ "Error Handling Standards" requires the
+// missing-constant sentinel, and the engine now raises it. The distinction
+// is the point: a view can tell "you did not supply this" from "our
+// artifact is broken".
 func TestMissingCuratedConstantCrossesWithAStableCode(t *testing.T) {
 	m := stagesModule(t)
 	incomplete := `{"biodomeCropSlots":"16","faunaYieldPerCycle":"12"}`
@@ -381,8 +383,8 @@ func TestMissingCuratedConstantCrossesWithAStableCode(t *testing.T) {
 	if env.Error.Code == bridge.CodeUnclassified {
 		t.Error("a missing constant crossed as UNCLASSIFIED")
 	}
-	if env.Error.Code != bridge.CodeInvalidArtifact {
-		t.Errorf("code = %q, want %q", env.Error.Code, bridge.CodeInvalidArtifact)
+	if env.Error.Code != bridge.CodeMissingConstant {
+		t.Errorf("code = %q, want %q", env.Error.Code, bridge.CodeMissingConstant)
 	}
 	if !strings.Contains(env.Error.Message, "fauna cycle seconds") {
 		t.Errorf("message %q does not name the missing constant", env.Error.Message)

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -28,9 +28,20 @@ var (
 	// ancestor.
 	ErrCycleDetected = errors.New("cycle detected")
 
-	// ErrMissingConstant reports an absent Tier 2 economy constant. Stage 1
-	// never returns it; it is defined here so the sentinel set is complete
-	// and stable across stages.
+	// ErrMissingConstant reports an absent Tier 2 economy constant — a
+	// curated scalar the caller did not supply, or an economy value the
+	// artifact carries no usable figure for.
+	//
+	// Governing: SPEC-0001 REQ "Error Handling Standards" — Scenario
+	// "Missing constant is distinguishable".
+	//
+	// Distinct from ErrUnknownItem, which reports a looked-up name that does
+	// not exist, and from ErrInvalidArtifact, which reports data that is
+	// structurally wrong. The distinction is what lets a caller tell "you
+	// did not configure this" from "our artifact is broken" — the same
+	// classification-by-context the boundary's Load path preserves.
+	//
+	// Stage 1 never returns it; stages 2 and 3 do.
 	ErrMissingConstant = errors.New("missing constant")
 
 	// ErrInvalidArtifact reports a Tier 1 artifact that failed structural

--- a/internal/domain/power.go
+++ b/internal/domain/power.go
@@ -163,7 +163,7 @@ func powerFor(base BaseID, c *Constants, in PowerInput) (PowerBudget, error) {
 			return PowerBudget{}, fmt.Errorf("base %q: %w", base, err)
 		}
 		if gen.Primary.Rate <= 0 {
-			return PowerBudget{}, fmt.Errorf("%w: %s states no output", ErrInvalidArtifact, PartGenerator)
+			return PowerBudget{}, fmt.Errorf("%w: %s states no output", ErrMissingConstant, PartGenerator)
 		}
 		strength, err := c.ClassStrength("Power", cfg.EMClass)
 		if err != nil {
@@ -182,7 +182,7 @@ func powerFor(base BaseID, c *Constants, in PowerInput) (PowerBudget, error) {
 			return PowerBudget{}, fmt.Errorf("base %q: %w", base, err)
 		}
 		if panel.Primary.Rate <= 0 {
-			return PowerBudget{}, fmt.Errorf("%w: %s states no output", ErrInvalidArtifact, PartSolar)
+			return PowerBudget{}, fmt.Errorf("%w: %s states no output", ErrMissingConstant, PartSolar)
 		}
 		budget.generation.Add(budget.generation,
 			new(big.Rat).Mul(new(big.Rat).SetInt64(panel.Primary.Rate), new(big.Rat).SetInt64(cfg.SolarPanels)))
@@ -190,7 +190,7 @@ func powerFor(base BaseID, c *Constants, in PowerInput) (PowerBudget, error) {
 		perBattery := c.Curated().PanelsPerBattery
 		if perBattery <= 0 {
 			return PowerBudget{}, fmt.Errorf("%w: panels per battery is %d; it must be supplied",
-				ErrInvalidArtifact, perBattery)
+				ErrMissingConstant, perBattery)
 		}
 		budget.Batteries = ceilRat(big.NewRat(cfg.SolarPanels, perBattery))
 	}

--- a/internal/domain/power_test.go
+++ b/internal/domain/power_test.go
@@ -405,8 +405,8 @@ func TestGeneratorWithNoStatedOutputIsRefused(t *testing.T) {
 	if err == nil {
 		t.Fatal("Power accepted a generator stating no output")
 	}
-	if !errors.Is(err, ErrInvalidArtifact) {
-		t.Errorf("error is %v, want ErrInvalidArtifact", err)
+	if !errors.Is(err, ErrMissingConstant) {
+		t.Errorf("error is %v, want ErrMissingConstant", err)
 	}
 	if !strings.Contains(err.Error(), PartGenerator) {
 		t.Errorf("error %q does not name the part at fault", err)

--- a/internal/domain/producer.go
+++ b/internal/domain/producer.go
@@ -347,7 +347,7 @@ func farmRow(d LeafDemand, c *Constants) (FarmRow, error) {
 	// and the failure mode is a farm that never fills the order.
 	perPlant := crop.Yield.Min
 	if perPlant <= 0 {
-		return FarmRow{}, fmt.Errorf("%w: crop %q yields %d per plant", ErrInvalidArtifact, crop.ID, perPlant)
+		return FarmRow{}, fmt.Errorf("%w: crop %q yields %d per plant", ErrMissingConstant, crop.ID, perPlant)
 	}
 
 	plants := ceilRat(new(big.Rat).Quo(d.Total(), new(big.Rat).SetInt64(perPlant)))

--- a/internal/domain/rollup.go
+++ b/internal/domain/rollup.go
@@ -375,7 +375,13 @@ func (c *Constants) ClassStrength(category string, class HotspotClass) (*big.Rat
 		return nil, fmt.Errorf("%w: %s class %s strength is not a finite number", ErrInvalidArtifact, category, class)
 	}
 	if r.Sign() <= 0 {
-		return nil, fmt.Errorf("%w: %s class %s strength is %v", ErrInvalidArtifact, category, class, v)
+		// Zero is what an absent strength decodes to — Strengths is a
+		// struct, so the field is always present and a missing source value
+		// is indistinguishable from a stated zero. Same shape as a part
+		// stating no rate or no storage buffer, and classified the same
+		// way. A non-finite strength above is different: that is data the
+		// artifact has and got wrong.
+		return nil, fmt.Errorf("%w: %s class %s strength is %v", ErrMissingConstant, category, class, v)
 	}
 	return r, nil
 }

--- a/internal/domain/rollup.go
+++ b/internal/domain/rollup.go
@@ -159,7 +159,7 @@ func (c Curated) validate() error {
 	} {
 		if f.v <= 0 {
 			return fmt.Errorf("%w: curated constant %q is %d; it must be supplied, not defaulted",
-				ErrInvalidArtifact, f.name, f.v)
+				ErrMissingConstant, f.name, f.v)
 		}
 	}
 	return nil
@@ -263,7 +263,7 @@ func (c *Constants) ExtractorRate(itemID string, class HotspotClass) (*big.Rat, 
 	category, ok := c.curated.ResourceHotspots[itemID]
 	if !ok {
 		return nil, fmt.Errorf("%w: no hotspot category is configured for %q, so no extractor can be sized for it",
-			ErrUnknownItem, itemID)
+			ErrMissingConstant, itemID)
 	}
 	part := PartExtractorMineral
 	if category == "Gas" {
@@ -274,7 +274,7 @@ func (c *Constants) ExtractorRate(itemID string, class HotspotClass) (*big.Rat, 
 		return nil, err
 	}
 	if p.Primary.Rate <= 0 {
-		return nil, fmt.Errorf("%w: %s states no extraction rate", ErrInvalidArtifact, part)
+		return nil, fmt.Errorf("%w: %s states no extraction rate", ErrMissingConstant, part)
 	}
 	strength, err := c.ClassStrength(category, class)
 	if err != nil {
@@ -319,7 +319,7 @@ func (c *Constants) DepotCapacity() (int64, error) {
 		return 0, err
 	}
 	if p.Primary.Storage <= 0 {
-		return 0, fmt.Errorf("%w: %s states no storage buffer", ErrInvalidArtifact, PartSupplyDepot)
+		return 0, fmt.Errorf("%w: %s states no storage buffer", ErrMissingConstant, PartSupplyDepot)
 	}
 	return p.Primary.Storage, nil
 }
@@ -333,7 +333,7 @@ func (c *Constants) BatteryCapacity() (int64, error) {
 		return 0, err
 	}
 	if p.Primary.Storage <= 0 {
-		return 0, fmt.Errorf("%w: %s states no storage buffer", ErrInvalidArtifact, PartBattery)
+		return 0, fmt.Errorf("%w: %s states no storage buffer", ErrMissingConstant, PartBattery)
 	}
 	return p.Primary.Storage, nil
 }

--- a/internal/domain/rollup_test.go
+++ b/internal/domain/rollup_test.go
@@ -489,7 +489,8 @@ func TestAbsentTier2ConstantMatchesTheMissingConstantSentinel(t *testing.T) {
 	  ],
 	  "hotspots":[
 	    {"category":"Mineral","strengths":{"c":1,"b":1,"a":2,"s":2.5},"weightings":{"c":1,"b":1,"a":1,"s":1}},
-	    {"category":"Power","strengths":{"c":150,"b":220,"a":250,"s":300},"weightings":{"c":1,"b":1,"a":1,"s":1}}
+	    {"category":"Power","strengths":{"c":150,"b":220,"a":250,"s":300},"weightings":{"c":1,"b":1,"a":1,"s":1}},
+	    {"category":"Thin","strengths":{"c":1,"a":2,"s":2.5},"weightings":{"c":1,"b":1,"a":1,"s":1}}
 	  ],
 	  "crops":[{"id":"PLANT_Z","substance":"crop_z","yield":{"min":0,"max":0},"growth_seconds":60}]
 	}`
@@ -532,6 +533,16 @@ func TestAbsentTier2ConstantMatchesTheMissingConstantSentinel(t *testing.T) {
 			names: PartSupplyDepot,
 			run: func(c *Constants) error {
 				_, err := c.DepotCapacity()
+				return err
+			},
+		},
+		{
+			// "Thin" states c, a and s but not b — the field decodes to
+			// zero, which is what an absent source value looks like.
+			name:  "hotspot class strength is absent",
+			names: "Thin class B strength",
+			run: func(c *Constants) error {
+				_, err := c.ClassStrength("Thin", ClassB)
 				return err
 			},
 		},

--- a/internal/domain/rollup_test.go
+++ b/internal/domain/rollup_test.go
@@ -383,8 +383,8 @@ func TestCuratedConstantsMustBeSupplied(t *testing.T) {
 			curated := full
 			clear(&curated)
 			c, err := NewConstants(a1, curated)
-			if !errors.Is(err, ErrInvalidArtifact) {
-				t.Fatalf("error = %v, want ErrInvalidArtifact", err)
+			if !errors.Is(err, ErrMissingConstant) {
+				t.Fatalf("error = %v, want ErrMissingConstant", err)
 			}
 			if c != nil {
 				t.Error("constants were returned alongside an error")
@@ -465,5 +465,116 @@ func TestStageOneNeedsNoRollupConfiguration(t *testing.T) {
 	}
 	if len(grouping.Groups) != 1 || !grouping.Groups[0].IsUnassigned() {
 		t.Errorf("groups = %+v, want one unassigned group", grouping.Groups)
+	}
+}
+
+// SPEC-0001 REQ "Error Handling Standards" — Scenario "Missing constant is
+// distinguishable":
+// WHEN a Tier 2 constant required by a producer calculation is absent
+// THEN the engine returns an error matching the missing-constant sentinel,
+// naming the constant.
+//
+// One case per kind of absence the stages can meet, because the sentinel's
+// value is the distinction it draws: each of these is the caller or the
+// artifact failing to supply a figure, and none of them is the artifact
+// being structurally wrong. A test per site is what stops the next one
+// added from quietly reaching for ErrInvalidArtifact again.
+func TestAbsentTier2ConstantMatchesTheMissingConstantSentinel(t *testing.T) {
+	const econ = `{
+	  "parts":[
+	    {"id":"U_EXTRACTOR_S","primary":{"network":"resources","rate":0,"storage":360000},"hotspot":"Mineral"},
+	    {"id":"U_SILO_S","primary":{"network":"resources","rate":0,"storage":0}},
+	    {"id":"U_GENERATOR_S","primary":{"network":"power","rate":0},"hotspot":"Power"},
+	    {"id":"U_SOLAR_S","primary":{"network":"power","rate":0}}
+	  ],
+	  "hotspots":[
+	    {"category":"Mineral","strengths":{"c":1,"b":1,"a":2,"s":2.5},"weightings":{"c":1,"b":1,"a":1,"s":1}},
+	    {"category":"Power","strengths":{"c":150,"b":220,"a":250,"s":300},"weightings":{"c":1,"b":1,"a":1,"s":1}}
+	  ],
+	  "crops":[{"id":"PLANT_Z","substance":"crop_z","yield":{"min":0,"max":0},"growth_seconds":60}]
+	}`
+	a1 := producerArtifact(t, econ, `{"id":"crop_z","name":"Crop Z","raw_obtainable":true,"default_method":"raw"}`)
+
+	for _, tc := range []struct {
+		name  string
+		names string
+		run   func(*Constants) error
+	}{
+		{
+			name:  "curated scalar not supplied",
+			names: "panels per battery",
+			run: func(*Constants) error {
+				_, err := NewConstants(a1, Curated{
+					BiodomeCropSlots: 16, FaunaYieldPerCycle: 12, FaunaCycleSeconds: 1800,
+					StepsPerProcessor: 2, DepotThreshold: 1000, ProcessSeconds: 30,
+				})
+				return err
+			},
+		},
+		{
+			name:  "no hotspot category configured for a resource",
+			names: "gas_a",
+			run: func(c *Constants) error {
+				_, err := c.ExtractorRate("gas_a", ClassB)
+				return err
+			},
+		},
+		{
+			name:  "part states no extraction rate",
+			names: PartExtractorMineral,
+			run: func(c *Constants) error {
+				_, err := c.ExtractorRate("crop_z", ClassB)
+				return err
+			},
+		},
+		{
+			name:  "depot states no storage buffer",
+			names: PartSupplyDepot,
+			run: func(c *Constants) error {
+				_, err := c.DepotCapacity()
+				return err
+			},
+		},
+		{
+			name:  "generator states no output",
+			names: PartGenerator,
+			run: func(c *Constants) error {
+				_, err := ComputePower(c, PowerInput{
+					Config: map[BaseID]PowerConfig{"a": {EMGenerators: 1, EMClass: ClassB}},
+				})
+				return err
+			},
+		},
+		{
+			name:  "crop states no yield",
+			names: "PLANT_Z",
+			run: func(c *Constants) error {
+				_, err := RollupProducers(
+					demandOf("a", SiteConfig{ExtractorClass: ClassB, FillSeconds: 3600},
+						map[string]int64{"crop_z": 10}),
+					a1, c, ProducerInput{})
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			curated := baseCurated()
+			curated.ResourceHotspots = map[string]string{"crop_z": "Mineral"}
+			c := constantsFor(t, a1, curated)
+
+			err := tc.run(c)
+			if err == nil {
+				t.Fatal("no error for an absent Tier 2 constant")
+			}
+			if !errors.Is(err, ErrMissingConstant) {
+				t.Errorf("error = %v, want ErrMissingConstant", err)
+			}
+			if errors.Is(err, ErrInvalidArtifact) {
+				t.Errorf("error also matches ErrInvalidArtifact, which erases the distinction: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.names) {
+				t.Errorf("error %q does not name the constant at fault (%q)", err, tc.names)
+			}
+		})
 	}
 }


### PR DESCRIPTION
First of two fixes from `/sdd:audit`. SPEC-0001 REQ "Error Handling Standards" carries a scenario the engine did not satisfy:

> **WHEN** a Tier 2 constant required by a producer calculation is absent
> **THEN** the engine returns an error matching the missing-constant sentinel, naming the constant

Every absent-constant path raised `ErrInvalidArtifact`. `errors.Is(err, ErrMissingConstant)` was false everywhere — the sentinel was defined in the vocabulary, mapped to `CodeMissingConstant` at the boundary, asserted in the boundary's code-mapping test, and **raised by nothing in the repository**.

Demonstrated before fixing, with a `Curated` set missing `panelsPerBattery`:

```
error: invalid tier 1 artifact: curated constant "panels per battery" is 0; it must be supplied, not defaulted
errors.Is(err, ErrMissingConstant) = false   <-- spec requires true
errors.Is(err, ErrInvalidArtifact) = true
```

## Why it matters

The distinction is the whole value of the sentinel. A view previously received `INVALID_ARTIFACT` for both *"you did not supply panels-per-battery"* (the caller's problem, fixable by them) and *"our artifact is broken"* (ours, not fixable by them).

That is precisely the classification the boundary's `Load` path goes out of its way to preserve — it has a long comment explaining why it classifies by *context* rather than by whichever sentinel wraps first, so that a view is never sent hunting through its own payload for our bug. The producer stages were collapsing the same distinction in the other direction.

SPEC-0007's base planner card is built almost entirely on curated constants — biodome capacity, fauna yield and cycle, steps per processor, depot threshold, panels per battery, processing time — so it is the surface that would have paid for this.

## The nine sites

Each is a Tier 2 figure that must be supplied and is not:

| Site | Message |
|---|---|
| `Curated.validate` | curated constant `%q` is 0; it must be supplied |
| `ExtractorRate` | no hotspot category is configured for `%q` |
| `ExtractorRate` | `U_EXTRACTOR_S` states no extraction rate |
| `DepotCapacity` | `U_SILO_S` states no storage buffer |
| `BatteryCapacity` | `U_BATTERY_S` states no storage buffer |
| `farmRow` | crop `%q` yields 0 per plant |
| `powerFor` | `U_GENERATOR_S` states no output |
| `powerFor` | `U_SOLAR_S` states no output |
| `powerFor` | panels per battery is 0; it must be supplied |

## What deliberately did not change

`Part`, `ClassStrength`'s category lookup, and `CropFor` keep `ErrUnknownItem`. Those report a **looked-up name that does not exist**, which is a different failure from a name that exists with no usable value — and `rollup_test.go` already asserts that distinction, so it is deliberate rather than incidental.

`NewConstants` with no economy section, a hotspot class outside C/B/A/S, a non-finite strength, and the nil-argument guards all keep `ErrInvalidArtifact`: those are the artifact being structurally wrong, which is what that sentinel is for.

`producer.go`'s "site fill duration must be configured" also keeps `ErrInvalidArtifact`. It is caller configuration rather than a Tier 2 constant, and the domain has no better sentinel for it — noted rather than reclassified, since inventing one is a SPEC-0001 change.

## Three tests changed, not worked around

`TestCuratedConstantsMustBeSupplied`, `TestGeneratorWithNoStatedOutputIsRefused`, and my own `TestMissingCuratedConstantCrossesWithAStableCode` from #69 all asserted the old sentinel. They encoded the behaviour the spec says is wrong, so they are updated to match the spec — per the audit rule that specs are the source of truth and code deviation is presumed wrong.

The boundary test's comment previously explained *why* the code was `INVALID_ARTIFACT` rather than `MISSING_CONSTANT`. That explanation is now the history of the bug, so the comment says so.

## New regression guard

`TestAbsentTier2ConstantMatchesTheMissingConstantSentinel` covers all six kinds of absence in one table, and asserts three things per case: the error matches `ErrMissingConstant`, it does **not** also match `ErrInvalidArtifact` (which would erase the distinction), and it names the constant at fault as the scenario requires.

Verified it fails without the fix — reverting just the depot site turns that subtest red and nothing else.

## Also

`ErrMissingConstant`'s doc comment read *"Stage 1 never returns it; it is defined here so the sentinel set is complete and stable across stages."* Stages 2 and 3 have since landed and still did not raise it, so the comment described a state that was meant to be temporary. It now says what raises it and how it differs from its two neighbours. (This was the audit's one policy finding.)

## Verification

```
gofmt -l .                     clean
go vet ./...                   clean
go test ./...                  all packages ok
go test -race ./...            all packages ok
GOOS=js GOARCH=wasm go build   ok
```

Found by `/sdd:audit`. Producer-stage provenance — the audit's other critical finding — follows in a separate PR.

Part of SPEC-0001

🤖 Generated with [Claude Code](https://claude.com/claude-code)