### PR TITLE
docs: advance SPEC-0006 and SPEC-0007 to approved

### DIFF
--- a/docs/openspec/specs/base-planner-card/spec.md
+++ b/docs/openspec/specs/base-planner-card/spec.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: approved
 date: 2026-08-20
 implements: [ADR-0004]
 requires: [SPEC-0001, SPEC-0002, SPEC-0005]

--- a/docs/openspec/specs/tree-canvas/spec.md
+++ b/docs/openspec/specs/tree-canvas/spec.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: approved
 date: 2026-08-19
 implements: [ADR-0004, ADR-0005]
 requires: [SPEC-0001, SPEC-0002, SPEC-0005]


### PR DESCRIPTION
Two frontmatter lines. No body content touched.

| Artifact | Change | Format |
|---|---|---|
| SPEC-0006 tree-canvas | `draft` → `approved` | yaml-frontmatter, preserved in place |
| SPEC-0007 base-planner-card | `draft` → `approved` | yaml-frontmatter, preserved in place |

## Format detection

Both files carry a `status:` key in a leading `---` block and **no** inline `- **Status:**` bullet within the 20 lines after their H1. Neither is a dual-format file, so there is no ambiguous source of truth to refuse. The edit touches only the `status:` line — no key reordered, no blank line inserted, no other frontmatter field read or rewritten.

## Why approved

Approval licenses planning; it does not follow it. In #77 I left these two at `draft` and gave the reason as "no epic, no stories, no code" — that was a reason not to change them unprompted, not a claim that approving them needs stories first. `/sdd:plan` runs *from* an approved spec.

Both are ready by the checks that do apply:

- Each is paired with a `design.md`
- Each declares its `## Graph Edges`, and both `implements: [ADR-0004]`
- Both `requires: [SPEC-0005]`, which reached `approved` in #77 and whose foundation stories are now built — #58 merged, and #78 / #79 / #80 are open for #61, #59 and #60

Not `implemented`: no code exists for either surface.

## Everything else left alone

| Spec | Status | Correct |
|---|---|---|
| SPEC-0001 rollup-engine | `implemented` | yes — code on main |
| SPEC-0002 wasm-boundary | `implemented` | yes |
| SPEC-0003 hgpak-reader | `implemented` | yes |
| SPEC-0004 tier1-normalizer | `implemented` | yes |
| SPEC-0005 view-foundations | `approved` | yes — four of six requirements still have no code |

## Next

Neither spec has been planned. `/sdd:plan SPEC-0006` and `/sdd:plan SPEC-0007` are what approval unblocks.
