### PR TITLE
fix(domain): carry provenance through the producer stage

### DIFF
--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -38,7 +38,11 @@ import (
 // backward compatible in shape — but the result payload is part of what a
 // consumer parses, and leaving two different payloads claiming one version
 // is the drift the requirement exists to prevent.
-const ContractVersion = "1.1.0"
+//
+// 1.2.0 added provenance to every producer row and to each base, and the
+// verified-dates map to the request. Same reasoning: additive, but a
+// consumer that branches on provenance needs to know it is there.
+const ContractVersion = "1.2.0"
 
 // Quantity is an exact quantity on the wire.
 //

--- a/internal/bridge/stages.go
+++ b/internal/bridge/stages.go
@@ -54,6 +54,14 @@ type Curated struct {
 	// category each extracted resource sits on.
 	FaunaProducts    []string          `json:"faunaProducts,omitempty"`
 	ResourceHotspots map[string]string `json:"resourceHotspots,omitempty"`
+
+	// VerifiedOn records the date each constant was confirmed in game,
+	// keyed by the domain's constant names. A constant absent from this map
+	// has no verified date, and every figure derived from it comes back
+	// unverified.
+	//
+	// Governing: SPEC-0001 REQ "Provenance Propagation".
+	VerifiedOn map[string]string `json:"verifiedOn,omitempty"`
 }
 
 // Byproduct declares that one producer's output covers another item's
@@ -149,6 +157,7 @@ type FarmRow struct {
 	Biodomes      Quantity   `json:"biodomes"`
 	YieldPerPlant YieldRange `json:"yieldPerPlant"`
 	GrowthSeconds Quantity   `json:"growthSeconds"`
+	Verified      bool       `json:"verified"`
 }
 
 // ExtractorRow is one extracted resource at one base.
@@ -169,6 +178,7 @@ type ExtractorRow struct {
 	// configured duration, and usually less because the count rounded up.
 	RatePerSecond Quantity `json:"ratePerSecond"`
 	FillSeconds   Quantity `json:"fillSeconds"`
+	Verified      bool     `json:"verified"`
 }
 
 // RanchRow is one fauna product at one base.
@@ -178,6 +188,7 @@ type RanchRow struct {
 	Required     Quantity `json:"required"`
 	Fauna        Quantity `json:"fauna"`
 	CycleSeconds Quantity `json:"cycleSeconds"`
+	Verified     bool     `json:"verified"`
 }
 
 // KitchenInput is one ingredient of a processing step.
@@ -194,6 +205,7 @@ type KitchenStep struct {
 	Required       Quantity       `json:"required"`
 	ProcessSeconds Quantity       `json:"processSeconds"`
 	Final          bool           `json:"final"`
+	Verified       bool           `json:"verified"`
 	Inputs         []KitchenInput `json:"inputs,omitempty"`
 }
 
@@ -207,6 +219,7 @@ type NoBuildRow struct {
 	Name     string   `json:"name"`
 	From     string   `json:"from"`
 	Required Quantity `json:"required"`
+	Verified bool     `json:"verified"`
 }
 
 // BaseBuild is one base's construction instructions.
@@ -224,6 +237,10 @@ type BaseBuild struct {
 	PelletFeeders      Quantity `json:"pelletFeeders"`
 
 	NoBuild []NoBuildRow `json:"noBuild,omitempty"`
+
+	// Verified is the base-level answer: every row here, and the constant
+	// that sized its processors.
+	Verified bool `json:"verified"`
 }
 
 // Build is stage 2's output.
@@ -329,6 +346,12 @@ func DecodeCurated(c Curated) (domain.Curated, error) {
 		out.ResourceHotspots = make(map[string]string, len(c.ResourceHotspots))
 		for item, category := range c.ResourceHotspots {
 			out.ResourceHotspots[item] = category
+		}
+	}
+	if len(c.VerifiedOn) > 0 {
+		out.VerifiedOn = make(map[string]string, len(c.VerifiedOn))
+		for name, date := range c.VerifiedOn {
+			out.VerifiedOn[name] = date
 		}
 	}
 	return out, nil
@@ -481,6 +504,7 @@ func encodeBaseBuild(b domain.BaseBuild) BaseBuild {
 		},
 		NutrientProcessors: QuantityOfInt(b.NutrientProcessors),
 		PelletFeeders:      QuantityOfInt(b.PelletFeeders),
+		Verified:           b.Verified,
 	}
 	for _, r := range b.Farms {
 		out.Farms = append(out.Farms, FarmRow{
@@ -494,6 +518,7 @@ func encodeBaseBuild(b domain.BaseBuild) BaseBuild {
 				Max: QuantityOfInt(r.YieldPerPlant.Max),
 			},
 			GrowthSeconds: QuantityOfInt(r.GrowthSeconds),
+			Verified:      r.Verified,
 		})
 	}
 	for _, r := range b.Extractors {
@@ -506,6 +531,7 @@ func encodeBaseBuild(b domain.BaseBuild) BaseBuild {
 			Depots:         QuantityOfInt(r.Depots),
 			RatePerSecond:  QuantityOf(r.RatePerSecond()),
 			FillSeconds:    QuantityOf(r.FillSeconds()),
+			Verified:       r.Verified,
 		})
 	}
 	for _, r := range b.Ranches {
@@ -515,6 +541,7 @@ func encodeBaseBuild(b domain.BaseBuild) BaseBuild {
 			Required:     QuantityOf(r.Required()),
 			Fauna:        QuantityOfInt(r.Fauna),
 			CycleSeconds: QuantityOfInt(r.CycleSeconds),
+			Verified:     r.Verified,
 		})
 	}
 	for _, s := range b.Kitchen {
@@ -525,6 +552,7 @@ func encodeBaseBuild(b domain.BaseBuild) BaseBuild {
 			Required:       QuantityOf(s.Required()),
 			ProcessSeconds: QuantityOfInt(s.ProcessSeconds),
 			Final:          s.Final,
+			Verified:       s.Verified,
 		}
 		for _, i := range s.Inputs {
 			step.Inputs = append(step.Inputs, KitchenInput{
@@ -540,6 +568,7 @@ func encodeBaseBuild(b domain.BaseBuild) BaseBuild {
 			Name:     n.Name,
 			From:     n.From,
 			Required: QuantityOf(n.Required()),
+			Verified: n.Verified,
 		})
 	}
 	return out

--- a/internal/bridge/stages_test.go
+++ b/internal/bridge/stages_test.go
@@ -503,3 +503,50 @@ func TestUnassignedLeavesAreReported(t *testing.T) {
 		t.Errorf("unassigned = %+v, want gas_a totalling 30", build.Unassigned[0])
 	}
 }
+
+// SPEC-0001 REQ "Provenance Propagation", crossing the boundary.
+//
+// The stage-2 payload previously carried no provenance at all: the domain
+// computed it for the leaf demand and the producer rows dropped it, so a
+// view had nothing to mark. Both halves cross now — the row's own flag and
+// the base-level answer.
+func TestProducerProvenanceCrossesTheBoundary(t *testing.T) {
+	m := stagesModule(t)
+
+	// No verified dates: every constant is unconfirmed, which is the true
+	// state of this project's curated set today.
+	_, unverified := callOK(t, m, "rollup", rollupRequest(curatedJSON))
+	base := unverified.Data.Build.Bases[0]
+	if base.Farms[0].Verified {
+		t.Error("farm row crossed as verified with no constant dates supplied")
+	}
+	if base.Extractors[0].Verified {
+		t.Error("extractor row crossed as verified with no constant dates supplied")
+	}
+	if base.Verified {
+		t.Error("base crossed as verified with no constant dates supplied")
+	}
+
+	// The same plan with dates supplied crosses verified, so the flag
+	// tracks the input rather than being hardcoded either way.
+	dated := `{
+	  "biodomeCropSlots":"16","faunaYieldPerCycle":"12","faunaCycleSeconds":"1800",
+	  "stepsPerProcessor":"2","depotThreshold":"1000","processSeconds":"30",
+	  "panelsPerBattery":"2",
+	  "resourceHotspots":{"gas_a":"Gas"},
+	  "verifiedOn":{
+	    "biodome crop slots":"2026-08-20","depot threshold":"2026-08-20",
+	    "fauna yield per cycle":"2026-08-20","fauna cycle seconds":"2026-08-20",
+	    "steps per processor":"2026-08-20","process seconds":"2026-08-20",
+	    "panels per battery":"2026-08-20"
+	  }}`
+	_, verified := callOK(t, m, "rollup", rollupRequest(dated))
+	base = verified.Data.Build.Bases[0]
+	if !base.Farms[0].Verified || !base.Extractors[0].Verified {
+		t.Errorf("a row crossed unverified with every date supplied: farm=%v extractor=%v",
+			base.Farms[0].Verified, base.Extractors[0].Verified)
+	}
+	if !base.Verified {
+		t.Error("base crossed unverified with every date supplied")
+	}
+}

--- a/internal/domain/power.go
+++ b/internal/domain/power.go
@@ -58,7 +58,10 @@ type PowerBudget struct {
 	// see.
 	FixUnsized bool
 
-	// Verified is false when any contributing figure is.
+	// Verified is false when any contributing figure is: the caller
+	// declared this base unverified, or a curated constant this budget's
+	// arithmetic read has no verified date.
+	//
 	// Governing: SPEC-0001 REQ "Provenance Propagation".
 	Verified bool
 
@@ -193,6 +196,17 @@ func powerFor(base BaseID, c *Constants, in PowerInput) (PowerBudget, error) {
 				ErrMissingConstant, perBattery)
 		}
 		budget.Batteries = ceilRat(big.NewRat(cfg.SolarPanels, perBattery))
+
+		// The battery count is derived entirely from a curated constant, so
+		// it carries that constant's provenance. Applied inside the solar
+		// branch rather than beside the base's own flag: a base running no
+		// panels never reads this constant, and tainting it there would be
+		// the blanket behaviour the producer rows deliberately avoid.
+		//
+		// Governing: SPEC-0001 REQ "Provenance Propagation" — "Where any
+		// contributing node or constant is marked unverified in the source
+		// data, the derived figure MUST be marked unverified."
+		budget.Verified = budget.Verified && c.allVerified(ConstantPanelsPerBattery)
 	}
 
 	// Draw: every part's power dependency, times how many are built.

--- a/internal/domain/power_test.go
+++ b/internal/domain/power_test.go
@@ -439,3 +439,67 @@ func constantsFrom(t *testing.T, economy, version string) *Constants {
 	}
 	return c
 }
+
+// SPEC-0001 REQ "Provenance Propagation", applied to the power stage:
+// a battery count is derived entirely from a curated constant, so it
+// carries that constant's provenance.
+//
+// The selectivity case matters as much as the positive one. Batteries are
+// the only figure in this stage that reads a curated constant, so a base
+// running no solar panels must not be tainted by it — generation from
+// electromagnetic generators reads the artifact's part rate and hotspot
+// strength, neither of which is curated.
+func TestPanelsPerBatteryProvenanceReachesThePowerBudget(t *testing.T) {
+	const econ = `{
+	  "parts":[
+	    {"id":"U_SOLAR_S","primary":{"network":"power","rate":50}},
+	    {"id":"U_GENERATOR_S","primary":{"network":"power","rate":1},"hotspot":"Power"},
+	    {"id":"U_BATTERY_S","primary":{"network":"power","rate":0,"storage":45000}}
+	  ],
+	  "hotspots":[{"category":"Power","strengths":{"c":150,"b":220,"a":250,"s":300},"weightings":{"c":1,"b":1,"a":1,"s":1}}],
+	  "crops":[]}`
+	a1 := producerArtifact(t, econ)
+
+	budgetFor := func(t *testing.T, dated bool, cfg PowerConfig) PowerBudget {
+		t.Helper()
+		curated := baseCurated()
+		if dated {
+			curated.VerifiedOn = map[string]string{ConstantPanelsPerBattery: "2026-08-20"}
+		}
+		c := constantsFor(t, a1, curated)
+		budgets, err := ComputePower(c, PowerInput{
+			Config: map[BaseID]PowerConfig{"base": cfg},
+		})
+		if err != nil {
+			t.Fatalf("ComputePower: %v", err)
+		}
+		return budgets[0]
+	}
+
+	t.Run("solar with no verified date is unverified", func(t *testing.T) {
+		b := budgetFor(t, false, PowerConfig{SolarPanels: 4})
+		if b.Batteries != 2 {
+			t.Fatalf("batteries = %d, want 2", b.Batteries)
+		}
+		if b.Verified {
+			t.Error("a battery count derived from an unverified constant reported itself verified")
+		}
+	})
+
+	t.Run("solar with a verified date is verified", func(t *testing.T) {
+		b := budgetFor(t, true, PowerConfig{SolarPanels: 4})
+		if !b.Verified {
+			t.Error("budget unverified with the constant's date supplied")
+		}
+	})
+
+	t.Run("a base with no panels is not tainted by the constant", func(t *testing.T) {
+		b := budgetFor(t, false, PowerConfig{EMGenerators: 1, EMClass: ClassB})
+		if b.Batteries != 0 {
+			t.Fatalf("batteries = %d, want 0 with no panels", b.Batteries)
+		}
+		if !b.Verified {
+			t.Error("a base running no panels was tainted by a constant it never read")
+		}
+	})
+}

--- a/internal/domain/producer.go
+++ b/internal/domain/producer.go
@@ -50,6 +50,13 @@ type FarmRow struct {
 	// GrowthSeconds is time to maturity, from the artifact.
 	GrowthSeconds int64
 
+	// Verified is false when this row's demand carried unverified
+	// provenance, or when a curated constant its sizing read has no
+	// verified date.
+	//
+	// Governing: SPEC-0001 REQ "Provenance Propagation".
+	Verified bool
+
 	required *big.Rat
 }
 
@@ -73,6 +80,13 @@ type ExtractorRow struct {
 	// Depots is ceil(required / depot capacity) above the configured
 	// threshold, and zero below it.
 	Depots int64
+
+	// Verified is false when this row's demand carried unverified
+	// provenance, or when a curated constant its sizing read has no
+	// verified date.
+	//
+	// Governing: SPEC-0001 REQ "Provenance Propagation".
+	Verified bool
 
 	required *big.Rat
 	rate     *big.Rat
@@ -104,6 +118,13 @@ type RanchRow struct {
 	// CycleSeconds is that cycle's duration.
 	CycleSeconds int64
 
+	// Verified is false when this row's demand carried unverified
+	// provenance, or when a curated constant its sizing read has no
+	// verified date.
+	//
+	// Governing: SPEC-0001 REQ "Provenance Propagation".
+	Verified bool
+
 	required *big.Rat
 }
 
@@ -129,6 +150,12 @@ type KitchenStep struct {
 	// Governing: SPEC-0001 REQ "Producer Rollup" — Scenario "Final kitchen
 	// step is distinguished".
 	Final bool
+
+	// Verified is false when a curated constant this step's timing read has
+	// no verified date.
+	//
+	// Governing: SPEC-0001 REQ "Provenance Propagation".
+	Verified bool
 
 	required *big.Rat
 }
@@ -160,6 +187,12 @@ type NoBuild struct {
 	// From names the producer whose byproduct covers it.
 	From string
 
+	// Verified carries the demand's provenance. A covered demand builds
+	// nothing, but it is still a figure the plan reports.
+	//
+	// Governing: SPEC-0001 REQ "Provenance Propagation".
+	Verified bool
+
 	required *big.Rat
 }
 
@@ -187,6 +220,14 @@ type BaseBuild struct {
 
 	// NoBuild are items a byproduct at this base already covers.
 	NoBuild []NoBuild
+
+	// Verified is false when any row at this base is unverified, or when
+	// the constant sizing the base's nutrient processors has no verified
+	// date. It is the base-level answer to "was everything contributing to
+	// these instructions confirmed".
+	//
+	// Governing: SPEC-0001 REQ "Provenance Propagation".
+	Verified bool
 }
 
 // Build is stage 2's producer output.
@@ -284,6 +325,7 @@ func rollupBase(group BaseGroup, t *Tier1, c *Constants, in ProducerInput) (*Bas
 		if from, ok := covered[demand.ItemID]; ok {
 			build.NoBuild = append(build.NoBuild, NoBuild{
 				ItemID: demand.ItemID, Name: demand.Name, From: from,
+				Verified: demand.Verified,
 				required: demand.Total(),
 			})
 			continue
@@ -329,8 +371,48 @@ func rollupBase(group BaseGroup, t *Tier1, c *Constants, in ProducerInput) (*Bas
 		build.NutrientProcessors = ceilRat(big.NewRat(n, c.Curated().StepsPerProcessor))
 	}
 
+	// The base's own provenance: every row it carries, plus the constant
+	// that sized its processors. Computed after the rows rather than
+	// alongside them, because it is an answer about the whole base and a
+	// row added later must be included without a second place to remember.
+	//
+	// Governing: SPEC-0001 REQ "Provenance Propagation" — "The engine MUST
+	// NOT silently present unverified-derived values as verified."
+	build.Verified = build.rowsVerified() &&
+		(build.NutrientProcessors == 0 || c.allVerified(ConstantStepsPerProcessor))
+
 	sortRows(build)
 	return build, nil
+}
+
+// rowsVerified reports whether every row at this base is verified.
+func (b *BaseBuild) rowsVerified() bool {
+	for _, r := range b.Farms {
+		if !r.Verified {
+			return false
+		}
+	}
+	for _, r := range b.Extractors {
+		if !r.Verified {
+			return false
+		}
+	}
+	for _, r := range b.Ranches {
+		if !r.Verified {
+			return false
+		}
+	}
+	for _, s := range b.Kitchen {
+		if !s.Verified {
+			return false
+		}
+	}
+	for _, n := range b.NoBuild {
+		if !n.Verified {
+			return false
+		}
+	}
+	return true
 }
 
 // farmRow sizes plants and biodomes for a crop.
@@ -361,7 +443,9 @@ func farmRow(d LeafDemand, c *Constants) (FarmRow, error) {
 		Plants: plants, Biodomes: domes,
 		YieldPerPlant: crop.Yield,
 		GrowthSeconds: crop.GrowthSeconds,
-		required:      d.Total(),
+		// Domes are sized by a curated constant; plants are not.
+		Verified: d.Verified && c.allVerified(ConstantBiodomeCropSlots),
+		required: d.Total(),
 	}, nil
 }
 
@@ -391,6 +475,10 @@ func extractorRow(d LeafDemand, site SiteConfig, c *Constants) (ExtractorRow, er
 	row := ExtractorRow{
 		ItemID: d.ItemID, Name: d.Name,
 		Class: site.ExtractorClass, Extractors: count,
+		// The depot threshold is read on every row, not only on those that
+		// report depots: it is the comparison that decides whether a row
+		// reports none, so a row saying "no depots" rests on it too.
+		Verified: d.Verified && c.allVerified(ConstantDepotThreshold),
 		required: d.Total(), rate: rate, fill: fill,
 	}
 
@@ -415,6 +503,8 @@ func ranchRow(d LeafDemand, c *Constants) RanchRow {
 	return RanchRow{
 		ItemID: d.ItemID, Name: d.Name,
 		Fauna: fauna, CycleSeconds: curated.FaunaCycleSeconds,
+		Verified: d.Verified &&
+			c.allVerified(ConstantFaunaYieldPerCycle, ConstantFaunaCycleSeconds),
 		required: d.Total(),
 	}
 }
@@ -448,6 +538,7 @@ func kitchenSteps(inputs []KitchenStepInput, t *Tier1, c *Constants) ([]KitchenS
 		s := KitchenStep{
 			ItemID: step.ItemID, Name: item.Name, Recipe: recipe.ID,
 			ProcessSeconds: c.ProcessSeconds(),
+			Verified:       c.allVerified(ConstantProcessSeconds),
 			required:       new(big.Rat).SetInt64(step.Quantity),
 			// The last step named is the one producing the plan target;
 			// everything before it is intermediate.

--- a/internal/domain/producer_test.go
+++ b/internal/domain/producer_test.go
@@ -591,3 +591,142 @@ func TestUnclassifiedResourceIsRefused(t *testing.T) {
 		t.Errorf("error %q does not name the item and what is missing", err)
 	}
 }
+
+// SPEC-0001 REQ "Provenance Propagation" — Scenario "Unverified constant
+// taints producer count":
+// WHEN a Tier 2 constant used in a producer calculation lacks a verified
+// date THEN the resulting producer count is marked unverified.
+//
+// The selectivity cases are the point. A blanket "any constant unverified"
+// flag would pass the first two assertions and be useless: it would mark a
+// farm row unverified because nobody has confirmed the fauna cycle length.
+// Provenance is only worth carrying if it is computed from the constants
+// the row's own arithmetic read.
+func TestUnverifiedConstantTaintsOnlyTheRowsThatReadIt(t *testing.T) {
+	// milk, crop_a and gas_a are all in producerArtifact's base item set.
+	a1 := producerArtifact(t, economyFor(25, 1800, 100, 720))
+
+	site := SiteConfig{ExtractorClass: ClassB, FillSeconds: 3600}
+	demands := map[string]int64{"crop_a": 200, "gas_a": 300, "milk": 120}
+
+	rollupWith := func(t *testing.T, verifiedOn map[string]string) BaseBuild {
+		t.Helper()
+		curated := baseCurated()
+		curated.VerifiedOn = verifiedOn
+		c := constantsFor(t, a1, curated)
+		b := build(t, demandOf("alpha", site, demands), a1, c, ProducerInput{})
+		base, ok := b.Base("alpha")
+		if !ok {
+			t.Fatal("no build for alpha")
+		}
+		return base
+	}
+
+	t.Run("no dates at all taints every row", func(t *testing.T) {
+		base := rollupWith(t, nil)
+		if base.Farms[0].Verified {
+			t.Error("farm row verified with no constant dates")
+		}
+		if base.Extractors[0].Verified {
+			t.Error("extractor row verified with no constant dates")
+		}
+		if base.Ranches[0].Verified {
+			t.Error("ranch row verified with no constant dates")
+		}
+		if base.Verified {
+			t.Error("base verified with no constant dates")
+		}
+	})
+
+	t.Run("every date present verifies every row", func(t *testing.T) {
+		base := rollupWith(t, map[string]string{
+			ConstantBiodomeCropSlots:   "2026-08-20",
+			ConstantDepotThreshold:     "2026-08-20",
+			ConstantFaunaYieldPerCycle: "2026-08-20",
+			ConstantFaunaCycleSeconds:  "2026-08-20",
+			ConstantStepsPerProcessor:  "2026-08-20",
+			ConstantProcessSeconds:     "2026-08-20",
+			ConstantPanelsPerBattery:   "2026-08-20",
+		})
+		if !base.Farms[0].Verified || !base.Extractors[0].Verified || !base.Ranches[0].Verified {
+			t.Errorf("a row is unverified with every date present: farm=%v extractor=%v ranch=%v",
+				base.Farms[0].Verified, base.Extractors[0].Verified, base.Ranches[0].Verified)
+		}
+		if !base.Verified {
+			t.Error("base unverified with every date present and every row verified")
+		}
+	})
+
+	t.Run("an unverified fauna constant leaves the farm and extractor alone", func(t *testing.T) {
+		base := rollupWith(t, map[string]string{
+			ConstantBiodomeCropSlots: "2026-08-20",
+			ConstantDepotThreshold:   "2026-08-20",
+			// fauna constants deliberately absent
+		})
+		if !base.Farms[0].Verified {
+			t.Error("farm row tainted by an unverified fauna constant it never read")
+		}
+		if !base.Extractors[0].Verified {
+			t.Error("extractor row tainted by an unverified fauna constant it never read")
+		}
+		if base.Ranches[0].Verified {
+			t.Error("ranch row verified without a fauna constant date")
+		}
+		if base.Verified {
+			t.Error("base verified while one of its rows is not")
+		}
+	})
+
+	t.Run("an unverified dome constant leaves the extractor alone", func(t *testing.T) {
+		base := rollupWith(t, map[string]string{
+			ConstantDepotThreshold:     "2026-08-20",
+			ConstantFaunaYieldPerCycle: "2026-08-20",
+			ConstantFaunaCycleSeconds:  "2026-08-20",
+		})
+		if base.Farms[0].Verified {
+			t.Error("farm row verified without a biodome constant date")
+		}
+		if !base.Extractors[0].Verified {
+			t.Error("extractor row tainted by an unverified biodome constant it never read")
+		}
+	})
+}
+
+// SPEC-0001 REQ "Provenance Propagation" — Scenario "Unverified input taints
+// derived total", carried into stage 2.
+//
+// Stage 1 already marked the demand; before this the producer stage dropped
+// that mark on the floor, so a row derived entirely from unverified data
+// reported nothing about it.
+func TestUnverifiedDemandTaintsItsProducerRow(t *testing.T) {
+	a1 := producerArtifact(t, economyFor(25, 1800, 100, 720))
+
+	curated := baseCurated()
+	curated.VerifiedOn = map[string]string{
+		ConstantBiodomeCropSlots: "2026-08-20",
+		ConstantDepotThreshold:   "2026-08-20",
+	}
+	c := constantsFor(t, a1, curated)
+
+	group := demandOf("alpha", SiteConfig{ExtractorClass: ClassB, FillSeconds: 3600},
+		map[string]int64{"crop_a": 200, "gas_a": 300})
+	// crop_a arrives unverified from stage 1; gas_a does not.
+	for i := range group.Groups[0].Demands {
+		if group.Groups[0].Demands[i].ItemID == "crop_a" {
+			group.Groups[0].Demands[i].Verified = false
+		}
+	}
+
+	b := build(t, group, a1, c, ProducerInput{})
+	base, _ := b.Base("alpha")
+
+	if base.Farms[0].Verified {
+		t.Error("a row built from an unverified demand reported itself verified")
+	}
+	if !base.Extractors[0].Verified {
+		t.Error("a verified demand's row was tainted by an unrelated unverified demand")
+	}
+	if base.Verified {
+		t.Error("base verified while one of its rows is not")
+	}
+}

--- a/internal/domain/rollup.go
+++ b/internal/domain/rollup.go
@@ -141,21 +141,50 @@ type Curated struct {
 	// before.
 	FaunaProducts    map[string]bool
 	ResourceHotspots map[string]string
+
+	// VerifiedOn records the date each curated constant was confirmed in
+	// game, keyed by the names above. A constant absent from this map has
+	// no verified date, and every figure derived from it is reported
+	// unverified.
+	//
+	// Governing: SPEC-0001 REQ "Provenance Propagation" — Scenario
+	// "Unverified constant taints producer count".
+	//
+	// Absence rather than a boolean is deliberate: "we have not checked" is
+	// the honest default for a set that is curated precisely because the
+	// game tables do not state it, and a caller who has checked records
+	// when. An empty map therefore taints every producer count, which is
+	// the correct reading of today's data rather than a limitation.
+	VerifiedOn map[string]string
 }
 
 // validate refuses a partially-specified constant set.
+// The curated constants' names, used both to report an unsupplied one and
+// to key its verification date. Named rather than repeated as literals so
+// a constant cannot be validated under one spelling and verified under
+// another.
+const (
+	ConstantBiodomeCropSlots   = "biodome crop slots"
+	ConstantFaunaYieldPerCycle = "fauna yield per cycle"
+	ConstantFaunaCycleSeconds  = "fauna cycle seconds"
+	ConstantStepsPerProcessor  = "steps per processor"
+	ConstantDepotThreshold     = "depot threshold"
+	ConstantProcessSeconds     = "process seconds"
+	ConstantPanelsPerBattery   = "panels per battery"
+)
+
 func (c Curated) validate() error {
 	for _, f := range []struct {
 		name string
 		v    int64
 	}{
-		{"biodome crop slots", c.BiodomeCropSlots},
-		{"fauna yield per cycle", c.FaunaYieldPerCycle},
-		{"fauna cycle seconds", c.FaunaCycleSeconds},
-		{"steps per processor", c.StepsPerProcessor},
-		{"depot threshold", c.DepotThreshold},
-		{"process seconds", c.ProcessSeconds},
-		{"panels per battery", c.PanelsPerBattery},
+		{ConstantBiodomeCropSlots, c.BiodomeCropSlots},
+		{ConstantFaunaYieldPerCycle, c.FaunaYieldPerCycle},
+		{ConstantFaunaCycleSeconds, c.FaunaCycleSeconds},
+		{ConstantStepsPerProcessor, c.StepsPerProcessor},
+		{ConstantDepotThreshold, c.DepotThreshold},
+		{ConstantProcessSeconds, c.ProcessSeconds},
+		{ConstantPanelsPerBattery, c.PanelsPerBattery},
 	} {
 		if f.v <= 0 {
 			return fmt.Errorf("%w: curated constant %q is %d; it must be supplied, not defaulted",
@@ -233,6 +262,30 @@ func NewConstants(t *Tier1, curated Curated) (*Constants, error) {
 
 // Curated returns the caller-supplied constants.
 func (c *Constants) Curated() Curated { return c.curated }
+
+// ConstantVerified reports whether a curated constant carries a verified
+// date.
+//
+// Governing: SPEC-0001 REQ "Provenance Propagation" — "Where any
+// contributing node or constant is marked unverified in the source data,
+// the derived figure MUST be marked unverified."
+func (c *Constants) ConstantVerified(name string) bool {
+	_, ok := c.curated.VerifiedOn[name]
+	return ok
+}
+
+// allVerified reports whether every named constant carries a date. Used by
+// the producer stage to decide a row's provenance from the constants that
+// row's arithmetic actually read — not from the whole set, which would
+// taint a farm row for an unverified ranch constant.
+func (c *Constants) allVerified(names ...string) bool {
+	for _, n := range names {
+		if !c.ConstantVerified(n) {
+			return false
+		}
+	}
+	return true
+}
 
 // ProcessSeconds is one nutrient processor step's duration.
 func (c *Constants) ProcessSeconds() int64 { return c.curated.ProcessSeconds }


### PR DESCRIPTION
Second of two fixes from `/sdd:audit`. Independent of #73 — different requirement, no shared files beyond the package.

## The gap

SPEC-0001 REQ "Provenance Propagation" opens:

> Every computed figure MUST carry provenance indicating whether all inputs contributing to it were verified.

No producer-stage figure did. `FarmRow`, `ExtractorRow`, `RanchRow`, `KitchenStep`, `NoBuild` and `BaseBuild` had **no provenance field at all** — `grep -n Verified internal/domain/producer.go` returned nothing. Stage 1 computed the leaf's provenance into `LeafDemand.Verified`, and stage 2 read that grouping and dropped it.

The requirement's second scenario had nothing to evaluate either:

> **WHEN** a Tier 2 constant used in a producer calculation lacks a verified date
> **THEN** the resulting producer count is marked unverified

`Curated` carried no dates, so "lacks a verified date" could not be asked of it.

This lands hardest on SPEC-0007's base planner card, which is built almost entirely on curated constants — biodome capacity, fauna yield and cycle, steps per processor, depot threshold, panels per battery, processing time. Its provenance requirement is currently phrased as a *prohibition on implying a check was made*, because the positive form was unavailable. It can be tightened once this lands.

## Verified dates, not a boolean

`Curated` gains `VerifiedOn map[string]string`, keyed by constant name.

Absence rather than a boolean is deliberate. "We have not checked" is the honest default for a set that is curated *precisely because the game tables do not state these values* — ADR-0001 records biodome slots as community-wiki-sourced, and `Curated`'s own comments say the fauna constants "do not appear in the reality tables". An empty map taints every producer count, which is the correct reading of today's data rather than a limitation of the model.

## Selectivity is the point

Each row's provenance is its demand's provenance **and the constants its own arithmetic read** — not the whole set.

A blanket "any constant unverified" flag would satisfy the requirement's letter and be useless: it would mark a farm row unverified because nobody has confirmed the fauna cycle length. So:

| Constant | Taints |
|---|---|
| biodome crop slots | farm rows |
| depot threshold | extractor rows (every row — it is the comparison deciding whether a row reports *no* depots) |
| fauna yield per cycle, fauna cycle seconds | ranch rows |
| process seconds | kitchen steps |
| steps per processor | the base's processor count |

Four selectivity subtests hold that line, including two that assert a row is **not** tainted by a constant it never read.

The base's own flag is computed after its rows rather than alongside them, so a row type added later is included without a second place to remember.

## Constant names

The names were string literals inside `validate()`. They are now named constants, because a constant validated under one spelling and verified under another would silently never be verified — a bug with no symptom except everything reading unverified forever.

## Tests

- `TestUnverifiedConstantTaintsOnlyTheRowsThatReadIt` — four cases: no dates taints everything; all dates verifies everything; an unverified fauna constant leaves farm and extractor alone; an unverified dome constant leaves the extractor alone.
- `TestUnverifiedDemandTaintsItsProducerRow` — stage 1's mark now survives into stage 2, and does not bleed onto a sibling row whose demand was verified.
- `TestProducerProvenanceCrossesTheBoundary` — both halves cross, and the flag tracks the input rather than being hardcoded either way.

## Contract version 1.1.0 → 1.2.0

Every producer row and each base gained `verified`; the request gained `verifiedOn`. Additive, same reasoning as 1.1.0 — a consumer that branches on provenance needs to know it is there.

## Verification

```
gofmt -l .                     clean
go vet ./...                   clean
go test ./...                  all packages ok
go test -race ./...            all packages ok
GOOS=js GOARCH=wasm go build   ok
```

Purity guards pass, including `TestAdapterHoldsNoDomainLogic` — the provenance decision is the domain's and the adapter only renders the flag.

Found by `/sdd:audit`.

Part of SPEC-0001

🤖 Generated with [Claude Code](https://claude.com/claude-code)