### PR TITLE
test(web): complete the accessibility baseline

### DIFF
--- a/web/scripts/mutation-check.sh
+++ b/web/scripts/mutation-check.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
-# Governing: SPEC-0005 REQ "Token Discipline", REQ "Component Styling Discipline"
+# Governing: SPEC-0005 REQ "Token Discipline", REQ "Component Styling
+# Discipline", Accessibility Requirements
 #
 # "Each test fails against a deliberately broken stylesheet, checked by
 #  breaking it rather than assumed." (issue #61)
+#
+# "Every focus-return route is tested separately — a single 'close the
+#  popover' test would pass while two of the three routes are broken."
+#  (issue #62)
+#
+# #61 covered the stylesheet. #62 extends the same treatment to the
+# accessibility primitives, because the same argument applies and more
+# sharply: a focus trap that has stopped restoring focus looks identical on
+# screen to one that works.
 #
 # A passing suite proves the stylesheet is not broken in the ways the suite
 # knows how to look for. It does not prove the suite can see anything at all —
@@ -20,8 +30,15 @@ cd "$(dirname "$0")/.."
 
 BASE="src/styles/base.css"
 TOKENS="src/styles/tokens.css"
+TRAP="src/a11y/useFocusTrap.ts"
+LIVE="src/a11y/useLiveRegion.ts"
+SHELL="src/shell/AppShell.tsx"
+BADGE="src/shell/StatusBadge.tsx"
 
-restore() { git checkout -- "$BASE" "$TOKENS" 2>/dev/null || true; }
+MUTABLE="$BASE $TOKENS $TRAP $LIVE $SHELL $BADGE"
+
+# shellcheck disable=SC2086
+restore() { git checkout -- $MUTABLE 2>/dev/null || true; }
 trap restore EXIT
 
 # mutate <file> <python-expression-safe-old> <new>
@@ -136,6 +153,71 @@ check "the coarse-pointer target shrinks below 44px" \
   tests/control-scale.spec.ts "$BASE" \
   "    min-height: var(--target-coarse);" \
   "    min-height: 40px;"
+
+# ----------------------------------------------------------------------
+# Accessibility primitives.
+#
+# The focus-trap mutations are the ones worth reading. "Escape-only restore"
+# is not a strawman — it is the natural way to write it, and it leaves the
+# Escape test green while the backdrop and close-control tests go red. That
+# is the whole reason issue #62 words the criterion around routes.
+# ----------------------------------------------------------------------
+
+check "focus is never returned on close" \
+  tests/shell/a11y-primitives.spec.ts "$TRAP" \
+  "      if (target?.isConnected) target.focus();" \
+  "      void target;"
+
+check "focus is restored only by the Escape handler" \
+  tests/shell/a11y-primitives.spec.ts "$TRAP" \
+  "      if (target?.isConnected) target.focus();" \
+  "      void target;
+      // the Escape-only implementation restores here instead"
+
+check "the focus trap stops containing Tab" \
+  tests/shell/a11y-primitives.spec.ts "$TRAP" \
+  "      if (event.key !== \"Tab\") return;" \
+  "      if (event.key !== \"Tab\") return;
+      return;"
+
+check "the live region announces on first render too" \
+  tests/shell/a11y-primitives.spec.ts "$LIVE" \
+  "    if (first || !changed || token === null) return;" \
+  "    if (!changed) return;"
+
+check "the live region announces on every render" \
+  tests/shell/a11y-primitives.spec.ts "$LIVE" \
+  "    if (first || !changed || token === null) return;" \
+  "    if (false) return;"
+
+check "a landmark goes missing" \
+  tests/shell/shell.spec.ts "$SHELL" \
+  '      <footer className="shell-footer">' \
+  '      <div className="shell-footer">'
+
+check "the navigation landmark loses its name" \
+  tests/shell/shell.spec.ts "$SHELL" \
+  '      <nav className="shell-nav" aria-label="Surfaces">' \
+  '      <nav className="shell-nav">'
+
+check "a status loses the word beside its colour" \
+  tests/shell/a11y-baseline.spec.ts "$BADGE" \
+  '  ok: { tokenClass: "status-ok", glyph: "✓", label: "OK" },' \
+  '  ok: { tokenClass: "status-ok", glyph: "✓", label: "" },'
+
+check "two statuses become indistinguishable without colour" \
+  tests/shell/a11y-baseline.spec.ts "$BADGE" \
+  '  unverified: { tokenClass: "status-unverified", glyph: "?", label: "Unverified" },' \
+  '  unverified: { tokenClass: "status-unverified", glyph: "?", label: "Pending" },'
+
+check "a control is named only by a glyph" \
+  tests/shell/a11y-baseline.spec.ts "$SHELL" \
+  '        <button type="submit" className="control control-primary interactive">
+          Recompute
+        </button>' \
+  '        <button type="submit" className="control control-primary interactive">
+          →
+        </button>'
 
 echo
 if [ "$failures" -gt 0 ]; then

--- a/web/tests/fixtures/status-harness.tsx
+++ b/web/tests/fixtures/status-harness.tsx
@@ -1,0 +1,41 @@
+/*
+ * Renders every status through the real component.
+ *
+ * Governing: SPEC-0005 Accessibility Requirements — "Colour MUST NOT be the
+ * sole carrier of any distinction."
+ *
+ * The shell can only reach two of the five statuses by driving its controls,
+ * so a test that walks the running app checks two and infers three. This
+ * mounts StatusBadge once per member of its own exported table, so the
+ * assertion covers every state the component can produce and a status added
+ * without a glyph and a word fails rather than going unvisited.
+ *
+ * It renders the real component, not a copy. A fixture that reimplemented the
+ * badge would pass against a component that had stopped rendering its word.
+ */
+
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { StatusBadge, STATUSES } from "../../src/shell/StatusBadge";
+
+import "../../src/styles/tokens.css";
+import "../../src/styles/base.css";
+import "../../src/styles/shell.css";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("status.html is missing #root");
+
+createRoot(root).render(
+  <StrictMode>
+    <ul>
+      {STATUSES.map((status) => (
+        <li key={status} data-status={status}>
+          <StatusBadge status={status} />
+        </li>
+      ))}
+    </ul>
+  </StrictMode>,
+);
+
+document.body.dataset["statusCount"] = String(STATUSES.length);

--- a/web/tests/fixtures/status.html
+++ b/web/tests/fixtures/status.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Status badge fixture</title>
+  </head>
+  <body>
+    <!--
+      Governing: SPEC-0005 Accessibility Requirements
+
+      Every status the component can render, mounted through the component
+      itself. The shell reaches two of five by ordinary use; this reaches all
+      of them so "colour is never the only carrier" is checked exhaustively
+      rather than sampled.
+    -->
+    <div id="root"></div>
+    <script type="module" src="./status-harness.tsx"></script>
+  </body>
+</html>

--- a/web/tests/helpers/accessible-name.ts
+++ b/web/tests/helpers/accessible-name.ts
@@ -1,0 +1,96 @@
+/*
+ * Computing the accessible name of a control, in the browser.
+ *
+ * Governing: SPEC-0005 Accessibility Requirements
+ *
+ * Runs as a page function rather than in Node: an accessible name comes from
+ * `aria-labelledby`, `aria-label`, content, and `title` in that order, and
+ * only the document can resolve the second and third.
+ *
+ * This exists because axe does not catch the case SPEC-0005 actually names.
+ * "Icon-only controls MUST carry an aria-label" is about a control whose only
+ * content is a glyph — `✕`, `⚠`, `→`. axe's `button-name` rule sees text
+ * content there and calls the control named, because by the specification's
+ * definition it is. It is named "✕", which a screen reader reads as "multiplication
+ * X" or skips entirely, and which tells nobody what the control does.
+ *
+ * So the rule enforced here is narrower and stricter than the standard: a
+ * control whose accessible name contains no letter and no digit is treated as
+ * unlabelled.
+ */
+
+/** Returned by {@link ICON_ONLY_CONTROL_AUDIT}. */
+export interface UnnamedControl {
+  readonly tag: string;
+  readonly text: string;
+  readonly name: string;
+  readonly outer: string;
+}
+
+/*
+ * Serialized as a string and evaluated in the page, so it can be passed to
+ * page.evaluate() from any spec without importing browser globals into Node.
+ */
+export const ICON_ONLY_CONTROL_AUDIT = (): UnnamedControl[] => {
+  const SELECTOR = [
+    "button",
+    "a[href]",
+    '[role="button"]',
+    '[role="link"]',
+    '[role="tab"]',
+    '[role="menuitem"]',
+    '[role="checkbox"]',
+    '[role="switch"]',
+  ].join(",");
+
+  const named = (element: Element): string => {
+    const labelledBy = element.getAttribute("aria-labelledby");
+    if (labelledBy) {
+      const parts = labelledBy
+        .split(/\s+/)
+        .map((id) => document.getElementById(id)?.textContent ?? "")
+        .join(" ");
+      if (parts.trim()) return parts;
+    }
+
+    const label = element.getAttribute("aria-label");
+    if (label?.trim()) return label;
+
+    /*
+     * Content, minus anything hidden from assistive technology. A glyph
+     * marked aria-hidden is correctly excluded here — which is why a badge
+     * rendering "✓" hidden plus the word "OK" visible passes, and one
+     * rendering only "✓" does not.
+     */
+    const clone = element.cloneNode(true) as Element;
+    clone.querySelectorAll('[aria-hidden="true"]').forEach((hidden) => {
+      hidden.remove();
+    });
+    const content = clone.textContent ?? "";
+    if (content.trim()) return content;
+
+    return element.getAttribute("title") ?? "";
+  };
+
+  const out: UnnamedControl[] = [];
+  document.querySelectorAll(SELECTOR).forEach((element) => {
+    /* Deliberately out of the tree; nothing announces it. */
+    if (element.getAttribute("aria-hidden") === "true") return;
+
+    const name = named(element).trim();
+
+    /*
+     * A name of pure punctuation or symbols is not a name. Letters and
+     * digits are what a person can be told; `✕` is not.
+     */
+    if (/[\p{L}\p{N}]/u.test(name)) return;
+
+    out.push({
+      tag: element.tagName.toLowerCase(),
+      text: (element.textContent ?? "").trim().slice(0, 20),
+      name,
+      outer: element.outerHTML.slice(0, 120),
+    });
+  });
+  return out;
+};

--- a/web/tests/shell/a11y-baseline.spec.ts
+++ b/web/tests/shell/a11y-baseline.spec.ts
@@ -1,0 +1,359 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+import { ICON_ONLY_CONTROL_AUDIT } from "../helpers/accessible-name";
+import { STATUSES } from "../../src/shell/StatusBadge";
+
+/*
+ * Governing: ADR-0004 (React view layer), ADR-0019 (frontend quality),
+ * SPEC-0005 Accessibility Requirements
+ *
+ * The accessibility criterion ADR-0004 states as "tested, not assumed".
+ *
+ * #60 shipped the primitives with tests for the parts that were load-bearing
+ * to building them: the four landmarks, the audit, the three focus-return
+ * routes, and the live region's recompute-not-render distinction. Those are on
+ * main and are not repeated here.
+ *
+ * This file covers what that left, and each of them is a case that passes
+ * vacuously if written carelessly:
+ *
+ *   - icon-only labelling, where the standard's own definition of "named"
+ *     accepts a control called "✕"
+ *   - tab order against visual layout, which nothing currently checks
+ *   - Space as well as Enter, where testing one and assuming the other is the
+ *     whole failure mode
+ *   - every colour-carried state, where testing one badge and generalising is
+ *     the same mistake in a different place
+ *   - composite widgets, where there are none yet, so the only honest test is
+ *     one that fails when one appears without arrow keys
+ */
+
+const SHELL = "/";
+
+async function resolveAPlan(page: Page): Promise<void> {
+  await page.getByLabel("Target").fill("ANTIMATTER");
+  await page.getByRole("button", { name: "Recompute" }).click();
+  await expect(page.getByRole("heading", { level: 3 })).toBeVisible({ timeout: 20_000 });
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(SHELL);
+});
+
+/* ----------------------------------------------------------------------
+ * Icon-only controls
+ * ------------------------------------------------------------------- */
+
+test("no control is named only by a glyph", async ({ page }) => {
+  await resolveAPlan(page);
+  await page.locator(".figure-row").first().click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+
+  /*
+   * How many controls the audit actually looked at. Without this the
+   * assertion below is satisfied by a page with no controls, or by a
+   * selector list that has stopped matching anything — both of which report
+   * "no unnamed controls" perfectly well.
+   */
+  const examined = await page.evaluate(
+    () =>
+      document.querySelectorAll('button, a[href], [role="button"], [role="link"]').length,
+  );
+  expect(examined, "the audit found no controls to examine").toBeGreaterThan(3);
+
+  const unnamed = await page.evaluate(ICON_ONLY_CONTROL_AUDIT);
+  expect(
+    unnamed.map((control) => `${control.tag}: ${control.outer}`),
+    "these controls have no name a person could be told",
+  ).toEqual([]);
+});
+
+test("the glyph check rejects a control broken on purpose", async ({ page }) => {
+  /*
+   * Without this the assertion above is satisfied by a checker that returns
+   * an empty array unconditionally — and it would, if the selector list or
+   * the name computation ever stopped matching.
+   *
+   * All four planted controls are ones axe reports as *named*: axe sees text
+   * content and is satisfied. That is the gap this check exists to cover. The
+   * last two are the controls that should pass — one labelled, one pairing an
+   * aria-hidden glyph with a word — so the checker is shown to discriminate
+   * rather than to flag everything.
+   */
+  await page.evaluate(() => {
+    const host = document.createElement("div");
+    host.id = "glyph-plant";
+    host.innerHTML = `
+      <button type="button">✕</button>
+      <button type="button"><span>→</span></button>
+      <button type="button" aria-label="Dismiss">✕</button>
+      <button type="button"><span aria-hidden="true">✓</span><span>Confirm</span></button>
+    `;
+    document.body.append(host);
+  });
+
+  /* The real audit function, not a reconstruction of it. */
+  const found = await page.evaluate(ICON_ONLY_CONTROL_AUDIT);
+
+  expect(found).toHaveLength(2);
+  const flagged = found.map((control) => control.outer).join(" ");
+  expect(flagged).toContain("✕");
+  expect(flagged).toContain("→");
+  expect(flagged, "a labelled control was flagged").not.toContain("Dismiss");
+  expect(flagged, "a glyph-plus-word control was flagged").not.toContain("Confirm");
+});
+
+test("axe does not catch the glyph case, which is why the check above exists", async ({
+  page,
+}) => {
+  /*
+   * Recording the gap rather than asserting it from memory. If a future axe
+   * version starts flagging glyph-named controls, this fails and the bespoke
+   * check can be reconsidered — which is a better outcome than carrying a
+   * redundant check forever because nobody rechecked the assumption.
+   */
+  await page.evaluate(() => {
+    const host = document.createElement("div");
+    host.id = "glyph-probe";
+    host.innerHTML = `<button type="button">✕</button>`;
+    document.body.append(host);
+  });
+
+  const results = await new AxeBuilder({ page })
+    .include("#glyph-probe")
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+
+  expect(
+    results.violations.map((v) => v.id),
+    "axe now flags glyph-named controls — the bespoke check may be redundant",
+  ).not.toContain("button-name");
+});
+
+/* ----------------------------------------------------------------------
+ * Keyboard operation
+ * ------------------------------------------------------------------- */
+
+async function tabOrder(page: Page): Promise<{ id: string; x: number; y: number }[]> {
+  const seen: { id: string; x: number; y: number }[] = [];
+  for (let press = 0; press < 25; press += 1) {
+    await page.keyboard.press("Tab");
+    const current = await page.evaluate(() => {
+      const active = document.activeElement;
+      if (!active || active === document.body) return null;
+      const box = active.getBoundingClientRect();
+      return {
+        id:
+          active.id ||
+          `${active.tagName.toLowerCase()}.${active.className.split(" ")[0] ?? ""}`,
+        x: Math.round(box.x),
+        y: Math.round(box.y),
+      };
+    });
+    if (!current) break;
+    if (seen.some((entry) => entry.id === current.id && entry.x === current.x)) break;
+    seen.push(current);
+  }
+  return seen;
+}
+
+test("the shell's tab order follows visual layout", async ({ page }) => {
+  /*
+   * Scoped to the shell deliberately.
+   *
+   * SPEC-0006's design settles the opposite rule for the tree canvas: node
+   * tab order is the payload's topological order, not the layout's, because
+   * build order is more useful than reading order for a dependency graph. It
+   * calls that "a deliberate divergence ... worth stating so it is not later
+   * 'fixed'".
+   *
+   * A blanket "tab order follows visual layout" test would be exactly the
+   * later fix that breaks it. This asserts the rule where it applies and says
+   * where it does not.
+   */
+  const order = await tabOrder(page);
+  expect(order.length).toBeGreaterThan(2);
+
+  const ROW_TOLERANCE = 12;
+  for (let i = 1; i < order.length; i += 1) {
+    const previous = order[i - 1];
+    const current = order[i];
+    if (!previous || !current) continue;
+
+    const sameRow = Math.abs(current.y - previous.y) <= ROW_TOLERANCE;
+    const readingOrder = sameRow ? current.x >= previous.x : current.y > previous.y;
+    expect(
+      readingOrder,
+      `tab moved from ${previous.id} (${String(previous.x)},${String(previous.y)}) ` +
+        `to ${current.id} (${String(current.x)},${String(current.y)}), against reading order`,
+    ).toBe(true);
+  }
+});
+
+test("Space activates a control, not only Enter", async ({ page }) => {
+  /*
+   * The failure mode is testing one and assuming the other. A div with a
+   * click handler and `role="button"` responds to Enter through the browser's
+   * default and to Space not at all, which is the most common form of this
+   * bug — and a suite that only presses Enter reports it as working.
+   */
+  await resolveAPlan(page);
+
+  await page.locator(".figure-row").first().focus();
+  await page.keyboard.press("Space");
+  await expect(page.getByRole("dialog"), "Space did not activate the node").toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("dialog")).toBeHidden();
+
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("dialog"), "Enter did not activate the node").toBeVisible();
+});
+
+test("Escape dismisses from anywhere inside the dialog, not only from its first control", async ({
+  page,
+}) => {
+  await resolveAPlan(page);
+  await page.locator(".figure-row").first().focus();
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("dialog")).toBeVisible();
+
+  /* Move focus deeper before pressing Escape — a handler bound to one element
+   * rather than the document would stop working here. */
+  await page.keyboard.press("Tab");
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("dialog")).toBeHidden();
+});
+
+test("no composite widget exists without arrow-key navigation", async ({ page }) => {
+  /*
+   * SPEC-0005 requires arrow keys within composite widgets. The shell has no
+   * composite widget yet, so a test driving arrow keys would assert nothing
+   * and pass forever.
+   *
+   * This is the honest form: it enumerates the roles that carry an arrow-key
+   * obligation and fails the moment one appears, so the requirement is
+   * enforced at the point it becomes real rather than remembered later. The
+   * tree canvas (SPEC-0006) and its method and recipe controls are where that
+   * is expected to happen.
+   */
+  await resolveAPlan(page);
+  await page.locator(".figure-row").first().click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+
+  const COMPOSITE_ROLES = [
+    "tablist",
+    "menu",
+    "menubar",
+    "listbox",
+    "tree",
+    "grid",
+    "radiogroup",
+    "toolbar",
+    "combobox",
+  ];
+
+  const present = await page.evaluate(
+    (roles) =>
+      roles.filter((role) => document.querySelector(`[role="${role}"]`) !== null),
+    COMPOSITE_ROLES,
+  );
+
+  expect(
+    present,
+    "a composite widget appeared — SPEC-0005 requires arrow-key navigation within it, " +
+      "so replace this guard with a test that drives the arrow keys",
+  ).toEqual([]);
+});
+
+/* ----------------------------------------------------------------------
+ * Colour is never the only carrier
+ * ------------------------------------------------------------------- */
+
+test("every status renders a glyph and a word, not a colour alone", async ({ page }) => {
+  /*
+   * Every status, rendered through the real component via the fixture.
+   *
+   * The shell reaches two of the five by ordinary use — the invalid-quantity
+   * warning and the pending badge — so walking the running app checks two and
+   * infers three. #60's test did exactly that. This mounts one badge per
+   * member of the component's own table, so a status added without a second
+   * carrier fails here rather than never being visited.
+   */
+  await page.goto("/tests/fixtures/status.html");
+  await expect(page.locator("body")).toHaveAttribute(
+    "data-status-count",
+    String(STATUSES.length),
+  );
+
+  const badges = page.locator(".status-badge");
+  await expect(badges).toHaveCount(STATUSES.length);
+
+  for (const status of STATUSES) {
+    const badge = page.locator(`[data-status="${status}"] .status-badge`);
+    await expect(badge, `${status} did not render`).toBeVisible();
+
+    await expect(badge.locator(".status-glyph"), `${status} has no glyph`).toBeVisible();
+
+    /*
+     * Two, not three. The `ok` badge reads "OK", which is the shortest label
+     * in the table and a perfectly good word — the first draft of this test
+     * used a threshold of three and failed on it. The threshold is calibrated
+     * to the real table rather than the table trimmed to the threshold.
+     */
+    const text = await badge.innerText();
+    expect(
+      text.replace(/[^\p{L}\p{N}]/gu, "").length,
+      `the ${status} badge carries no word, so colour is doing the work alone`,
+    ).toBeGreaterThanOrEqual(2);
+  }
+});
+
+test("each status is distinguishable without colour", async ({ page }) => {
+  /*
+   * The companion. Every badge having *a* word is not the requirement — the
+   * requirement is that the states are told apart. Five badges all reading
+   * "Status" with five different colours would pass the test above.
+   */
+  await page.goto("/tests/fixtures/status.html");
+
+  /*
+   * The accessible text, not innerText.
+   *
+   * innerText includes the glyph, so two statuses reading "Pending" with
+   * different glyphs look distinct to this test and identical to a screen
+   * reader — which is the population the requirement is about. The mutation
+   * check caught that: relabelling `unverified` to "Pending" left this test
+   * green until it started excluding aria-hidden content.
+   */
+  const words: string[] = [];
+  for (const status of STATUSES) {
+    words.push(
+      await page.locator(`[data-status="${status}"] .status-badge`).evaluate((badge) => {
+        const clone = badge.cloneNode(true) as Element;
+        clone.querySelectorAll('[aria-hidden="true"]').forEach((hidden) => {
+          hidden.remove();
+        });
+        return (clone.textContent ?? "").trim();
+      }),
+    );
+  }
+
+  expect(
+    new Set(words).size,
+    `two statuses are announced identically: ${words.join(" | ")}`,
+  ).toBe(STATUSES.length);
+});
+
+test("the status table is exhaustive over what the component can render", async () => {
+  /*
+   * Guards the enumeration itself. If STATUSES stopped being derived from the
+   * presentation table — say someone replaced it with a hand-written list —
+   * every loop above would silently check fewer states than exist.
+   */
+  const { STATUSES: live } = (await import("../../src/shell/StatusBadge")) as {
+    STATUSES: readonly string[];
+  };
+  expect([...live].sort()).toEqual(["danger", "ok", "pending", "unverified", "warning"]);
+});


### PR DESCRIPTION
Closes #62
Part of #57

Implements SPEC-0005 Accessibility Requirements.

ADR-0004's fourth Confirmation criterion is that accessibility is "tested, not assumed". #60 shipped the primitives with tests for the parts load-bearing to building them — four landmarks, the axe audit, all three focus-return routes, the live region's recompute-not-render distinction. Those are on main and are **not repeated here**. This is what that left.

10 new tests, and the mutation check grows from 11 to 21.

## Every case here passes vacuously if written carelessly

**Icon-only labelling needed a bespoke check, because axe does not catch it.** A button containing only `✕` has an accessible name by the specification's own definition — it is named `✕` — and axe's `button-name` rule is satisfied. A screen reader reads "multiplication X" or skips it. The rule enforced is therefore stricter than the standard: a name containing no letter and no digit is not a name.

There's a test asserting axe still misses this, so if a future axe version starts flagging glyph-named controls, that fails and the bespoke check gets reconsidered — rather than carried forever because nobody rechecked the assumption.

**Tab order is asserted for the shell only, and says why.** SPEC-0006's design settles the *opposite* rule for the tree canvas: node tab order is the payload's topological order, not the layout's, because build order beats reading order for a dependency graph. It explicitly calls that "a deliberate divergence ... worth stating so it is not later 'fixed'". A blanket "tab order follows visual layout" test would be exactly that later fix, so this one is scoped and the exception is written down.

**Arrow keys have no composite widget to drive yet.** A test pressing arrow keys would assert nothing. The honest form enumerates the roles that carry the obligation — `tablist`, `menu`, `listbox`, `tree`, `grid`, `radiogroup`, `toolbar`, `combobox` — and fails the moment one appears, so the requirement is enforced when it becomes real. #87's method and recipe controls are where that's expected.

**Space as well as Enter.** Testing one and assuming the other is the entire failure mode: a `role="button"` div responds to Enter through the browser default and to Space not at all.

**Colour-carried states are now exhaustive.** All five statuses render through the real component via a fixture, one badge per member of its own exported table. #60 checked one badge and inferred four.

## The mutation check found two real defects in my own tests

#82 ran the accessibility mutations by hand and didn't commit them — which proves an afternoon and nothing after. They're committed now, and they earned it on the first run:

**Relabelling `unverified` to "Pending" left "each status is distinguishable" green.** The test compared `innerText`, which includes the glyph — so two badges that *announce identically* looked distinct because one showed `?` and the other `…`. It now compares accessible text with `aria-hidden` content removed, which is the population the requirement is actually about.

**One mutation anchor didn't match** — the check reporting its own blind spot rather than quietly passing.

The Escape-only focus-trap mutation is the one worth reading in the output. It is not a strawman; it's the natural way to write the restore, and it leaves the Escape test green while the backdrop and close-control tests go red. That is precisely why #62 words the criterion around routes.

```
ok    focus is never returned on close — tests/shell/a11y-primitives.spec.ts went red
ok    focus is restored only by the Escape handler — tests/shell/a11y-primitives.spec.ts went red
ok    the focus trap stops containing Tab — tests/shell/a11y-primitives.spec.ts went red
ok    the live region announces on first render too — tests/shell/a11y-primitives.spec.ts went red
ok    the live region announces on every render — tests/shell/a11y-primitives.spec.ts went red
ok    a landmark goes missing — tests/shell/shell.spec.ts went red
ok    the navigation landmark loses its name — tests/shell/shell.spec.ts went red
ok    a status loses the word beside its colour — tests/shell/a11y-baseline.spec.ts went red
ok    two statuses become indistinguishable without colour — tests/shell/a11y-baseline.spec.ts went red
ok    a control is named only by a glyph — tests/shell/a11y-baseline.spec.ts went red
```

All 21 red, including the 11 stylesheet mutations from #61.

## One threshold I got wrong

The exhaustive status test failed on its first run against a threshold I'd set at three letters. The `ok` badge reads **"OK"** — two characters, and a perfectly good word. The threshold was wrong, not the component. It's calibrated to the real table now with the reason recorded in the test, rather than the table trimmed to fit the threshold.

## Acceptance criteria

| Criterion | Where |
|---|---|
| Every focus-return route tested separately | #82, plus two mutations here proving the separation matters |
| Live-region test distinguishes recompute from render | #82, plus two mutations here |
| The audit runs in CI and fails the build | `Frontend tests` job, already green on main |
| Colour-only distinctions checked for **each** state | new — exhaustive via the fixture, plus a distinguishability test |
| All four landmarks present exactly once | #82, plus a mutation here |
| Icon-only controls carry `aria-label` | new — bespoke check, because axe doesn't catch it |
| Tab order, Enter/Space, Escape, arrow keys | new |

## Verified locally

`npm run lint`, `lint:css`, `typecheck`, `format:check`, `check:tokens`, `npm test` (119 passed), `npm run test:mutation` (21/21 red).

