### PR TITLE
feat(web): boundary client rollup and power

### DIFF
--- a/web/src/boundary/build.ts
+++ b/web/src/boundary/build.ts
@@ -1,0 +1,319 @@
+/*
+ * The stage 2 build payload: one base's construction instructions.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0002 REQ "Exact Quantity
+ * Encoding", SPEC-0005 REQ "The View Computes No Domain Values",
+ * SPEC-0007 REQ "Card Composition From the Build Payload"
+ *
+ * Every count here is the domain's — plants, biodomes, extractors, depots,
+ * fauna, nutrient processors, pellet feeders. SPEC-0007 forbids the view
+ * computing any of them from a quantity and a rate even when both are in
+ * the payload, so they arrive as exact strings and stay that way.
+ *
+ * Two fields exist because omitting them would lose a planning result:
+ * `noBuild` carries demands a byproduct already covers, and `unassigned`
+ * carries leaves the plan places nowhere. An absent row is indistinguishable
+ * from an overlooked requirement.
+ */
+
+import { flag, list, object, quantity, text, type Raw } from "./decode";
+import type { Quantity } from "./quantity";
+
+export interface YieldRange {
+  readonly min: Quantity;
+  readonly max: Quantity;
+}
+
+export interface FarmRow {
+  readonly itemId: string;
+  readonly name: string;
+  readonly required: Quantity;
+  readonly plants: Quantity;
+  readonly biodomes: Quantity;
+  /** Both bounds. The domain sizes plants on the pessimistic one. */
+  readonly yieldPerPlant: YieldRange;
+  readonly growthSeconds: Quantity;
+  readonly verified: boolean;
+}
+
+export interface ExtractorRow {
+  readonly itemId: string;
+  readonly name: string;
+  readonly class: string;
+  readonly required: Quantity;
+  readonly extractorCount: Quantity;
+  readonly depots: Quantity;
+  readonly ratePerSecond: Quantity;
+  /** What the built extractors actually take — at most the configured duration. */
+  readonly fillSeconds: Quantity;
+  readonly verified: boolean;
+}
+
+export interface RanchRow {
+  readonly itemId: string;
+  readonly name: string;
+  readonly required: Quantity;
+  readonly fauna: Quantity;
+  readonly cycleSeconds: Quantity;
+  readonly verified: boolean;
+}
+
+export interface KitchenInput {
+  readonly itemId: string;
+  readonly perOutput: Quantity;
+}
+
+export interface KitchenStep {
+  readonly itemId: string;
+  readonly name: string;
+  readonly recipe: string;
+  readonly required: Quantity;
+  readonly processSeconds: Quantity;
+  readonly final: boolean;
+  readonly verified: boolean;
+  readonly inputs: readonly KitchenInput[];
+}
+
+/** A demand a byproduct at the same base already covers. */
+export interface NoBuildRow {
+  readonly itemId: string;
+  readonly name: string;
+  readonly from: string;
+  readonly required: Quantity;
+  readonly verified: boolean;
+}
+
+export interface Site {
+  readonly extractorClass: string;
+  readonly fillSeconds: Quantity;
+}
+
+export interface BaseBuild {
+  readonly base: string;
+  readonly site: Site;
+  readonly farms: readonly FarmRow[];
+  readonly extractors: readonly ExtractorRow[];
+  readonly ranches: readonly RanchRow[];
+  readonly kitchen: readonly KitchenStep[];
+  /** Per base, not per row. Summing a per-row figure would overcount. */
+  readonly nutrientProcessors: Quantity;
+  readonly pelletFeeders: Quantity;
+  readonly noBuild: readonly NoBuildRow[];
+  /** The base-level answer: every row here, and the constant that sized its processors. */
+  readonly verified: boolean;
+}
+
+export interface Demand {
+  readonly itemId: string;
+  readonly name: string;
+  readonly total: Quantity;
+  readonly verified: boolean;
+}
+
+export interface Build {
+  readonly bases: readonly BaseBuild[];
+  /** Leaves the plan places nowhere. Reported rather than lost silently. */
+  readonly unassigned: readonly Demand[];
+}
+
+function decodeYieldRange(value: unknown): YieldRange | null {
+  const raw = object(value);
+  if (!raw) return null;
+  const min = quantity(raw["min"]);
+  const max = quantity(raw["max"]);
+  return min === null || max === null ? null : { min, max };
+}
+
+function decodeFarm(value: unknown): FarmRow | null {
+  const raw = object(value);
+  if (!raw) return null;
+
+  const itemId = text(raw["itemId"]);
+  const name = text(raw["name"]);
+  const required = quantity(raw["required"]);
+  const plants = quantity(raw["plants"]);
+  const biodomes = quantity(raw["biodomes"]);
+  const growthSeconds = quantity(raw["growthSeconds"]);
+  const yieldPerPlant = decodeYieldRange(raw["yieldPerPlant"]);
+  const verified = flag(raw["verified"]);
+
+  if (itemId === null || name === null || required === null) return null;
+  if (plants === null || biodomes === null || growthSeconds === null) return null;
+  if (yieldPerPlant === null || verified === null) return null;
+
+  return {
+    itemId,
+    name,
+    required,
+    plants,
+    biodomes,
+    yieldPerPlant,
+    growthSeconds,
+    verified,
+  };
+}
+
+function decodeExtractor(value: unknown): ExtractorRow | null {
+  const raw = object(value);
+  if (!raw) return null;
+
+  const itemId = text(raw["itemId"]);
+  const name = text(raw["name"]);
+  const rowClass = text(raw["class"]);
+  const required = quantity(raw["required"]);
+  const extractorCount = quantity(raw["extractorCount"]);
+  const depots = quantity(raw["depots"]);
+  const ratePerSecond = quantity(raw["ratePerSecond"]);
+  const fillSeconds = quantity(raw["fillSeconds"]);
+  const verified = flag(raw["verified"]);
+
+  if (itemId === null || name === null || rowClass === null || required === null)
+    return null;
+  if (extractorCount === null || depots === null) return null;
+  if (ratePerSecond === null || fillSeconds === null || verified === null) return null;
+
+  return {
+    itemId,
+    name,
+    class: rowClass,
+    required,
+    extractorCount,
+    depots,
+    ratePerSecond,
+    fillSeconds,
+    verified,
+  };
+}
+
+function decodeRanch(value: unknown): RanchRow | null {
+  const raw = object(value);
+  if (!raw) return null;
+
+  const itemId = text(raw["itemId"]);
+  const name = text(raw["name"]);
+  const required = quantity(raw["required"]);
+  const fauna = quantity(raw["fauna"]);
+  const cycleSeconds = quantity(raw["cycleSeconds"]);
+  const verified = flag(raw["verified"]);
+
+  if (itemId === null || name === null || required === null) return null;
+  if (fauna === null || cycleSeconds === null || verified === null) return null;
+
+  return { itemId, name, required, fauna, cycleSeconds, verified };
+}
+
+function decodeKitchenInput(value: unknown): KitchenInput | null {
+  const raw = object(value);
+  if (!raw) return null;
+  const itemId = text(raw["itemId"]);
+  const perOutput = quantity(raw["perOutput"]);
+  return itemId === null || perOutput === null ? null : { itemId, perOutput };
+}
+
+function decodeKitchen(value: unknown): KitchenStep | null {
+  const raw = object(value);
+  if (!raw) return null;
+
+  const itemId = text(raw["itemId"]);
+  const name = text(raw["name"]);
+  const recipe = text(raw["recipe"]);
+  const required = quantity(raw["required"]);
+  const processSeconds = quantity(raw["processSeconds"]);
+  const final = flag(raw["final"]);
+  const verified = flag(raw["verified"]);
+  const inputs = list(raw["inputs"], decodeKitchenInput);
+
+  if (itemId === null || name === null || recipe === null || required === null)
+    return null;
+  if (processSeconds === null || final === null || verified === null || inputs === null)
+    return null;
+
+  return { itemId, name, recipe, required, processSeconds, final, verified, inputs };
+}
+
+function decodeNoBuild(value: unknown): NoBuildRow | null {
+  const raw = object(value);
+  if (!raw) return null;
+
+  const itemId = text(raw["itemId"]);
+  const name = text(raw["name"]);
+  const from = text(raw["from"]);
+  const required = quantity(raw["required"]);
+  const verified = flag(raw["verified"]);
+
+  if (itemId === null || name === null || from === null) return null;
+  if (required === null || verified === null) return null;
+
+  return { itemId, name, from, required, verified };
+}
+
+function decodeSite(value: unknown): Site | null {
+  const raw = object(value);
+  if (!raw) return null;
+  const extractorClass = text(raw["extractorClass"]);
+  const fillSeconds = quantity(raw["fillSeconds"]);
+  return extractorClass === null || fillSeconds === null
+    ? null
+    : { extractorClass, fillSeconds };
+}
+
+function decodeDemand(value: unknown): Demand | null {
+  const raw = object(value);
+  if (!raw) return null;
+  const itemId = text(raw["itemId"]);
+  const name = text(raw["name"]);
+  const total = quantity(raw["total"]);
+  const verified = flag(raw["verified"]);
+  if (itemId === null || name === null || total === null || verified === null)
+    return null;
+  return { itemId, name, total, verified };
+}
+
+function decodeBase(value: unknown): BaseBuild | null {
+  const raw = object(value);
+  if (!raw) return null;
+
+  const base = text(raw["base"]);
+  const site = decodeSite(raw["site"]);
+  const farms = list(raw["farms"], decodeFarm);
+  const extractors = list(raw["extractors"], decodeExtractor);
+  const ranches = list(raw["ranches"], decodeRanch);
+  const kitchen = list(raw["kitchen"], decodeKitchen);
+  const noBuild = list(raw["noBuild"], decodeNoBuild);
+  const nutrientProcessors = quantity(raw["nutrientProcessors"]);
+  const pelletFeeders = quantity(raw["pelletFeeders"]);
+  const verified = flag(raw["verified"]);
+
+  if (base === null || site === null) return null;
+  if (farms === null || extractors === null || ranches === null) return null;
+  if (kitchen === null || noBuild === null) return null;
+  if (nutrientProcessors === null || pelletFeeders === null || verified === null)
+    return null;
+
+  return {
+    base,
+    site,
+    farms,
+    extractors,
+    ranches,
+    kitchen,
+    nutrientProcessors,
+    pelletFeeders,
+    noBuild,
+    verified,
+  };
+}
+
+/** Pull `data.build` out of a result payload, or return null. */
+export function selectBuild(data: unknown): Build | null {
+  const payload = object(data);
+  const raw: Raw | null = payload === null ? null : object(payload["build"]);
+  if (!raw) return null;
+
+  if (!Array.isArray(raw["bases"])) return null;
+  const bases = list(raw["bases"], decodeBase);
+  const unassigned = list(raw["unassigned"], decodeDemand);
+  if (bases === null || unassigned === null) return null;
+
+  return { bases, unassigned };
+}

--- a/web/src/boundary/client.ts
+++ b/web/src/boundary/client.ts
@@ -21,7 +21,15 @@
 
 import type { PlannerModule } from "./contract";
 import { decodeEnvelope, isNotReady, type Outcome } from "./envelope";
+import { selectBuild, type Build } from "./build";
 import { selectGraph, type ResolvedGraph } from "./graph";
+import { selectPower, type Power } from "./power";
+import {
+  powerToWire,
+  rollupToWire,
+  type PowerRequest,
+  type RollupRequest,
+} from "./requests";
 import {
   BoundaryModule,
   DEFAULT_PATHS,
@@ -96,6 +104,29 @@ export class BoundaryClient {
   /** Resolve a plan into a graph. */
   async resolve(plan: Plan): Promise<Outcome<ResolvedGraph>> {
     return this.#call((planner) => planner.resolve(planToWire(plan)), selectGraph);
+  }
+
+  /**
+   * Stage 2: a plan plus curated constants into construction instructions.
+   *
+   * Takes the plan rather than a resolved graph. SPEC-0002 REQ "Boundary
+   * Surface" requires one call to perform one complete stage, and a caller
+   * obliged to hand back a graph it received would be assembling the stage
+   * out of two crossings.
+   */
+  async rollup(request: RollupRequest): Promise<Outcome<Build>> {
+    return this.#call((planner) => planner.rollup(rollupToWire(request)), selectBuild);
+  }
+
+  /**
+   * Stage 3: generation and draw into a power position.
+   *
+   * Takes no plan. The domain's power stage costs a base sketched by hand
+   * exactly as it costs one a rollup produced, and requiring a plan here
+   * would invent a coupling the engine does not have.
+   */
+  async power(request: PowerRequest): Promise<Outcome<Power>> {
+    return this.#call((planner) => planner.power(powerToWire(request)), selectPower);
   }
 
   /**

--- a/web/src/boundary/decode.ts
+++ b/web/src/boundary/decode.ts
@@ -1,0 +1,94 @@
+/*
+ * The decode primitives every payload shares.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0002 REQ "Exact Quantity
+ * Encoding", SPEC-0005 REQ "The View Computes No Domain Values"
+ *
+ * Extracted from graph.ts when the build and power payloads arrived rather
+ * than copied into them. Three decoders with three private copies of
+ * `optionalQuantity` is three places for the omitempty rule to drift, and
+ * the rule is the same everywhere: absent is fine, present-and-wrong is not.
+ *
+ * Nothing here parses a quantity. `asQuantity` validates the shape and hands
+ * back the same characters; a payload that does not validate is rejected
+ * whole rather than repaired, because a build missing one figure reads as a
+ * build that costs less than it does.
+ */
+
+import { asQuantity, type Quantity } from "./quantity";
+
+export type Raw = Record<string, unknown>;
+
+export function object(value: unknown): Raw | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Raw)
+    : null;
+}
+
+export function text(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+export function textList(value: unknown): readonly string[] | null {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) return null;
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") return null;
+    out.push(entry);
+  }
+  return out;
+}
+
+/**
+ * A required quantity.
+ *
+ * Distinct from {@link optionalQuantity}: a field the wire always sends is
+ * missing rather than absent when it is not there, and treating the two the
+ * same is how a zero gets substituted for a figure the domain reported.
+ */
+export function quantity(value: unknown): Quantity | null {
+  return asQuantity(value);
+}
+
+/** An omitempty field: absent is fine, present-and-wrong is not. */
+export function optionalQuantity(
+  value: unknown,
+): { ok: true; value: Quantity | null } | { ok: false } {
+  if (value === undefined || value === "") return { ok: true, value: null };
+  const parsed = asQuantity(value);
+  return parsed === null ? { ok: false } : { ok: true, value: parsed };
+}
+
+/**
+ * A boolean field.
+ *
+ * Strict rather than truthy. `verified` and `fixUnsized` both carry meaning
+ * in their false case, and coercing an absent field to false would report a
+ * definite answer the payload did not give.
+ */
+export function flag(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+/**
+ * Decode a list whose absence means empty, rejecting the whole list if any
+ * element fails.
+ *
+ * The all-or-nothing rule applied one level down. A row that cannot be read
+ * is not a row to skip: it is a payload this view does not understand.
+ */
+export function list<T>(
+  value: unknown,
+  decode: (entry: unknown) => T | null,
+): T[] | null {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) return null;
+  const out: T[] = [];
+  for (const entry of value) {
+    const decoded = decode(entry);
+    if (decoded === null) return null;
+    out.push(decoded);
+  }
+  return out;
+}

--- a/web/src/boundary/graph.ts
+++ b/web/src/boundary/graph.ts
@@ -11,6 +11,7 @@
  * less than it does.
  */
 
+import { list, object, optionalQuantity, text, textList } from "./decode";
 import { asQuantity, type Quantity } from "./quantity";
 
 export interface ResolvedEdge {
@@ -42,38 +43,6 @@ export interface ResolvedGraph {
   readonly nodes: readonly ResolvedNode[];
 }
 
-type Raw = Record<string, unknown>;
-
-function object(value: unknown): Raw | null {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Raw)
-    : null;
-}
-
-function text(value: unknown): string | null {
-  return typeof value === "string" ? value : null;
-}
-
-function textList(value: unknown): readonly string[] | null {
-  if (value === undefined) return [];
-  if (!Array.isArray(value)) return null;
-  const out: string[] = [];
-  for (const entry of value) {
-    if (typeof entry !== "string") return null;
-    out.push(entry);
-  }
-  return out;
-}
-
-/** An omitempty field: absent is fine, present-and-wrong is not. */
-function optionalQuantity(
-  value: unknown,
-): { ok: true; value: Quantity | null } | { ok: false } {
-  if (value === undefined || value === "") return { ok: true, value: null };
-  const quantity = asQuantity(value);
-  return quantity === null ? { ok: false } : { ok: true, value: quantity };
-}
-
 function decodeEdge(value: unknown): ResolvedEdge | null {
   const raw = object(value);
   if (!raw) return null;
@@ -103,16 +72,8 @@ function decodeNode(value: unknown): ResolvedNode | null {
   const applications = optionalQuantity(raw["applications"]);
   if (!yieldValue.ok || !applications.ok) return null;
 
-  const children: ResolvedEdge[] = [];
-  const rawChildren = raw["children"];
-  if (rawChildren !== undefined) {
-    if (!Array.isArray(rawChildren)) return null;
-    for (const entry of rawChildren) {
-      const edge = decodeEdge(entry);
-      if (edge === null) return null;
-      children.push(edge);
-    }
-  }
+  const children = list(raw["children"], decodeEdge);
+  if (children === null) return null;
 
   return {
     itemId,
@@ -141,15 +102,9 @@ export function selectGraph(data: unknown): ResolvedGraph | null {
   const gameVersion = text(raw["gameVersion"]);
   if (target === null || quantity === null || gameVersion === null) return null;
 
-  const rawNodes = raw["nodes"];
-  if (!Array.isArray(rawNodes)) return null;
-
-  const nodes: ResolvedNode[] = [];
-  for (const entry of rawNodes) {
-    const node = decodeNode(entry);
-    if (node === null) return null;
-    nodes.push(node);
-  }
+  if (!Array.isArray(raw["nodes"])) return null;
+  const nodes = list(raw["nodes"], decodeNode);
+  if (nodes === null) return null;
 
   return { target, quantity, gameVersion, nodes };
 }

--- a/web/src/boundary/index.ts
+++ b/web/src/boundary/index.ts
@@ -23,6 +23,30 @@ export {
 } from "./contract";
 export type { Failure, Outcome } from "./envelope";
 export type { ResolvedEdge, ResolvedGraph, ResolvedNode } from "./graph";
+export type {
+  BaseBuild,
+  Build,
+  Demand,
+  ExtractorRow,
+  FarmRow,
+  KitchenInput,
+  KitchenStep,
+  NoBuildRow,
+  RanchRow,
+  Site,
+  YieldRange,
+} from "./build";
+export type { Power, PowerBudget } from "./power";
+export type {
+  ByproductSource,
+  Curated,
+  KitchenStepRequest,
+  PowerGeneration,
+  PowerRequest,
+  PowerUnit,
+  RollupRequest,
+  SiteConfig,
+} from "./requests";
 export {
   EMPTY_PLAN,
   isEmptyPlan,

--- a/web/src/boundary/power.ts
+++ b/web/src/boundary/power.ts
@@ -1,0 +1,104 @@
+/*
+ * The stage 3 power payload: one base's power position.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0002 REQ "Exact Quantity
+ * Encoding", SPEC-0005 REQ "The View Computes No Domain Values",
+ * SPEC-0007 REQ "Power Position", REQ "Deficit Is an Action, Including When
+ * It Cannot Be Sized"
+ *
+ * `balance` and `deficit` both cross as the domain's own values — the
+ * adapter does not subtract, and neither does this. SPEC-0007 forbids the
+ * card computing a balance, a percentage or a meter proportion from the two
+ * figures as displayed.
+ *
+ * `fixUnsized` is decoded as its own field and never inferred from a zero
+ * generator count. It reports that a deficit exists but no class is
+ * configured to size the fix with, and design.md warns that an implementer
+ * working from the prototype alone would meet a budget in deficit with
+ * `additionalGenerators` of zero and reasonably conclude there was nothing
+ * to show.
+ */
+
+import { flag, list, object, quantity, text, type Raw } from "./decode";
+import type { Quantity } from "./quantity";
+
+export interface PowerBudget {
+  readonly base: string;
+
+  readonly generation: Quantity;
+  readonly draw: Quantity;
+
+  /** Generation minus draw, and may be negative. The domain's own value. */
+  readonly balance: Quantity;
+  /** The shortfall as a positive figure, or zero. Also the domain's. */
+  readonly deficit: Quantity;
+  readonly inDeficit: boolean;
+
+  readonly perGenerator: Quantity;
+  readonly batteries: Quantity;
+
+  /** How many more generators at this base's class would clear the deficit. */
+  readonly additionalGenerators: Quantity;
+  /**
+   * A deficit exists but no class is configured to cost the fix with.
+   *
+   * Distinct from `additionalGenerators` being zero because there is no
+   * deficit. A card must show the deficit either way and must not present
+   * an unsized fix as an actionable count.
+   */
+  readonly fixUnsized: boolean;
+
+  readonly verified: boolean;
+}
+
+export interface Power {
+  readonly bases: readonly PowerBudget[];
+}
+
+function decodeBudget(value: unknown): PowerBudget | null {
+  const raw = object(value);
+  if (!raw) return null;
+
+  const base = text(raw["base"]);
+  const generation = quantity(raw["generation"]);
+  const draw = quantity(raw["draw"]);
+  const balance = quantity(raw["balance"]);
+  const deficit = quantity(raw["deficit"]);
+  const perGenerator = quantity(raw["perGenerator"]);
+  const batteries = quantity(raw["batteries"]);
+  const additionalGenerators = quantity(raw["additionalGenerators"]);
+  const inDeficit = flag(raw["inDeficit"]);
+  const fixUnsized = flag(raw["fixUnsized"]);
+  const verified = flag(raw["verified"]);
+
+  if (base === null || generation === null || draw === null) return null;
+  if (balance === null || deficit === null) return null;
+  if (perGenerator === null || batteries === null || additionalGenerators === null)
+    return null;
+  if (inDeficit === null || fixUnsized === null || verified === null) return null;
+
+  return {
+    base,
+    generation,
+    draw,
+    balance,
+    deficit,
+    inDeficit,
+    perGenerator,
+    batteries,
+    additionalGenerators,
+    fixUnsized,
+    verified,
+  };
+}
+
+/** Pull `data.power` out of a result payload, or return null. */
+export function selectPower(data: unknown): Power | null {
+  const payload = object(data);
+  const raw: Raw | null = payload === null ? null : object(payload["power"]);
+  if (!raw) return null;
+
+  if (!Array.isArray(raw["bases"])) return null;
+  const bases = list(raw["bases"], decodeBudget);
+  return bases === null ? null : { bases };
+}

--- a/web/src/boundary/requests.ts
+++ b/web/src/boundary/requests.ts
@@ -1,0 +1,109 @@
+/*
+ * What the view sends to stages 2 and 3.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0002 REQ "Exact Quantity
+ * Encoding", SPEC-0001 design.md "Tier 2 constants injected, never
+ * hardcoded"
+ *
+ * Every scalar is a quantity string for the same reason node totals are: a
+ * count that crosses as a JSON number has left the exactness contract. The
+ * curated constants cross with the request rather than living in the module
+ * because the engine refuses to default any of them and names the one it is
+ * missing — a guarantee that only holds if the view never invents one.
+ *
+ * These are request shapes, not domain values. The view assembles them from
+ * plan state and player configuration; it computes none of them.
+ */
+
+import type { Plan } from "./plan";
+import type { Quantity } from "./quantity";
+
+/** The Tier 2 constant set. The engine defaults none of it. */
+export interface Curated {
+  readonly biodomeCropSlots: Quantity;
+  readonly faunaYieldPerCycle: Quantity;
+  readonly faunaCycleSeconds: Quantity;
+  readonly stepsPerProcessor: Quantity;
+  readonly depotThreshold: Quantity;
+  readonly processSeconds: Quantity;
+  readonly panelsPerBattery: Quantity;
+  /** Which leaves come from creatures. */
+  readonly faunaProducts?: readonly string[];
+  /** Which hotspot category each extracted resource sits on. */
+  readonly resourceHotspots?: Readonly<Record<string, string>>;
+}
+
+export interface SiteConfig {
+  readonly extractorClass: string;
+  readonly fillSeconds: Quantity;
+}
+
+export interface ByproductSource {
+  readonly item: string;
+  readonly from: string;
+}
+
+export interface KitchenStepRequest {
+  readonly itemId: string;
+  readonly recipe: string;
+  readonly quantity: Quantity;
+}
+
+export interface RollupRequest {
+  readonly plan: Plan;
+  readonly assignments?: Readonly<Record<string, string>>;
+  readonly sites?: Readonly<Record<string, SiteConfig>>;
+  readonly byproducts?: Readonly<Record<string, readonly ByproductSource[]>>;
+  readonly kitchen?: Readonly<Record<string, readonly KitchenStepRequest[]>>;
+  readonly constants: Curated;
+}
+
+/**
+ * One base's generation setup.
+ *
+ * Three independent values, not a choice between two modes. The domain
+ * models them that way — a base may run both — and SPEC-0007 REQ "Power
+ * Configuration Supports Mixed Sources" requires the view to be able to
+ * express it. Solar carries no class, because the domain's solar output is
+ * classless and offering one would imply a computation it does not perform.
+ */
+export interface PowerGeneration {
+  readonly emGenerators?: Quantity;
+  readonly emClass?: string;
+  readonly solarPanels?: Quantity;
+}
+
+/** A count of one buildable drawing power at a base. */
+export interface PowerUnit {
+  readonly partId: string;
+  readonly count: Quantity;
+}
+
+export interface PowerRequest {
+  readonly sources?: Readonly<Record<string, PowerGeneration>>;
+  readonly draws?: Readonly<Record<string, readonly PowerUnit[]>>;
+  /**
+   * The bases whose contributing figures are not verified.
+   *
+   * A list rather than a map to boolean: the set is what is meant, and a
+   * map with false values would encode a distinction that is not one.
+   */
+  readonly unverified?: readonly string[];
+  readonly constants: Curated;
+}
+
+/*
+ * The wire encoders.
+ *
+ * `JSON.stringify` drops undefined keys, which is exactly the omitempty
+ * behaviour the Go side expects — an absent optional means "not configured",
+ * and the engine names any constant it needed and did not get.
+ */
+
+export function rollupToWire(request: RollupRequest): string {
+  return JSON.stringify(request);
+}
+
+export function powerToWire(request: PowerRequest): string {
+  return JSON.stringify(request);
+}

--- a/web/tests/boundary/stages-integration.spec.ts
+++ b/web/tests/boundary/stages-integration.spec.ts
@@ -1,0 +1,189 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/*
+ * Governing: ADR-0003 (Go domain, thin adapter), ADR-0004 (React view
+ * layer), SPEC-0002 REQ "Boundary Surface"
+ *
+ * Stage 2 and stage 3 against the real module and the real artifact.
+ *
+ * tests/boundary/stages.spec.ts drives the decoders with hand-built
+ * payloads, which proves they decode what this file says the wire looks
+ * like. This proves that is what the wire actually looks like.
+ */
+
+const FIXTURE = "/tests/fixtures/boundary.html";
+
+/*
+ * The Tier 2 constant set. SPEC-0001 design.md requires these be injected
+ * rather than defaulted, and the engine refuses a partially-specified set
+ * and names the constant it is missing — so a request that omits one fails
+ * loudly rather than silently using a number nobody chose.
+ *
+ * Values mirror internal/domain/power_test.go's set.
+ */
+const CONSTANTS = {
+  biodomeCropSlots: "16",
+  faunaYieldPerCycle: "12",
+  faunaCycleSeconds: "1800",
+  stepsPerProcessor: "2",
+  depotThreshold: "1000",
+  processSeconds: "30",
+  panelsPerBattery: "2",
+  faunaProducts: [],
+  resourceHotspots: {},
+};
+
+interface Outcome {
+  kind: string;
+  code?: string;
+  value?: unknown;
+}
+
+async function callRollup(page: Page, request: unknown): Promise<Outcome> {
+  return page.evaluate(async (payload) => {
+    await window.__boundary.start();
+    return (await window.__boundary.rollup(payload)) as Outcome;
+  }, request);
+}
+
+async function callPower(page: Page, request: unknown): Promise<Outcome> {
+  return page.evaluate(async (payload) => {
+    await window.__boundary.start();
+    return (await window.__boundary.power(payload)) as Outcome;
+  }, request);
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(FIXTURE, { waitUntil: "load" });
+});
+
+test("rollup crosses and returns a build", async ({ page }) => {
+  const outcome = await callRollup(page, {
+    plan: { target: "ULTRAPROD2", quantity: "1" },
+    constants: CONSTANTS,
+  });
+
+  expect(outcome.kind, `rollup failed: ${outcome.code ?? ""}`).toBe("ok");
+  const build = outcome.value as { bases: unknown[]; unassigned: unknown[] };
+  expect(Array.isArray(build.bases)).toBe(true);
+  expect(Array.isArray(build.unassigned)).toBe(true);
+});
+
+test("unassigned leaves are reported rather than lost", async ({ page }) => {
+  /*
+   * With no assignments, every leaf is unplaced. The producer stage skips
+   * them because there is no site to build them at, and the payload carries
+   * them so the view can say so rather than showing an empty build.
+   */
+  const outcome = await callRollup(page, {
+    plan: { target: "ULTRAPROD2", quantity: "1" },
+    constants: CONSTANTS,
+  });
+
+  expect(outcome.kind).toBe("ok");
+  const build = outcome.value as { unassigned: { itemId: string; total: string }[] };
+  expect(build.unassigned.length).toBeGreaterThan(0);
+  expect(build.unassigned[0]?.total).toMatch(/^-?\d+(\/\d+)?$/);
+});
+
+test("power crosses and returns a budget with the domain's own balance", async ({
+  page,
+}) => {
+  const outcome = await callPower(page, {
+    sources: { A: { emGenerators: "4", emClass: "C" } },
+    draws: { A: [{ partId: "BUILDLIGHT", count: "10" }] },
+    constants: CONSTANTS,
+  });
+
+  expect(outcome.kind, `power failed: ${outcome.code ?? ""}`).toBe("ok");
+  const power = outcome.value as {
+    bases: {
+      base: string;
+      generation: string;
+      draw: string;
+      balance: string;
+      fixUnsized: boolean;
+    }[];
+  };
+
+  const budget = power.bases[0];
+  expect(budget?.base).toBe("A");
+  for (const figure of [budget?.generation, budget?.draw, budget?.balance]) {
+    expect(figure, "a power figure did not cross as an exact quantity").toMatch(
+      /^-?\d+(\/\d+)?$/,
+    );
+  }
+  expect(typeof budget?.fixUnsized).toBe("boolean");
+});
+
+test("a deficit with no class configured crosses as fixUnsized", async ({ page }) => {
+  /*
+   * The state design.md warns an implementer would conclude was nothing to
+   * show. Configuring draw with no generator class leaves the domain unable
+   * to size the fix — and it reports that rather than reporting zero
+   * additional generators and letting the view guess why.
+   */
+  const outcome = await callPower(page, {
+    sources: { A: { emGenerators: "0" } },
+    draws: { A: [{ partId: "BUILDLIGHT", count: "50" }] },
+    constants: CONSTANTS,
+  });
+
+  expect(outcome.kind, `power failed: ${outcome.code ?? ""}`).toBe("ok");
+  const power = outcome.value as {
+    bases: { inDeficit: boolean; additionalGenerators: string; fixUnsized: boolean }[];
+  };
+
+  const budget = power.bases[0];
+  expect(budget?.inDeficit, "the base should be in deficit").toBe(true);
+  expect(budget?.fixUnsized, "no class is configured, so the fix cannot be sized").toBe(
+    true,
+  );
+  expect(budget?.additionalGenerators).toBe("0");
+});
+
+test("a missing curated constant is refused by name, not defaulted", async ({ page }) => {
+  /*
+   * SPEC-0001 design.md: "Tier 2 constants injected, never hardcoded." The
+   * engine refuses a partial set. This asserts the client surfaces that as
+   * a stable code rather than the request silently succeeding with a number
+   * nobody chose.
+   */
+  const partial: Record<string, unknown> = { ...CONSTANTS };
+  delete partial["depotThreshold"];
+  const outcome = await callRollup(page, {
+    plan: { target: "ULTRAPROD2", quantity: "1" },
+    constants: partial,
+  });
+
+  expect(outcome.kind).toBe("failed");
+  expect(outcome.code).toBeTruthy();
+});
+
+test("both stages return the same outcome shape as resolve", async ({ page }) => {
+  /*
+   * A component handles all three identically, which is only true if the
+   * discriminant is the same. Typecheck covers the declaration; this covers
+   * the runtime value.
+   */
+  const shapes = await page.evaluate(async (constants) => {
+    await window.__boundary.start();
+    const resolve = (await window.__boundary.resolve({
+      target: "ULTRAPROD2",
+      quantity: "1",
+    })) as Record<string, unknown>;
+    const rollup = (await window.__boundary.rollup({
+      plan: { target: "ULTRAPROD2", quantity: "1" },
+      constants,
+    })) as Record<string, unknown>;
+    const power = (await window.__boundary.power({ constants })) as Record<
+      string,
+      unknown
+    >;
+    return [resolve, rollup, power].map((outcome) =>
+      Object.keys(outcome).sort().join(","),
+    );
+  }, CONSTANTS);
+
+  expect(new Set(shapes).size, `outcome shapes differ: ${shapes.join(" | ")}`).toBe(1);
+});

--- a/web/tests/boundary/stages.spec.ts
+++ b/web/tests/boundary/stages.spec.ts
@@ -1,0 +1,246 @@
+import { expect, test } from "@playwright/test";
+
+import { selectBuild } from "../../src/boundary/build";
+import { selectPower } from "../../src/boundary/power";
+
+/*
+ * Governing: ADR-0004 (React view layer), SPEC-0002 REQ "Exact Quantity
+ * Encoding", SPEC-0007 REQ "Card Composition From the Build Payload",
+ * REQ "Deficit Is an Action, Including When It Cannot Be Sized"
+ *
+ * The stage 2 and stage 3 decoders. Same discipline the graph decoder
+ * already holds: every quantity stays the string the boundary sent, and a
+ * payload that does not validate is rejected whole rather than repaired —
+ * a build missing one figure reads as a build that costs less than it does.
+ */
+
+/**
+ * The payload minus one field.
+ *
+ * A helper rather than rest-destructuring: `const { x: _dropped, ...rest }`
+ * leaves an unused binding the linter rightly objects to, and loosening the
+ * rule for one idiom is a worse trade than one small function.
+ */
+function without<T extends object>(value: T, key: keyof T): Partial<T> {
+  const copy: Partial<T> = { ...value };
+  delete copy[key];
+  return copy;
+}
+
+const BUDGET = {
+  base: "A",
+  generation: "600",
+  draw: "450",
+  balance: "150",
+  deficit: "0",
+  inDeficit: false,
+  perGenerator: "150",
+  batteries: "0",
+  additionalGenerators: "0",
+  fixUnsized: false,
+  verified: false,
+};
+
+const FARM = {
+  itemId: "LUSH1",
+  name: "Paraffinium",
+  required: "300",
+  plants: "19",
+  biodomes: "2",
+  yieldPerPlant: { min: "16", max: "24" },
+  growthSeconds: "1800",
+  verified: false,
+};
+
+const BASE = {
+  base: "A",
+  site: { extractorClass: "C", fillSeconds: "5400" },
+  farms: [FARM],
+  nutrientProcessors: "1",
+  pelletFeeders: "0",
+  verified: false,
+};
+
+test.describe("the build payload", () => {
+  test("decodes a base and keeps every count as the domain sent it", () => {
+    const build = selectBuild({ build: { bases: [BASE] } });
+    expect(build).not.toBeNull();
+
+    const base = build?.bases[0];
+    expect(base?.base).toBe("A");
+    expect(base?.farms[0]?.plants).toBe("19");
+    expect(base?.farms[0]?.biodomes).toBe("2");
+    expect(base?.nutrientProcessors).toBe("1");
+  });
+
+  test("both yield bounds survive", () => {
+    /*
+     * The domain sizes plants on the pessimistic bound and SPEC-0007 forbids
+     * the card presenting the optimistic one as the planning figure. A
+     * decoder that kept only one bound would make that requirement
+     * unsatisfiable rather than merely unmet.
+     */
+    const build = selectBuild({ build: { bases: [BASE] } });
+    expect(build?.bases[0]?.farms[0]?.yieldPerPlant).toEqual({ min: "16", max: "24" });
+  });
+
+  test("omitempty sections decode as empty, not as missing", () => {
+    const build = selectBuild({ build: { bases: [BASE] } });
+    const base = build?.bases[0];
+    expect(base?.extractors).toEqual([]);
+    expect(base?.ranches).toEqual([]);
+    expect(base?.kitchen).toEqual([]);
+    expect(base?.noBuild).toEqual([]);
+    expect(build?.unassigned).toEqual([]);
+  });
+
+  test("a no-build row carries what covers it", () => {
+    /*
+     * SPEC-0007 REQ "Byproducts Are Shown, Not Omitted": an absent row is
+     * indistinguishable from an overlooked requirement, so the decoder has
+     * to carry the covering producer as well as the demand.
+     */
+    const build = selectBuild({
+      build: {
+        bases: [
+          {
+            ...BASE,
+            noBuild: [
+              {
+                itemId: "CATALYST1",
+                name: "Condensed Carbon",
+                from: "gas refine",
+                required: "300",
+                verified: false,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(build?.bases[0]?.noBuild[0]?.from).toBe("gas refine");
+  });
+
+  test("a row missing a required field rejects the whole payload", () => {
+    /*
+     * Not "drop the row". A build with one farm missing is a build the
+     * player will follow and find short.
+     */
+    const withoutPlants = without(FARM, "plants");
+    expect(
+      selectBuild({ build: { bases: [{ ...BASE, farms: [withoutPlants] }] } }),
+    ).toBeNull();
+  });
+
+  test("a quantity that is not exact rejects the payload", () => {
+    expect(
+      selectBuild({ build: { bases: [{ ...BASE, nutrientProcessors: 1 }] } }),
+    ).toBeNull();
+    expect(
+      selectBuild({ build: { bases: [{ ...BASE, nutrientProcessors: "1.5" }] } }),
+    ).toBeNull();
+  });
+
+  test("a missing verified flag is not coerced to false", () => {
+    /*
+     * `verified` carries meaning in its false case — SPEC-0007 requires the
+     * card to mark unverified figures — so an absent flag is a payload this
+     * view does not understand, not a definite "no".
+     */
+    const withoutVerified = without(BASE, "verified");
+    expect(selectBuild({ build: { bases: [withoutVerified] } })).toBeNull();
+  });
+
+  test("anything that is not a build payload is rejected", () => {
+    for (const bad of [
+      null,
+      {},
+      { build: null },
+      { build: {} },
+      { build: { bases: "x" } },
+    ]) {
+      expect(selectBuild(bad), `${JSON.stringify(bad)} was accepted`).toBeNull();
+    }
+  });
+});
+
+test.describe("the power payload", () => {
+  test("decodes a budget and keeps balance and deficit as the domain sent them", () => {
+    const power = selectPower({ power: { bases: [BUDGET] } });
+    const budget = power?.bases[0];
+
+    expect(budget?.generation).toBe("600");
+    expect(budget?.draw).toBe("450");
+    expect(budget?.balance).toBe("150");
+    expect(budget?.deficit).toBe("0");
+  });
+
+  test("a negative balance survives", () => {
+    const power = selectPower({
+      power: {
+        bases: [
+          {
+            ...BUDGET,
+            generation: "300",
+            balance: "-150",
+            deficit: "150",
+            inDeficit: true,
+          },
+        ],
+      },
+    });
+    expect(power?.bases[0]?.balance).toBe("-150");
+    expect(power?.bases[0]?.deficit).toBe("150");
+  });
+
+  test("fixUnsized is decoded, not inferred from a zero generator count", () => {
+    /*
+     * The criterion this story exists to protect.
+     *
+     * design.md warns that an implementer working from the prototype alone
+     * "would meet a budget in deficit with AdditionalGenerators of zero and
+     * reasonably conclude there was nothing to show." These two payloads
+     * differ in exactly one boolean and must decode differently — a decoder
+     * that derived the flag from `additionalGenerators === "0"` would
+     * collapse them.
+     */
+    const inDeficit = {
+      ...BUDGET,
+      generation: "300",
+      balance: "-150",
+      deficit: "150",
+      inDeficit: true,
+    };
+
+    const sizeable = selectPower({
+      power: { bases: [{ ...inDeficit, additionalGenerators: "1", fixUnsized: false }] },
+    });
+    const unsizeable = selectPower({
+      power: { bases: [{ ...inDeficit, additionalGenerators: "0", fixUnsized: true }] },
+    });
+    const noDeficit = selectPower({
+      power: { bases: [{ ...BUDGET, additionalGenerators: "0", fixUnsized: false }] },
+    });
+
+    expect(sizeable?.bases[0]?.fixUnsized).toBe(false);
+    expect(unsizeable?.bases[0]?.fixUnsized).toBe(true);
+    expect(noDeficit?.bases[0]?.fixUnsized).toBe(false);
+
+    /* The two zero-generator cases are told apart by the flag alone. */
+    expect(unsizeable?.bases[0]?.additionalGenerators).toBe(
+      noDeficit?.bases[0]?.additionalGenerators,
+    );
+    expect(unsizeable?.bases[0]?.fixUnsized).not.toBe(noDeficit?.bases[0]?.fixUnsized);
+  });
+
+  test("a missing fixUnsized rejects the payload rather than defaulting", () => {
+    const withoutFlag = without(BUDGET, "fixUnsized");
+    expect(selectPower({ power: { bases: [withoutFlag] } })).toBeNull();
+  });
+
+  test("anything that is not a power payload is rejected", () => {
+    for (const bad of [null, {}, { power: null }, { power: { bases: "x" } }]) {
+      expect(selectPower(bad), `${JSON.stringify(bad)} was accepted`).toBeNull();
+    }
+  });
+});

--- a/web/tests/fixtures/boundary-harness.ts
+++ b/web/tests/fixtures/boundary-harness.ts
@@ -25,6 +25,8 @@ declare global {
       peek: () => ReturnType<BoundaryClient["peek"]>;
       start: () => Promise<void>;
       resolve: (plan: unknown) => Promise<unknown>;
+      rollup: (request: unknown) => Promise<unknown>;
+      power: (request: unknown) => Promise<unknown>;
       /** Issue a resolve without awaiting it, so a test can observe pending. */
       resolveLater: (plan: unknown) => void;
       settled: () => unknown;
@@ -64,6 +66,8 @@ window.__boundary = {
   peek: () => client.peek(),
   start: () => client.start(),
   resolve: async (value) => client.resolve(plan(value)),
+  rollup: async (request) => client.rollup(request as never),
+  power: async (request) => client.power(request as never),
   resolveLater: (value) => {
     pending = client.resolve(plan(value)).then((outcome) => {
       settled = outcome;


### PR DESCRIPTION
Closes #95
Part of #94

Implements SPEC-0002 REQ "Result Envelope", REQ "Exact Quantity Encoding" on the view side, unblocking SPEC-0007.

The client surface every SPEC-0007 story reads through, and the reason none of them could start first.

## The gap was one-sided

The Go half was already complete — `internal/bridge/module.go` implements `Rollup` and `Power` in full, `cmd/planner` registers both, and `EntryPoints` lists them. `web/src/boundary/client.ts` exposed **only `resolve`**. That was the entire gap, and it blocked an entire epic.

Both methods go through the existing `#call` path rather than growing their own readiness handling, so a rollup issued before the module has loaded waits on the same load a `resolve` does and retries once. That behaviour is inherited, not repeated.

## The decode primitives moved rather than being copied

`decode.ts` now holds `object`, `text`, `textList`, `quantity`, `optionalQuantity`, `flag` and `list`. Three decoders with three private copies of `optionalQuantity` is three places for the omitempty rule to drift, and the rule is identical everywhere: absent is fine, present-and-wrong is not.

`graph.ts` imports them, and its two hand-rolled `children`/`nodes` loops collapse into the shared `list` helper — which is where the all-or-nothing rule lives now, in one place instead of three.

## Two decisions worth reading

**`fixUnsized` is decoded, never inferred.** design.md warns that an implementer working from the prototype alone "would meet a budget in deficit with `AdditionalGenerators` of zero and reasonably conclude there was nothing to show." A test drives three payloads that differ only in that boolean and asserts the two zero-generator cases are told apart by the flag alone — a decoder that derived it from `additionalGenerators === "0"` would collapse them.

**Booleans decode strictly, not truthily.** `verified` and `fixUnsized` both carry meaning in their false case, so an absent flag is a payload this view does not understand rather than a definite "no". Coercing it would report an answer the payload never gave, and SPEC-0007 requires the card to mark unverified figures.

## Tested twice, deliberately

`tests/boundary/stages.spec.ts` drives the decoders with hand-built payloads. That proves they decode what those tests *say* the wire looks like.

`tests/boundary/stages-integration.spec.ts` runs both stages against the real module and the real artifact. That proves what the wire **actually is**:

- `rollup` crosses and returns a build, with unassigned leaves reported rather than lost
- `power` returns generation, draw and balance as exact quantity strings — no subtraction anywhere in the view
- **a deficit with no generator class configured crosses as `fixUnsized: true` from the real engine**, with `additionalGenerators: "0"`
- a missing curated constant is refused rather than defaulted, per SPEC-0001 design.md's "injected, never hardcoded"
- all three stages return the same `Outcome` shape at runtime, not just in the type declaration

Without the second file, the first is a test of my own assumptions about the payload.

## Consolidates work #88 was carrying

#88 (leaf assignment, SPEC-0006) was planned with its own `rollup` extension and a note that SPEC-0007 would want `power` from the same file. It now depends on this instead — two stories independently adding methods to one client is the drift a foundation story exists to prevent. **This unblocks #88 as well as the whole of #94.**

## One small thing

The rest-destructuring omit idiom (`const { x: _dropped, ...rest }`) trips `@typescript-eslint/no-unused-vars`. I used an explicit `without()` helper in the tests rather than loosening the rule project-wide for one idiom.

## Verified locally

`npm run lint`, `lint:css`, `typecheck`, `format:check`, `check:tokens`, `npm run build`, `npm test` (138 passed — 73 boundary, up from 54), `npm run test:mutation` (21/21 still red).

## Note on the push

Pushed over HTTPS: the 1Password SSH agent has stopped signing again. No workflow files are touched here, so the token's missing `workflow` scope did not bite.
