### PR TITLE
feat(web): let the boundary client send verified dates

### DIFF
--- a/web/src/boundary/requests.ts
+++ b/web/src/boundary/requests.ts
@@ -31,6 +31,28 @@ export interface Curated {
   readonly faunaProducts?: readonly string[];
   /** Which hotspot category each extracted resource sits on. */
   readonly resourceHotspots?: Readonly<Record<string, string>>;
+
+  /*
+   * The date each curated constant was confirmed in game, keyed by the
+   * domain's constant names ("biodome crop slots", "panels per battery", and
+   * the five others above).
+   *
+   * Optional, and absence is the meaningful case: the engine reads a
+   * constant as unverified when this map has no entry for it, and taints
+   * every figure derived from it. So omitting this field is not "no
+   * provenance information" — it is the claim that nothing has been
+   * confirmed, which is the honest state of this project's curated set
+   * today and the reason every producer row currently returns
+   * `verified: false`.
+   *
+   * It is here so that state can change. Without it the view can read
+   * provenance and never influence it, which makes the flag it decodes
+   * permanently false rather than merely false for now.
+   *
+   * Governing: SPEC-0001 REQ "Provenance Propagation" — Scenario
+   * "Unverified constant taints producer count".
+   */
+  readonly verifiedOn?: Readonly<Record<string, string>>;
 }
 
 export interface SiteConfig {

--- a/web/tests/boundary/stages-integration.spec.ts
+++ b/web/tests/boundary/stages-integration.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+import type { Curated } from "../../src/boundary/requests";
+
 /*
  * Governing: ADR-0003 (Go domain, thin adapter), ADR-0004 (React view
  * layer), SPEC-0002 REQ "Boundary Surface"
@@ -186,4 +188,100 @@ test("both stages return the same outcome shape as resolve", async ({ page }) =>
   }, CONSTANTS);
 
   expect(new Set(shapes).size, `outcome shapes differ: ${shapes.join(" | ")}`).toBe(1);
+});
+
+/*
+ * The provenance round trip, against the real engine.
+ *
+ * Governing: SPEC-0001 REQ "Provenance Propagation", SPEC-0007 REQ
+ * "Provenance on Displayed Figures"
+ *
+ * Every other test in this file exercises provenance's false branch by
+ * accident — no request carries verified dates, so everything comes back
+ * unverified and a client that could not send them at all would look
+ * identical. That was the gap: `verifiedOn` was absent from the request
+ * type, so the flag the decoders read carefully was permanently false and
+ * the view had no way to say otherwise.
+ *
+ * A solar base is the cheapest true case. Its battery count is derived
+ * entirely from `panels per battery`, so the budget's provenance is that one
+ * constant's — no assignments, no hotspot configuration, no producer rows
+ * needed to reach it.
+ *
+ * The three cases together are what make this meaningful. Asserting only the
+ * true case would pass against a decoder that hardcoded `true`; asserting
+ * only the pair would pass against one that tainted every base whenever any
+ * date was missing.
+ */
+/*
+ * The compile-time half of the guarantee.
+ *
+ * `callPower` takes `unknown` and the encoder is `JSON.stringify`, so at
+ * runtime a caller could always put `verifiedOn` on the wire whether or not
+ * the interface declared it — the field crossed fine before this change.
+ * What was missing was the type: no one writing against `Curated` could see
+ * the field existed, and a properly-typed call site would have been rejected
+ * for using it.
+ *
+ * So the guard is a type assertion rather than an assertion in a test body.
+ * `Pick<Curated, "verifiedOn">` does not compile if `Curated` has no such
+ * key, which makes `npm run typecheck` fail the moment the field is removed.
+ * The runtime tests below cannot do that job, and it is worth being precise
+ * about which half each one covers.
+ */
+const VERIFIED_ON_IS_SENDABLE: Pick<Curated, "verifiedOn"> = {
+  verifiedOn: { "panels per battery": "2026-08-28" },
+};
+
+test("a supplied verified date crosses and marks the budget verified", async ({
+  page,
+}) => {
+  const solar = { sources: { A: { solarPanels: "4" } }, draws: {} };
+
+  const withoutDates = await callPower(page, {
+    ...solar,
+    constants: CONSTANTS,
+  });
+  expect(withoutDates.kind, `power failed: ${withoutDates.code ?? ""}`).toBe("ok");
+  const unverified = (withoutDates.value as { bases: { verified: boolean }[] }).bases[0];
+  expect(
+    unverified?.verified,
+    "a battery count derived from an undated constant reported itself verified",
+  ).toBe(false);
+
+  const withDates = await callPower(page, {
+    ...solar,
+    constants: { ...CONSTANTS, ...VERIFIED_ON_IS_SENDABLE },
+  });
+  expect(withDates.kind, `power failed: ${withDates.code ?? ""}`).toBe("ok");
+  const verified = (withDates.value as { bases: { verified: boolean }[] }).bases[0];
+  expect(
+    verified?.verified,
+    "the supplied date did not reach the engine — verifiedOn is not crossing",
+  ).toBe(true);
+});
+
+test("a base that reads no curated constant is not tainted by an absent date", async ({
+  page,
+}) => {
+  /*
+   * Electromagnetic generation reads the artifact's part rate and hotspot
+   * strength, neither of which is curated. Without this case the pair above
+   * is satisfied by an engine that taints every base whenever any date is
+   * missing, which would make the flag useless rather than wrong.
+   */
+  const outcome = await callPower(page, {
+    sources: { A: { emGenerators: "1", emClass: "B" } },
+    draws: {},
+    constants: CONSTANTS,
+  });
+
+  expect(outcome.kind, `power failed: ${outcome.code ?? ""}`).toBe("ok");
+  const budget = (outcome.value as { bases: { verified: boolean; batteries: string }[] })
+    .bases[0];
+  expect(budget?.batteries).toBe("0");
+  expect(
+    budget?.verified,
+    "a base running no panels was tainted by a constant it never reads",
+  ).toBe(true);
 });


### PR DESCRIPTION
Closes #117

Implements SPEC-0001 REQ "Provenance Propagation", SPEC-0007 REQ "Provenance on Displayed Figures".

Three lines of type, two integration tests, and one compile-time guard.

## I overstated the finding, and the correction is the interesting part

Issue #117 says the client "cannot send `verifiedOn`". That is wrong, and I found out by writing the test.

The encoder is `JSON.stringify` and `callPower` takes `unknown`, so a caller could always put `verifiedOn` on the wire whether or not the interface declared it. My first version of the round-trip test passed **before** the fix — which is exactly what a test is for.

What was actually missing is the type. Nobody writing against `Curated` could see the field existed, and a properly-typed call site would have been rejected for using it. That is a real gap in a foundation client whose whole job is to be the surface every SPEC-0007 story reads through — but it is a discoverability and type-safety gap, not a capability one.

I have corrected the issue and my review comment on #116 rather than leaving the stronger claim standing.

## Which half each test covers

**The compile-time half is the guard.** `Pick<Curated, "verifiedOn">` does not compile if the key is absent, so `npm run typecheck` fails the moment the field is removed. Verified by removing it:

```
tests/boundary/stages-integration.spec.ts(232,46): error TS2344:
  Type '"verifiedOn"' does not satisfy the constraint 'keyof Curated'.
```

A runtime test cannot do that job here, and the comment in the file says which half it covers so the next person does not assume the integration tests are protecting the type.

**The runtime half proves the engine honours it**, against the real module and the real artifact:

- a solar base with no dates supplied comes back `verified: false`
- the same base with `{"panels per battery": "2026-08-28"}` comes back `verified: true`
- an electromagnetic-only base is **not** tainted by a constant it never reads

The third case matters as much as the pair. Asserting only the true case would pass against a decoder that hardcoded `true`; asserting only the pair would pass against an engine that tainted every base whenever any date was missing, which would make the flag useless rather than wrong.

A solar base is the cheapest true case — its battery count derives entirely from one curated constant, so no assignments, hotspot configuration or producer rows are needed to reach it.

## Why this was worth closing now

This is the first test in the repository that exercises provenance's **true** branch. Every existing test hits the false branch by accident, because no request carries dates — so a client that genuinely could not send them would have looked identical.

It is the third instance of the same shape in this project: the tree canvas's `unverified` badge, unreachable because the normalizer never emits `verified: false`; `ErrMissingConstant`, defined and mapped and raised by nothing until #73; and this. A mechanism built, wired, tested, and never fired.

## Verified

```
npm run typecheck      PASS      npm test             140 passed
npm run lint           PASS      npm run test:mutation  21/21 red
npm run lint:css       PASS      npm run build        PASS
npm run format:check   PASS      npm run check:tokens PASS
```

140 tests, up from 138. Docs and types only on the source side — no behaviour change to the encoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)