### PR TITLE
docs: advance SPEC-0005 to approved and accept ADR-0006/0007

### DIFF
--- a/docs/adrs/ADR-0006-freighter-surface.md
+++ b/docs/adrs/ADR-0006-freighter-surface.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-08-18
 decision-makers: [Jon Stump]
 extends: [ADR-0001, ADR-0002]

--- a/docs/adrs/ADR-0007-settlement-surface.md
+++ b/docs/adrs/ADR-0007-settlement-surface.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-08-18
 decision-makers: [Jon Stump]
 extends: [ADR-0001, ADR-0002]

--- a/docs/openspec/specs/view-foundations/spec.md
+++ b/docs/openspec/specs/view-foundations/spec.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: approved
 date: 2026-08-19
 implements: [ADR-0004]
 requires: [SPEC-0002]


### PR DESCRIPTION
Three frontmatter lines. No body content touched.

| Artifact | Change | Why |
|---|---|---|
| SPEC-0005 view-foundations | `draft` → `approved` | Five stories planned from it; PR #76 implements two of its six requirements |
| ADR-0006 freighter-surface | `proposed` → `accepted` | User decision |
| ADR-0007 settlement-surface | `proposed` → `accepted` | User decision |

## Why approved and not implemented

SPEC-0005 has been through a `/sdd:check` round with its findings resolved (#65), broken into epic #57's five stories, and #58 is in review. A spec five stories are being built from is not a draft.

But it is not implemented either: `web/` is not on main yet, and four of its six requirements — Boundary Client, View State Boundaries, Module Loading, The View Computes No Domain Values — have no code at all. `approved` is the accurate step.

## Everything else was checked and left alone

- SPEC-0001, SPEC-0002, SPEC-0003, SPEC-0004 — `implemented`, all with code on main. Correct.
- SPEC-0006 tree-canvas, SPEC-0007 base-planner-card — `draft`, no epic, no stories, no code. Correct.
- ADR-0001 … ADR-0005 — `accepted`. Correct.

## Format

All seven ADRs and all seven specs use `yaml-frontmatter`. None carries the inline `- **Status:**` bullet, so there is no dual-source-of-truth file to refuse. Format preserved in place.

## Index

`qmd update` was a day stale — it held 5 ADRs and 10 spec files against the 7 and 14 that exist. Re-synced; both collections are now current.

**Two context blurbs have drifted, and I have not rewritten them** — that is a deliberate edit, not a side effect of a status change:

- `nms-base-planner-specs` enumerates SPEC-0001 through SPEC-0005 only. SPEC-0006 and SPEC-0007 are missing. It also still describes SPEC-0002's rollup and power as "reserved to follow the same envelope contract when added" — #69 wired them.
- `nms-base-planner-adrs` does not mention ADR-0006 or ADR-0007 at all.

Neither drifted on *status*, because the specs blurb explicitly says lifecycle status lives in frontmatter and is authoritative there — which is exactly what that line was added for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)