### PR TITLE
docs: SPEC-0009, durable store

### DIFF
--- a/docs/openspec/specs/durable-store/design.md
+++ b/docs/openspec/specs/durable-store/design.md
@@ -1,0 +1,162 @@
+# Design: Durable Store
+
+## Context
+
+[ADR-0008](../../../adrs/ADR-0008-durable-user-data-store.md) decided that durable, player-authored data lives in a local-first IndexedDB store, with an optional account added later for sync and read-only sharing. [SPEC-0009](spec.md) is **stage 1 of three** — the local store, with no account, no server and no network.
+
+The gap it closes is concrete. SPEC-0007 REQ "Absent Data Is Absent" forbids the base planner card persisting ticks, stocked quantities, notes, tags or player-assigned names, and forbids even *showing a control implying persistence*, "until a governing decision establishes where it lives." ADR-0008 is that decision and is now `accepted`, so the clause is discharged — but the card still has nothing to persist into. Four surfaces are waiting: the planner card, the tree canvas's base assignments, and the freighter and settlement surfaces ADR-0006 and ADR-0007 add.
+
+There is a smaller gap that bites sooner. SPEC-0005 permits the view to hold "view-local preferences" as interface state, and `ViewState.preferences` holds exactly two — `groupSeparator` and `showUnverified`. With no store they last one page load, and a preference that forgets itself is not a preference.
+
+**Nothing here exists yet.** `grep -rn "localStorage\|sessionStorage\|indexedDB\|caches\.\|navigator.storage"` over `web/src`, `web/tests` and `web/index.html` returns nothing. The design README's storage prohibition is intact in code, not merely on paper, and ADR-0008 lifts it for durable data while keeping it for plan state.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Give durable per-place data a home, so SPEC-0007 can ship its todo list, notes and stocked counts
+- Give view preferences somewhere to survive a reload
+- Carry the schema room ADR-0008 reserved — `ownerId`, `updatedAt`, `revision` — so stages 2 and 3 are additions rather than migrations
+- Keep the store's failure modes legible: unrecognized version loads nothing, quota failure is not reported as success
+
+### Non-Goals
+
+- Accounts, identity, sign-in. ADR-0008 stage 2; ADR-0009's subject
+- Sharing and permissions. Stage 3; ADR-0010's subject
+- Multi-device sync and conflict resolution. ADR-0012's subject — `updatedAt` and `revision` are reserved here, and nothing reads them yet
+- Blob and screenshot storage. ADR-0013's subject. Stage 1 may hold an image locally; sharing or syncing one is out
+- Server hosting, retention operations. ADR-0011's subject. The *deletion* story is owed at stage 1 and is in scope; the *retention* story is not, because there is nothing retaining anything
+- Plan state. It stays in the URL hash. The two mechanisms stay two, and ADR-0008 measured why
+
+## Decisions
+
+### IndexedDB, not localStorage
+
+**Choice**: IndexedDB is the store.
+
+**Rationale**: `localStorage` is synchronous, string-only, and capped around 5 MB. Synchronous is the disqualifying one — every read and write would block the main thread, on the same thread the WASM module and the layout engine run on. The measured text workspace at 200 places is 596 KB, which fits either, but images do not and neither does headroom.
+
+It also matters that the design README's prohibition names `localStorage` specifically. Satisfying the letter of that rule while overturning its spirit would be the worse outcome, so ADR-0008 states the reversal explicitly and this spec is where it becomes normative.
+
+**Alternatives considered**:
+- *localStorage*: rejected — synchronous, string-only, too small for images, and the named subject of the prohibition
+- *Cache Storage API*: rejected — designed for responses keyed by request, not for structured records with versioned schemas
+- *In-memory with export/import*: rejected — makes "your data survived" a thing the player must do rather than a thing that happens
+
+### One record type for bases, freighters and settlements
+
+**Choice**: `PlaceRecord` with a `kind` field, not three record types.
+
+**Rationale**: ADR-0006 and ADR-0007 establish freighters and settlements as their own *surfaces* because their domain content differs — a freighter has no power grid, a settlement is judged on stats rather than assembled from parts. None of that reaches durable user data. A note is a note, a tick is a tick, and a player-assigned name is a name.
+
+Three record types would triple the schema, the versioning and the migration surface to express a distinction that does not exist at this layer. And ADR-0008 already settled the sharing unit as "one place", which only reads coherently if a place is one thing.
+
+**Alternatives considered**:
+- *One type per surface*: rejected — triples the schema to express a distinction the data does not have
+- *Untyped bag keyed by surface*: rejected — loses the ability to validate a record at all, and validation is what makes the version failure legible
+
+### Unrecognized version loads nothing
+
+**Choice**: a `schemaVersion` the running build does not understand loads no places at all and reports both versions. Not a partial load, not a silent migration, not a best-effort subset.
+
+**Rationale**: a partially loaded workspace is indistinguishable to the player from a complete one. They see their bases; they do not see that four of eleven are missing, and they make plans against what is there.
+
+This is a rule the project already applies twice. `plan-hash.ts` returns `EMPTY_PLAN` through one path rather than applying a partial decode, and ADR-0002 requires an unrecognized `BaseVersion` to import nothing rather than partially populate. Three mechanisms, one rule, and each of them is cheaper to hold than to re-argue.
+
+**Alternatives considered**:
+- *Load what parses, warn about the rest*: rejected — the warning is dismissed and the incomplete workspace persists
+- *Migrate forward automatically*: rejected for stage 1 — a migration that has never been exercised against real data is a bigger risk than refusing to load, and there is no data in the field yet to migrate
+
+### `ownerId`, `updatedAt` and `revision` are written from version 1
+
+**Choice**: three fields serving stages 2 and 3 exist and are written from the first version, unset or trivially set.
+
+**Rationale**: this is the whole reason ADR-0008 settled ownership and the sharing unit before building the sharing. Sign-in attaches an `ownerId` to a workspace that already has the field; it does not re-key records. A field added in version 2 cannot do that for data written under version 1, and the player who has ticked fifty construction items before signing up is exactly the person the migration is for.
+
+`revision` is the same argument for ADR-0012. A store that adds ordering later cannot order edits made before it existed.
+
+**Trade-off**: three fields nothing reads yet, which will look like speculative generality to a reader who has not read ADR-0008. The cost is three fields; the cost of the alternative is a migration over live user data.
+
+### Deletion is in scope; retention is not
+
+**Choice**: stage 1 owes the player a way to delete everything, from the application. Retention policy is ADR-0011's.
+
+**Rationale**: ADR-0002 banked "needs no upload endpoint, retention policy, or deletion story" as a benefit of holding nothing. This capability spends the third of those immediately — the moment data is held, the player is owed a way to remove it that does not involve developer tools.
+
+Retention genuinely is not owed yet: nothing retains anything, because nothing leaves the device. It becomes real at stage 2 and belongs with the server decision.
+
+### The store does not widen view state
+
+**Choice**: preferences persist *through* the store; they do not move into it as their source of truth. The view still owns them.
+
+**Rationale**: SPEC-0005's boundary is that the view holds interface state and never the plan, the graph or a derived quantity. Persisting a preference does not change what kind of state it is. Getting this wrong in the other direction — treating the store as a general state container — is how the plan ends up in it, which is the back door the whole `ViewState` and `ResultCache` design was built to keep shut.
+
+## Architecture
+
+```mermaid
+erDiagram
+    WORKSPACE ||--o{ PLACE : contains
+    WORKSPACE {
+        int schemaVersion
+        string ownerId "null in stage 1 — reserved for ADR-0009"
+        string preferences "view-local, SPEC-0005"
+    }
+    PLACE {
+        string id PK "stable, generated at creation"
+        string kind "base | freighter | settlement"
+        int schemaVersion
+        string name "player-assigned"
+        string notes
+        string tags
+        string ticks "construction items"
+        string stocked "quantities"
+        string updatedAt "reserved for ADR-0012"
+        int revision "reserved for ADR-0012"
+    }
+```
+
+```mermaid
+flowchart TD
+    subgraph Device["Player's device — stage 1 is entirely here"]
+        SURF["View surfaces<br/>SPEC-0006, SPEC-0007,<br/>ADR-0006, ADR-0007"]
+        STORE["Durable store<br/>SPEC-0009"]
+        IDB[("IndexedDB<br/>one workspace")]
+        HASH["URL hash<br/>plan state only"]
+        WASM["Go/WASM core<br/>ADR-0003 — untouched"]
+    end
+
+    FUTURE(["Accounts · sharing · sync<br/>ADR-0009 / 0010 / 0012"])
+
+    SURF <-->|durable data| STORE
+    SURF <-->|plan state| HASH
+    SURF -->|resolve / rollup / power| WASM
+    STORE <--> IDB
+    STORE -.->|never in stage 1| FUTURE
+
+    classDef deferred stroke-dasharray: 5 5
+    class FUTURE deferred
+```
+
+The two mechanisms stay two. Plan state is a pure input to the boundary, lives in the hash, and is shareable by anyone with no account. Durable data is authored, personal, and does not fit — ADR-0008 measured ten places of it at 3,260 bytes base64url against a ~2,000-byte hash ceiling.
+
+## Risks / Trade-offs
+
+- **IndexedDB is evictable.** Browsers clear origin storage under pressure and private windows discard it on close, and until an account exists there is no recovery path. → REQ "Storage Is Evictable and the Application Must Not Imply Otherwise" forbids the application claiming more than the storage delivers. It is a labelling requirement because there is no technical mitigation at stage 1.
+- **A quota failure silently discarded loses a player's work.** → It is called out by name in the error-handling requirement rather than left to the general no-swallowing rule, because it is the one failure that presents as success.
+- **Three fields nothing reads will look like speculative generality.** → design.md and ADR-0008 both record the reason. The alternative is a migration over live user data.
+- **This is the first place the project holds personal data**, and every later decision about it inherits this schema. → Which is why ADR-0008 settled ownership and the sharing unit before any of it was built.
+- **The bound on a place's size is unset.** → REQ "Request Body Size Limits" requires it be measured rather than guessed, and requires images to be explicitly in or out of scope when it is set. Same discipline SPEC-0008 applies to the save file size limit, and blocked on the same kind of missing measurement.
+- **A version-change event ignored presents as the application hanging on load**, not as a storage error. → Called out in the storage-operation requirement, because the symptom points nowhere near the cause.
+
+## Migration Plan
+
+Greenfield. No store exists, no data exists, nothing to migrate or roll back.
+
+The migration that matters is the one *out* of stage 1, and ADR-0008 designed it here rather than leaving it to be discovered: every place has a stable `id` generated at creation, `ownerId` is nullable and present from version 1, and first sign-in with a non-empty local workspace uploads it whole. Sign-out leaves the local copy in place. That is the whole of it, and it works only because the schema room was reserved before there was data in the field.
+
+## Open Questions
+
+- **The per-place size bound.** Required, deliberately unset. ADR-0008 measured the text case; the bound needs setting with images explicitly in or out of scope, and the image question is ADR-0013's.
+- **Whether view preferences share the workspace record or sit beside it.** They are not per-place and they are not a place; the ERD above puts them on the workspace, which is the simpler reading, but a separate settings record would keep the workspace record purely about places.
+- **What the application shows when storage is unavailable entirely** — a private window with storage blocked, or a browser with the API disabled. The empty state is a designed state; "storage does not work here" is a different state and this spec does not say what it looks like.
+- **Whether deletion offers per-place removal as well as delete-everything.** The requirement covers the second; the first is a product question that has not been asked.

--- a/docs/openspec/specs/durable-store/spec.md
+++ b/docs/openspec/specs/durable-store/spec.md
@@ -1,0 +1,278 @@
+---
+status: draft
+date: 2026-08-28
+implements: [ADR-0008]
+requires: [SPEC-0005]
+---
+
+# SPEC-0009: Durable Store
+
+## Graph Edges
+
+- **Implements:** [ADR-0008](../../../adrs/ADR-0008-durable-user-data-store.md) — durable user data in a local-first store, stage 1
+- **Requires:** [SPEC-0005](../view-foundations/spec.md) — the view-state boundaries this store sits beside, and the preferences it gives somewhere to live
+
+## Overview
+
+Where durable, player-authored data lives on the device: ticked construction items, stocked quantities, notes, tags, player-assigned names, and the view preferences that currently forget themselves on reload.
+
+Realizes [ADR-0008](../../../adrs/ADR-0008-durable-user-data-store.md) **stage 1 only** — the local store, with no account, no server and no network. That ADR's stages 2 and 3 (accounts, then read-only sharing) are separate decisions with their own ADRs pending, and nothing here implements them. What this spec does carry from them is the schema room they need, because retrofitting an owner onto data that already exists is the expensive migration and ADR-0008 settled the shape to avoid it.
+
+This is the first capability in the project that holds user data at all. `grep -rn "localStorage\|sessionStorage\|indexedDB" web/src web/tests web/index.html` returns nothing today, and the design README's storage prohibition is intact in code rather than merely on paper. ADR-0008 lifts it for durable data and keeps it for plan state; this spec is where that split becomes normative.
+
+**What it unblocks.** SPEC-0007 REQ "Absent Data Is Absent" forbids the base planner card persisting anything until a governing decision establishes where it lives. ADR-0008 is that decision and is now `accepted`, so the clause is discharged — but the card still has nothing to persist into until this spec is implemented. This is what closes that gap.
+
+## Requirements
+
+### Requirement: A Workspace Owns Places
+
+The store MUST hold exactly one workspace per device. The workspace MUST carry a `schemaVersion`, an `ownerId`, and a collection of place records.
+
+`ownerId` MUST be nullable and MUST be null in stage 1, where no account exists. It MUST be present in the schema from the first version rather than added later: ADR-0008's migration works because sign-in attaches an owner to an existing workspace rather than re-keying its contents, and a field added in version 2 cannot do that for data written under version 1.
+
+#### Scenario: The workspace exists before anything is stored in it
+
+- **WHEN** the store is opened on a device that has never used it
+- **THEN** a workspace exists with a null `ownerId`, the current `schemaVersion`, and no places
+
+#### Scenario: Owner is absent, not missing
+
+- **WHEN** a workspace written in stage 1 is inspected
+- **THEN** `ownerId` is present and null, rather than the field being absent from the record
+
+### Requirement: A Place Is One Record Type, Whatever Its Kind
+
+A place MUST be represented by a single record type covering bases, freighters and settlements. ADR-0006 and ADR-0007 add two more surfaces, and for the purpose of durable user data they are the same kind of thing: a location a player authors notes and ticks against.
+
+Each place MUST carry a stable `id` generated at creation, independent of any save file and independent of any account. It MUST carry `updatedAt` and a monotonically increasing `revision`.
+
+`updatedAt` and `revision` MUST be written from the first version even though stage 1 has nothing to reconcile. ADR-0008 defers multi-device sync and conflict resolution to a later ADR and reserves this room deliberately; a store that adds them later cannot order edits made before they existed.
+
+#### Scenario: Kind is a field, not a type
+
+- **WHEN** a freighter and a base are both stored
+- **THEN** both are place records distinguished by a kind field, and no second record type exists
+
+#### Scenario: Identity does not come from the save
+
+- **WHEN** a place is created by save import and the same place is later re-imported from a changed save
+- **THEN** the place's `id` is unchanged, because it was generated at creation rather than derived from save contents
+
+#### Scenario: Revision advances on every write
+
+- **WHEN** a place is modified twice
+- **THEN** its `revision` is strictly greater after the second write than after the first, and `updatedAt` reflects the later write
+
+### Requirement: Versioned, and Fails Legibly
+
+The store MUST carry a `schemaVersion` at the workspace and at each place.
+
+An unrecognized version MUST load **nothing** and MUST report it. The store MUST NOT apply a partial load, MUST NOT drop records it cannot read while keeping ones it can, and MUST NOT migrate silently.
+
+This is the standard `plan-hash.ts` already meets by returning `EMPTY_PLAN` through one path rather than applying a partial decode, and the standard ADR-0002 set for an unrecognized `BaseVersion`. A partially loaded workspace is indistinguishable to the player from a complete one.
+
+#### Scenario: A future version loads nothing
+
+- **WHEN** the store contains a workspace whose `schemaVersion` is higher than the running build understands
+- **THEN** no place is loaded, and a diagnostic states both versions
+
+#### Scenario: One bad place does not become a partial workspace
+
+- **WHEN** one place record carries an unreadable `schemaVersion` and the rest do not
+- **THEN** the load fails as a whole rather than returning the readable subset
+
+### Requirement: An Empty Store Is a Designed State
+
+An empty store MUST be a state the application presents deliberately, not an absence it renders as zeroes.
+
+Cleared storage, a fresh device, and a private browsing window all produce it, and all three are ordinary rather than exceptional. A consumer of this store MUST distinguish "nothing stored" from "stored as zero", and MUST NOT render a figure the player never entered.
+
+This is SPEC-0007 REQ "Absent Data Is Absent" applied to the store's own output: absent is rendered as absent.
+
+#### Scenario: A fresh device is not an error
+
+- **WHEN** the store is opened on a device with no prior data
+- **THEN** the application presents an intentional empty state, and reports no failure
+
+#### Scenario: Nothing stored is not zero stored
+
+- **WHEN** a place has no stocked quantity recorded for an item
+- **THEN** the consumer renders the quantity as absent rather than as `0`
+
+### Requirement: Stage 1 Reaches No Network
+
+Nothing in this capability MUST issue a network request. Stage 1 is local storage with no account, no server and no sync.
+
+The absence MUST be checkable mechanically rather than by review, and the check MUST assert on this capability's own call paths rather than on the absence of network code in the application bundle — the bundle will contain network code by design once ADR-0008 stage 2 ships, and a check phrased against the bundle would then be weakened to accommodate it.
+
+#### Scenario: Reading and writing issue no request
+
+- **WHEN** the store is opened, read from, and written to
+- **THEN** no network call of any kind is issued
+
+#### Scenario: The check survives a sync client existing
+
+- **WHEN** the application also contains code that makes network requests for unrelated reasons
+- **THEN** the assertion still holds and still fails if a request is added to a store path
+
+### Requirement: Nothing Is Marked for Synchronization
+
+No record written in stage 1 MUST be marked shared, synced, or pending upload.
+
+ADR-0008's compatibility line with ADR-0002 is that nothing derived from a save reaches a server unless the player deliberately shared the place it belongs to. A stage 1 store that pre-marked its records would make stage 2's first sign-in an upload the player never chose, which is that ADR being overturned by default rather than by decision.
+
+Where the schema carries fields serving stages 2 and 3 — `ownerId`, and any share state — they MUST be present and unset rather than absent.
+
+#### Scenario: A stored place is not queued for anything
+
+- **WHEN** any place is written
+- **THEN** it carries no flag marking it shared, synced, or pending upload
+
+### Requirement: View Preferences Survive a Reload
+
+View-local preferences that SPEC-0005 REQ "View State Boundaries" permits the view to hold MUST be persisted through this store and MUST be restored on load.
+
+A preference that forgets itself on reload is not a preference. SPEC-0005 permits the view to hold them and `ViewState.preferences` holds exactly two — `groupSeparator` and `showUnverified` — with nowhere to survive a page load.
+
+Persisting them MUST NOT move them out of view state. They remain interface state that the view owns; the store is where the view's own copy is written and read, and the plan, the resolved graph and every derived quantity MUST remain outside both.
+
+#### Scenario: A preference outlives the page
+
+- **WHEN** a player changes a view preference and reloads
+- **THEN** the preference is as they left it
+
+#### Scenario: Persistence does not widen view state
+
+- **WHEN** the view's state is inspected after a plan is resolved and preferences are restored
+- **THEN** it holds selection, collapse, inputs, focus and preferences, and no plan, graph or derived quantity
+
+### Requirement: Deletion Is a First-Class Operation
+
+The application MUST offer the player a way to delete everything this store holds, without requiring browser developer tools or a manual site-data clear.
+
+ADR-0002 listed "needs no upload endpoint, retention policy, or deletion story" as a benefit of holding nothing. This capability spends that, and the deletion story is owed at stage 1 even though the retention story belongs to the server stages.
+
+Deletion MUST remove the workspace and every place in it, MUST be confirmed before it runs, and MUST leave the application in the designed empty state rather than in an error state.
+
+#### Scenario: The player can delete their data from the application
+
+- **WHEN** the player chooses to delete stored data and confirms
+- **THEN** the workspace and every place are removed, and the application presents the empty state
+
+#### Scenario: Deletion is not reachable by accident
+
+- **WHEN** the deletion control is activated
+- **THEN** the action is confirmed before anything is removed
+
+### Requirement: Storage Is Evictable and the Application Must Not Imply Otherwise
+
+The application MUST NOT present locally stored data as guaranteed to persist.
+
+Browsers evict origin storage under pressure, and private browsing windows discard it on close. ADR-0008 records this as a cost of local-first: until an account exists there is no recovery path, so "saved" is a stronger claim than the storage makes.
+
+Where the application indicates that data is stored, the indication MUST be accurate about its scope — on this device — and MUST NOT use language implying a backup or a guarantee.
+
+#### Scenario: Stored does not read as backed up
+
+- **WHEN** the application indicates that a change has been stored
+- **THEN** the indication does not claim the data is backed up or synchronized
+
+### Requirement: Screenshots Are Local-Only
+
+Where the store holds an image, it MUST be held locally and MUST NOT be shareable or synchronizable.
+
+ADR-0008 defers blob storage to a later ADR and excludes it from that decision, on the measured grounds that one capture is 1.5–3 MB against 596 KB for a 200-place text workspace, and that blobs carry a different cost, abuse and moderation profile. Stage 1 MAY store images locally; nothing else about them is specified here.
+
+Until that ADR exists, the application MUST NOT offer a control to share or upload an image.
+
+#### Scenario: No share control for an image
+
+- **WHEN** a place holds an image
+- **THEN** the application offers no control whose effect would be to share or upload it
+
+### Requirement: Error Handling Standards
+
+All error-producing operations in this capability MUST follow structured error handling:
+
+- Errors MUST be wrapped with contextual information at each layer boundary, naming the workspace or place being read or written when the failure occurred
+- Sentinel errors MUST be defined for the failure modes a caller distinguishes programmatically — unsupported version, quota exceeded, storage unavailable, record not found — and MUST be selectable by identity rather than by message text, matching the discipline SPEC-0002 and the existing boundary client already enforce
+- Silent error swallowing MUST NOT occur. A quota failure in particular MUST NOT be discarded: a write that did not happen, reported as one that did, is the failure mode that loses a player's work
+- Structured logging MUST be used for error reporting
+
+#### Scenario: A failed write is not reported as a success
+
+- **WHEN** a write fails because the storage quota is exceeded
+- **THEN** the failure is returned to the caller and surfaced, and the application does not indicate that the change was stored
+
+#### Scenario: Callers branch on identity, not prose
+
+- **WHEN** the application distinguishes an unsupported version from unavailable storage
+- **THEN** it selects on the sentinel error, and no source or test matches on message text
+
+### Requirement: Storage Operation Standards
+
+All storage operations MUST follow structured data access patterns:
+
+- Transactions MUST be used for multi-step mutations that require atomicity. Writing a place and advancing the workspace's state are one unit, and a store that can complete the first without the second can produce a workspace that disagrees with its own contents
+- Connection lifecycle MUST be explicitly managed, with the database opened once and version-change events handled rather than ignored — an unhandled version change blocks the upgrade indefinitely and presents as the application hanging on load
+- The parameterized-query requirement does not apply: this store has no query language and no string-composed queries. It is recorded here as considered and inapplicable rather than omitted
+
+#### Scenario: A multi-step write is atomic
+
+- **WHEN** a write that touches a place and the workspace fails partway
+- **THEN** neither change is applied, and the store is left as it was
+
+#### Scenario: A version change does not hang the application
+
+- **WHEN** another tab holds the database open at an older version and an upgrade is attempted
+- **THEN** the version-change event is handled and the condition is surfaced, rather than the load blocking indefinitely
+
+## Security Requirements
+
+This capability is the first in the project to hold user data. It ships as part of a browser-rendered client with no server component, no accounts and no HTTP endpoints **in stage 1**. Each topic is recorded with its applicability so an uncovered one is visible rather than absent, and several change at ADR-0008 stage 2.
+
+### Authentication
+
+Not applicable in stage 1. There is no account, no session and no protected resource — `ownerId` exists in the schema and is null. ADR-0008 stage 2 introduces identity and it is ADR-0009's subject; when it lands, this topic MUST be answered rather than inherited from here.
+
+### Rate Limiting
+
+Not applicable. All operations are local, invoked by the player against their own device. There is no shared resource to exhaust and no remote call to throttle.
+
+### Security Headers
+
+Deferred to the application shell, which owns document delivery, per SPEC-0005 § Security Requirements → Security Headers. This capability contributes no headers and MUST NOT weaken any the shell sets; it introduces no requirement for inline script or `eval`.
+
+### Request Body Size Limits
+
+Applicable in an adapted form: there is no request, but there is a quota, and it is finite and shared with everything else the origin stores.
+
+A bound MUST be enforced on what a single place may hold, and the store MUST fail a write that would exceed it rather than attempting it and discovering the quota. The value MUST be derived from measurement rather than guessed — ADR-0008 measured the text case at 596 KB for a 200-place workspace and excluded images, which are three orders of magnitude larger, so the bound MUST be set with images in scope or out of it explicitly.
+
+#### Scenario: An oversized write is refused before it is attempted
+
+- **WHEN** a write would take a place beyond the configured bound
+- **THEN** it is refused with a message stating the limit, rather than attempted and failing on quota
+
+### CSRF Protection
+
+Not applicable in stage 1. There is no state-changing request, no session and no server to forge a request against.
+
+### Redirect Validation
+
+Applicable. Stored values are attacker-influenced in two ways: a place created by save import carries names from a file the player did not write, and ADR-0008 stage 3 will introduce records authored by another person.
+
+No value read from this store MUST be used to navigate, MUST be injected as markup, or MUST be used as a URL, image source, or link target. A note is text and MUST be rendered as text. This is the treatment #78 established for a decoded URL hash and SPEC-0008 applies to a parsed save — one rule, now three sources.
+
+#### Scenario: A stored value cannot navigate or inject
+
+- **WHEN** a place's name or note contains a `javascript:` URL or markup
+- **THEN** it renders as literal text, drives no navigation, and is not interpreted
+
+## Accessibility Requirements
+
+**Deliberately absent, and recorded so the absence is visible rather than an oversight.**
+
+This capability defines no component, no control and no template. Its one presentation requirement — REQ "An Empty Store Is a Designed State" — constrains what consumers render rather than rendering anything itself, and every consumer is a view surface already governed by SPEC-0005's accessibility baseline: WCAG 2.1 AA, landmarks, `aria-label` on icon-only controls, `aria-live` on recompute, keyboard operation, and focus management, all enforced mechanically by the checks SPEC-0005's test stories added.
+
+Two controls this spec requires — deletion, and any indication that data was stored — are built by a consuming surface and inherit that baseline there. The deletion confirmation in particular is a dialog and MUST use the shell's focus trap rather than its own.


### PR DESCRIPTION
Adds `docs/openspec/specs/durable-store/` — `spec.md` and `design.md`, status `draft`.

Realizes [ADR-0008](docs/adrs/ADR-0008-durable-user-data-store.md) **stage 1 only**: the local IndexedDB store, no account, no server, no network. Stages 2 and 3 are ADR-0009 and ADR-0010's and nothing here implements them.

**12 requirements, 24 scenarios.** `implements: [ADR-0008]` · `requires: [SPEC-0005]`

## What it closes

SPEC-0007 REQ "Absent Data Is Absent" forbade the base planner card persisting ticks, notes, stocked counts or player-assigned names "until a governing decision establishes where it lives." ADR-0008 is accepted, so the clause is discharged — but the card still has nothing to persist into. This is what it will persist into.

A smaller gap bites sooner: `ViewState.preferences` holds exactly two values and they last one page load. A preference that forgets itself is not a preference.

## Three fields nothing reads yet, on purpose

`ownerId`, `updatedAt` and `revision` are written from version 1, unset or trivially set.

That is the whole reason ADR-0008 settled ownership and the sharing unit before building any sharing. Sign-in attaches an `ownerId` to a workspace that already has the field; it does not re-key records. **A field added in version 2 cannot do that for data written under version 1**, and the player who ticked fifty construction items before signing up is exactly who the migration is for.

It will read as speculative generality to anyone who has not read ADR-0008, so design.md records the reason. The cost is three fields; the cost of the alternative is a migration over live user data.

## Unrecognized version loads nothing

Not a partial load, not a silent migration, not a best-effort subset. A partially loaded workspace is indistinguishable to the player from a complete one — they see their bases, they do not see that four of eleven are missing, and they plan against what is there.

The project already applies this rule twice: `plan-hash.ts` returns `EMPTY_PLAN` through one path rather than partially decoding, and ADR-0002 requires an unrecognized `BaseVersion` to import nothing. Three mechanisms, one rule.

## Two failures named rather than left to a general rule

**A quota failure silently discarded** is the one storage failure that presents as success — a write that did not happen, reported as one that did. It is called out by name in the error-handling requirement rather than covered by "no silent swallowing".

**An ignored version-change event** presents as the application hanging on load, not as a storage error. The symptom points nowhere near the cause, so the storage-operation requirement names it.

## Deletion is in scope; retention is not

ADR-0002 banked "needs no upload endpoint, retention policy, or deletion story" as a benefit of holding nothing. This capability spends the third immediately: the moment data is held, the player is owed a way to remove it that does not involve developer tools. The requirement covers delete-everything, confirmed, landing in the designed empty state.

Retention genuinely is not owed yet — nothing retains anything, because nothing leaves the device. It becomes real at stage 2 and belongs with ADR-0011.

## Section decisions worth flagging

**Security is included and is real.** This is the first capability in the project holding user data, so it is not six Not Applicables. Two topics have substance: the quota bound is the adapted form of a body-size limit and is required-but-unset for the same reason SPEC-0008's file limit is (measured, not guessed — and images explicitly in or out of scope when it is set); and redirect validation applies because stored values are attacker-influenced through save import today and shared records at stage 3. Authentication is Not Applicable *in stage 1* and the spec says it must be answered rather than inherited when ADR-0009 lands.

**Accessibility is deliberately absent, and says so.** The store defines no component, no control, no template. Its one presentation requirement constrains what consumers render, and every consumer is a view surface already under SPEC-0005's baseline. The section records this so an uncovered topic is visible rather than missing — including the note that the deletion confirmation is a dialog and must use the shell's focus trap rather than its own.

**Backend quality injected in adapted form.** Error handling applies straightforwardly. Storage operations reuse the transaction and connection-lifecycle guidance; the parameterized-query clause is recorded as considered and inapplicable — IndexedDB has no query language — rather than included as a vacuous bullet.

## Validation run before committing

| Check | Result |
|---|---|
| H1 SPEC number matches the number being authored | `SPEC-0009` ✓ |
| No `RFC-XXXX` numbering | none ✓ |
| Frontmatter edge targets exist | ADR-0008, SPEC-0005 ✓ |
| Relative links resolve | all ✓ |
| Every requirement has ≥1 scenario | 12/12 ✓ |
| Scenarios use `####` | 24 correct, 0 misuse ✓ |
| design.md retains Open Questions | ✓ (four) |
| design.md has a Mermaid diagram | ✓ (an ERD and a flowchart) |

## Status

`draft`, with four open questions — the per-place size bound, where preferences sit, what "storage unavailable entirely" looks like, and whether deletion offers per-place removal.

Unlike SPEC-0008, **this one is plannable now.** None of its open questions blocks a story: the size bound has a requirement that names it as unset, and the other three are product questions a first slice can answer. `/sdd:plan SPEC-0009` when you want it.

## Tooling note

qmd has been unreachable throughout this session, so the edge pre-search ran manually against the corpus. Worth `/sdd:graph validate` when it is back — and `/sdd:index update`, since the index still has ADR-0008 as `proposed`.
