### PR TITLE
docs: accept ADR-0008, and correct what that makes stale

### DIFF
--- a/docs/adrs/ADR-0008-durable-user-data-store.md
+++ b/docs/adrs/ADR-0008-durable-user-data-store.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-08-28
 decision-makers: [Jon Stump]
 extends: [ADR-0002]

--- a/docs/openspec/specs/save-import/design.md
+++ b/docs/openspec/specs/save-import/design.md
@@ -24,7 +24,7 @@ The upstream half is genuinely ready. SPEC-0004's artifact carries the 108-entry
 - Writing saves. There is no such code path and the spec forbids one
 - Container inventories. ADR-0002 marks the field unconfirmed; the spec forbids specifying it until reachability is recorded
 - Choosing the file size limit. The spec requires one and requires it be measured; there is nothing in the repo to measure
-- Persisting imported records. That is ADR-0008 (`proposed` in PR #91, not yet merged). Until it lands, import is session-scoped and says so
+- Persisting imported records. That is [ADR-0008](../../../adrs/ADR-0008-durable-user-data-store.md), accepted but not yet specified or built. Until its stage 1 store exists, import is session-scoped and says so
 - Deciding whether WASM was the right call. ADR-0002 records that as a judgment call weighted by project goals, with TypeScript an acceptable fallback; nothing here re-opens it
 
 ## Decisions
@@ -95,7 +95,7 @@ flowchart TD
         CAT[("Parts catalog<br/>SPEC-0004 artifact")]
         REC["Extracted records<br/>stage 1 identity<br/>stage 2 built inventory"]
         SURF["Import surface<br/>inherits SPEC-0005"]
-        STORE[("Durable store<br/>ADR-0008 — proposed")]
+        STORE[("Durable store<br/>ADR-0008 — accepted, unbuilt")]
     end
 
     NET(["Any network"])
@@ -132,7 +132,7 @@ The parse is a single crossing. The file goes in as bytes, one envelope comes ba
 
 Greenfield. No existing import path, no data to migrate, nothing to roll back.
 
-The staging is ADR-0002's: stage 1 (identity) ships alone and delivers most of the onboarding benefit; stage 2 (built inventory) follows and depends only on the SPEC-0004 parts catalog, which already exists. Neither stage depends on ADR-0008 being accepted — import is session-scoped and says so until the store exists.
+The staging is ADR-0002's: stage 1 (identity) ships alone and delivers most of the onboarding benefit; stage 2 (built inventory) follows and depends only on the SPEC-0004 parts catalog, which already exists. Neither stage depends on ADR-0008's store existing — import is session-scoped and says so until it does.
 
 ## Open Questions
 

--- a/docs/openspec/specs/save-import/spec.md
+++ b/docs/openspec/specs/save-import/spec.md
@@ -189,7 +189,7 @@ ADR-0002 names the reason: console players cannot readily extract save files, so
 
 Import MUST state where its results go, and MUST NOT imply a persistence it does not have.
 
-Until ADR-0008 (durable user data store — `proposed` in PR #91, not yet merged) is accepted and its stage 1 store exists, imported records are session-scoped: they populate the current session and do not survive a reload. The surface MUST say so plainly, and MUST NOT present a control whose effect would be to save them — the same standard SPEC-0007 REQ "Absent Data Is Absent" already sets.
+Until [ADR-0008](../../../adrs/ADR-0008-durable-user-data-store.md)'s stage 1 store exists, imported records are session-scoped: they populate the current session and do not survive a reload. The surface MUST say so plainly, and MUST NOT present a control whose effect would be to save them — the same standard SPEC-0007 REQ "Absent Data Is Absent" already sets.
 
 Once the durable store exists, import MUST write into it as an ordinary authored edit, and MUST NOT mark the resulting records for synchronization. ADR-0008's compatibility line is that nothing derived from a save reaches a server unless the player deliberately shared the place it belongs to; an import that opted its own output into sync would overturn ADR-0002 by default rather than by decision.
 


### PR DESCRIPTION
One frontmatter line, plus four statements that became false the moment it flipped.

| Artifact | Change | Format |
|---|---|---|
| ADR-0008 durable-user-data-store | `proposed` → `accepted` | yaml-frontmatter, preserved in place |

## Format detection

ADR-0008 carries a `status:` key in a leading `---` block and **no** inline `- **Status:**` bullet within the 20 lines after its H1 — not a dual-format file, so there is no ambiguous source of truth to refuse. Only the `status:` line changed: no key reordered, no blank line inserted, nothing else in the frontmatter read or rewritten. All seven other ADRs are the same format and remain `accepted`.

## What acceptance made stale

SPEC-0008 described ADR-0008 as "`proposed` in PR #91, not yet merged" — wrong twice over now. That parenthetical was also why the link had been demoted to plain text: when SPEC-0008 was written, PR #91 was open, so a markdown link to a file that did not exist on that branch failed the link check. The link is restored and the parenthetical dropped.

`design.md` carried the same claim in three places — its non-goal list, its architecture diagram node, and its migration note.

| File | Was | Now |
|---|---|---|
| `save-import/spec.md` | "ADR-0008 … `proposed` in PR #91, not yet merged" | linked, no status claim |
| `save-import/design.md` non-goal | "`proposed` in PR #91, not yet merged" | "accepted but not yet specified or built" |
| `save-import/design.md` diagram | `ADR-0008 — proposed` | `ADR-0008 — accepted, unbuilt` |
| `save-import/design.md` migration | "Neither stage depends on ADR-0008 being accepted" | "Neither stage depends on ADR-0008's store existing" |

**None of this changes what SPEC-0008 requires.** The store still does not exist, so imported records are still session-scoped and the surface must still say so. Only the reason changed: from "the decision has not been made" to "the decision has been made and not yet built."

## The consequence that is not cosmetic

SPEC-0007 REQ "Absent Data Is Absent" forbids the card persisting durable per-base data — ticks, stocked quantities, notes, tags, screenshots, player-assigned names — or presenting any control implying persistence, **"until a governing decision establishes where it lives."**

That clause is now discharged. The decision exists and it establishes where the data lives: a local-first IndexedDB store, with an optional account for sync and read-only sharing.

The prohibition does not lapse, but its grounds move. The card must still not invent a store — because there is no spec and no implementation, not because nobody has decided. Issues #94 and #99 have been updated: they asserted "ADR-0008 is `proposed`, not accepted", which is now false and would have misled whoever picks up #99.

## Amendments now due, not hypothetical

ADR-0008 lists these as owed. Accepting it makes them real work rather than a plan:

- `docs/openspec/specs/view-foundations/spec.md` § Security Requirements — written on "It has no server … There are no accounts and no server session." The save-file clause survives intact; the rest does not
- `docs/openspec/specs/base-planner-card/spec.md` § Security Requirements — same premise
- `docs/openspec/specs/base-planner-card/spec.md` REQ "Absent Data Is Absent" — its "until a governing decision" clause is discharged and should now point at ADR-0008
- `docs/design/README.md` line 37 — both halves, including the todo-checks half that moves out of the URL hash

**They are deliberately not in this PR.** Each is a requirements change needing its own reading, not a status flip, and bundling them here would hide four decisions inside a one-line change. They are also what `/sdd:spec durable-store` will want settled.

## Tooling note

The skill's Tier 1 `{repo}-adrs` re-sync did not run — qmd has been unreachable throughout this session. A stale index will keep returning ADR-0008 as `proposed`, which is exactly the context-drift case the skill warns is sharpest. Worth `/sdd:index update` when it is back.
