### PR TITLE
docs: record SPEC-0006 in ADR-0005's governs edge

### DIFF
--- a/docs/adrs/ADR-0005-multiple-recipes-per-output.md
+++ b/docs/adrs/ADR-0005-multiple-recipes-per-output.md
@@ -3,7 +3,7 @@ status: accepted
 date: 2026-08-18
 decision-makers: [Jon Stump]
 extends: [ADR-0001]
-governs: [SPEC-0001, SPEC-0004]
+governs: [SPEC-0001, SPEC-0004, SPEC-0006]
 ---
 
 # ADR-0005: Multiple recipes per output, with explicit yields and player selection
@@ -153,4 +153,4 @@ Sodium Nitrate is the readable example — 26 refine recipes including `2x Sodiu
 
 **On the plan-state cost.** ADR-0002 and the design handoffs put plan state in the URL hash. Adding a per-node recipe choice grows it, and the hash is already size-sensitive. The mitigation is that the default is deterministic: a node using its default recipe encodes nothing, so only deliberate overrides cost bytes.
 
-**Related.** ADR-0001 (two-tier ingestion — this extends its Tier 1 half), SPEC-0001 (rollup engine), SPEC-0004 (Tier 1 normalizer).
+**Related.** ADR-0001 (two-tier ingestion — this extends its Tier 1 half), SPEC-0001 (rollup engine), SPEC-0004 (Tier 1 normalizer), SPEC-0006 (tree canvas — the surface that carries out this decision's instruction to the view, offering a node's recipe alternatives rather than presenting one route as though it were the only one).


### PR DESCRIPTION
The audit's one remaining warning. Two lines.

ADR-0005 assigns the view a job explicitly — *"The view surfaces the alternatives per node and the player may pick another"* — and SPEC-0006 is the spec that carries it out, declaring `implements: [ADR-0004, ADR-0005]`.

ADR-0005's own `governs` list predated that spec and still named only SPEC-0001 and SPEC-0004, so `/sdd:graph` would show the decision governing two specs while three artifacts relate to it. `governs` and `implements` are independent forward edges (per the plugin's edge schema, neither is the other's inverse), so both sides need authoring and only one had been updated.

The prose **Related.** line carried the same omission and now agrees with the frontmatter.

**Deliberately unchanged:** the "Downstream amendments this decision requires" section. That records what ADR-0005 required of *existing* specs when it was made — SPEC-0001, SPEC-0002, SPEC-0004, all four of which landed. SPEC-0006 implements the decision rather than being amended by it, so adding it there would be revisionist about what the decision asked for at the time.

Docs only. Found by `/sdd:audit`.

Part of ADR-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)