### PR TITLE
feat(web): the durable store

### DIFF
--- a/web/src/store/durable-store.ts
+++ b/web/src/store/durable-store.ts
@@ -1,0 +1,360 @@
+/*
+ * The local store.
+ *
+ * Governing: ADR-0008 (durable user data lives in a local-first store),
+ * SPEC-0009 REQ "A Workspace Owns Places", REQ "A Place Is One Record Type,
+ * Whatever Its Kind", REQ "Versioned, and Fails Legibly", REQ "Error
+ * Handling Standards", REQ "Storage Operation Standards", REQ "Stage 1
+ * Reaches No Network"
+ *
+ * IndexedDB, not localStorage. The design README's prohibition names
+ * localStorage specifically and ADR-0008 lifts it for durable data only —
+ * plan state keeps the rule. localStorage would have been the letter of it
+ * and not the spirit: synchronous on the thread the WASM module runs on,
+ * string-only, and capped around 5 MB.
+ *
+ * This is the first code in the project that legitimately holds durable
+ * state, and it must not become the back door the other rules were keeping
+ * shut. `ViewState` still has no field a graph could go in and `ResultCache`
+ * still holds one deep-frozen entry. Nothing here stores a plan, a resolved
+ * graph, or any derived quantity.
+ */
+
+import { classify, failure, ok, type StoreResult } from "./errors";
+import { MAX_PLACE_BYTES, serializedBytes } from "./limits";
+import {
+  emptyWorkspace,
+  isPlaceKind,
+  SCHEMA_VERSION,
+  type PlaceRecord,
+  type Workspace,
+  type WorkspaceRecord,
+} from "./schema";
+
+const DATABASE = "nms-planner";
+
+/*
+ * The IndexedDB version, which is not the schema version.
+ *
+ * IndexedDB's version governs the object stores; `schemaVersion` on each
+ * record governs the shape of what is in them. They move independently: a
+ * record shape can change without adding a store, and the version failure
+ * SPEC-0009 requires is about the records, not the stores.
+ */
+const DB_VERSION = 1;
+
+const WORKSPACE_STORE = "workspace";
+const PLACES_STORE = "places";
+/** The workspace is a singleton; this is its key. */
+const WORKSPACE_KEY = "self";
+
+function request<T>(source: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    source.addEventListener("success", () => {
+      resolve(source.result);
+    });
+    source.addEventListener("error", () => {
+      reject(source.error ?? new Error("request failed"));
+    });
+  });
+}
+
+function settled(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.addEventListener("complete", () => {
+      resolve();
+    });
+    transaction.addEventListener("error", () => {
+      reject(transaction.error ?? new Error("transaction failed"));
+    });
+    transaction.addEventListener("abort", () => {
+      reject(transaction.error ?? new DOMException("aborted", "AbortError"));
+    });
+  });
+}
+
+/**
+ * Validate a stored place against the shape this build reads.
+ *
+ * Returns a StoreResult rather than `PlaceRecord | StoreFailure`. Both of
+ * those carry a `kind` field — a place's is its type, a failure's is the
+ * literal "failed" — so narrowing on it happened to work and read as though
+ * it were designed. One of them changing would have broken it silently.
+ */
+function readPlace(value: unknown): StoreResult<PlaceRecord> {
+  if (typeof value !== "object" || value === null) {
+    return failure("MALFORMED_RECORD", "a stored place is not an object");
+  }
+  const raw = value as Record<string, unknown>;
+
+  const version = raw["schemaVersion"];
+  if (typeof version !== "number") {
+    return failure("MALFORMED_RECORD", "a stored place carries no schemaVersion");
+  }
+  if (version > SCHEMA_VERSION) {
+    return failure(
+      "UNSUPPORTED_VERSION",
+      `a stored place is schema version ${String(version)}, and this build reads ${String(SCHEMA_VERSION)}`,
+    );
+  }
+
+  if (typeof raw["id"] !== "string" || !isPlaceKind(raw["kind"])) {
+    return failure("MALFORMED_RECORD", "a stored place has no usable id or kind");
+  }
+  if (typeof raw["updatedAt"] !== "string" || typeof raw["revision"] !== "number") {
+    return failure(
+      "MALFORMED_RECORD",
+      `place ${raw["id"]} is missing updatedAt or revision`,
+    );
+  }
+
+  return ok(raw as unknown as PlaceRecord);
+}
+
+export interface StoreOptions {
+  /** Injected so tests can drive time. Defaults to the wall clock. */
+  readonly now?: () => string;
+  /** Injected so a test can use its own database rather than the app's. */
+  readonly databaseName?: string;
+}
+
+export class DurableStore {
+  readonly #databaseName: string;
+  readonly #now: () => string;
+  #db: IDBDatabase | null = null;
+
+  constructor(options: StoreOptions = {}) {
+    this.#databaseName = options.databaseName ?? DATABASE;
+    this.#now = options.now ?? (() => new Date().toISOString());
+  }
+
+  /**
+   * Open the database, creating its stores on first use.
+   *
+   * Idempotent. The `versionchange` handler is the load-bearing part: when
+   * another tab opens the database at a higher version, this connection is
+   * told and closes. Without it that tab's upgrade blocks indefinitely and
+   * presents as the application hanging on load — a symptom pointing
+   * nowhere near its cause, which is why SPEC-0009 names it.
+   */
+  async open(): Promise<StoreResult<void>> {
+    if (this.#db) return ok(undefined);
+
+    if (typeof indexedDB === "undefined") {
+      return failure("STORAGE_UNAVAILABLE", "this browser exposes no IndexedDB");
+    }
+
+    try {
+      const opening = indexedDB.open(this.#databaseName, DB_VERSION);
+
+      opening.addEventListener("upgradeneeded", () => {
+        const db = opening.result;
+        if (!db.objectStoreNames.contains(WORKSPACE_STORE))
+          db.createObjectStore(WORKSPACE_STORE);
+        if (!db.objectStoreNames.contains(PLACES_STORE)) {
+          db.createObjectStore(PLACES_STORE, { keyPath: "id" });
+        }
+      });
+
+      const db = await request(opening);
+      db.addEventListener("versionchange", () => {
+        db.close();
+        this.#db = null;
+      });
+
+      this.#db = db;
+      return ok(undefined);
+    } catch (error) {
+      return classify(error, "opening the store");
+    }
+  }
+
+  close(): void {
+    this.#db?.close();
+    this.#db = null;
+  }
+
+  /**
+   * Read the whole workspace.
+   *
+   * One transaction covering both stores, and **all or nothing**. An
+   * unrecognized version anywhere loads no places at all — not the readable
+   * subset. A partially loaded workspace is indistinguishable to the player
+   * from a complete one: they see their bases and do not see that four of
+   * eleven are missing.
+   */
+  async load(): Promise<StoreResult<Workspace>> {
+    const db = this.#db;
+    if (!db) return failure("STORAGE_UNAVAILABLE", "the store is not open");
+
+    try {
+      const transaction = db.transaction([WORKSPACE_STORE, PLACES_STORE], "readonly");
+      const storedWorkspace = await request<unknown>(
+        transaction.objectStore(WORKSPACE_STORE).get(WORKSPACE_KEY),
+      );
+      const storedPlaces = await request<unknown[]>(
+        transaction.objectStore(PLACES_STORE).getAll(),
+      );
+      await settled(transaction);
+
+      /*
+       * A device that has never used the store. Ordinary, not a failure.
+       *
+       * Only when there are no places either. A missing workspace record
+       * with places present is not a fresh device — it is a store whose
+       * two halves disagree, and returning "empty" there would silently
+       * drop every place the player has. An earlier draft did exactly that
+       * and the malformed-record test caught it.
+       */
+      if (storedWorkspace === undefined) {
+        if (storedPlaces.length > 0) {
+          return failure(
+            "MALFORMED_RECORD",
+            `the store holds ${String(storedPlaces.length)} places and no workspace record`,
+          );
+        }
+        return ok({ workspace: emptyWorkspace(this.#now()), places: [] });
+      }
+
+      const raw = storedWorkspace as Record<string, unknown>;
+      const version = raw["schemaVersion"];
+      if (typeof version !== "number") {
+        return failure(
+          "MALFORMED_RECORD",
+          "the stored workspace carries no schemaVersion",
+        );
+      }
+      if (version > SCHEMA_VERSION) {
+        return failure(
+          "UNSUPPORTED_VERSION",
+          `the stored workspace is schema version ${String(version)}, ` +
+            `and this build reads ${String(SCHEMA_VERSION)}`,
+        );
+      }
+      if (!("ownerId" in raw)) {
+        return failure("MALFORMED_RECORD", "the stored workspace has no ownerId field");
+      }
+
+      const places: PlaceRecord[] = [];
+      for (const stored of storedPlaces) {
+        const place = readPlace(stored);
+        if (place.kind !== "ok") return place;
+        places.push(place.value);
+      }
+
+      return ok({ workspace: raw as unknown as WorkspaceRecord, places });
+    } catch (error) {
+      return classify(error, "loading the store");
+    }
+  }
+
+  /**
+   * Write one place, advancing its revision.
+   *
+   * The size bound is checked before anything is attempted: SPEC-0009
+   * requires the store fail a write that would exceed it "rather than
+   * attempting it and discovering the quota", because a quota failure is
+   * shared with everything else the origin stores and is a worse way to
+   * find out.
+   *
+   * The place and the workspace's `updatedAt` move in one transaction. A
+   * store that could complete the first without the second would produce a
+   * workspace that disagrees with its own contents.
+   */
+  async putPlace(
+    place: Omit<PlaceRecord, "schemaVersion" | "updatedAt" | "revision">,
+  ): Promise<StoreResult<PlaceRecord>> {
+    const db = this.#db;
+    if (!db) return failure("STORAGE_UNAVAILABLE", "the store is not open");
+
+    const size = serializedBytes(place);
+    if (size > MAX_PLACE_BYTES) {
+      return failure(
+        "PLACE_TOO_LARGE",
+        `place ${place.id} is ${String(size)} bytes, and the limit is ${String(MAX_PLACE_BYTES)}`,
+      );
+    }
+
+    try {
+      const now = this.#now();
+      const transaction = db.transaction([WORKSPACE_STORE, PLACES_STORE], "readwrite");
+      const places = transaction.objectStore(PLACES_STORE);
+      const workspaces = transaction.objectStore(WORKSPACE_STORE);
+
+      const existing = (await request<unknown>(places.get(place.id))) as
+        { revision?: number } | undefined;
+      const revision = (existing?.revision ?? 0) + 1;
+
+      const record: PlaceRecord = {
+        ...place,
+        schemaVersion: SCHEMA_VERSION,
+        updatedAt: now,
+        revision,
+      };
+      await request(places.put(record));
+
+      const storedWorkspace = (await request<unknown>(workspaces.get(WORKSPACE_KEY))) as
+        WorkspaceRecord | undefined;
+      await request(
+        workspaces.put(
+          { ...(storedWorkspace ?? emptyWorkspace(now)), updatedAt: now },
+          WORKSPACE_KEY,
+        ),
+      );
+
+      await settled(transaction);
+      return ok(record);
+    } catch (error) {
+      return classify(error, `writing place ${place.id}`);
+    }
+  }
+
+  /** Persist the view's own preferences. Interface state, not domain state. */
+  async putPreferences(
+    preferences: Readonly<Record<string, string | boolean>>,
+  ): Promise<StoreResult<void>> {
+    const db = this.#db;
+    if (!db) return failure("STORAGE_UNAVAILABLE", "the store is not open");
+
+    try {
+      const now = this.#now();
+      const transaction = db.transaction(WORKSPACE_STORE, "readwrite");
+      const workspaces = transaction.objectStore(WORKSPACE_STORE);
+      const stored = (await request<unknown>(workspaces.get(WORKSPACE_KEY))) as
+        WorkspaceRecord | undefined;
+      await request(
+        workspaces.put(
+          { ...(stored ?? emptyWorkspace(now)), preferences, updatedAt: now },
+          WORKSPACE_KEY,
+        ),
+      );
+      await settled(transaction);
+      return ok(undefined);
+    } catch (error) {
+      return classify(error, "writing preferences");
+    }
+  }
+
+  /**
+   * Remove everything.
+   *
+   * ADR-0002 banked "needs no upload endpoint, retention policy, or
+   * deletion story" as a benefit of holding nothing. The moment data is
+   * held the player is owed a way to remove it that is not developer tools,
+   * and this is that operation's storage half.
+   */
+  async deleteAll(): Promise<StoreResult<void>> {
+    const db = this.#db;
+    if (!db) return failure("STORAGE_UNAVAILABLE", "the store is not open");
+
+    try {
+      const transaction = db.transaction([WORKSPACE_STORE, PLACES_STORE], "readwrite");
+      await request(transaction.objectStore(PLACES_STORE).clear());
+      await request(transaction.objectStore(WORKSPACE_STORE).clear());
+      await settled(transaction);
+      return ok(undefined);
+    } catch (error) {
+      return classify(error, "deleting stored data");
+    }
+  }
+}

--- a/web/src/store/errors.ts
+++ b/web/src/store/errors.ts
@@ -1,0 +1,81 @@
+/*
+ * The store's failure modes, as sentinels rather than prose.
+ *
+ * Governing: ADR-0008 (durable user data), SPEC-0009 REQ "Error Handling
+ * Standards"
+ *
+ * Selectable by identity, never by message text. The boundary client
+ * already enforces this discipline and `tests/boundary/discipline.spec.ts`
+ * checks it mechanically; the same rule applies here for the same reason —
+ * a message is diagnostic text with no contractual format, and branching on
+ * it makes the next wording change a behaviour change.
+ */
+
+export const STORE_CODES = [
+  /** The stored schemaVersion is one this build does not understand. */
+  "UNSUPPORTED_VERSION",
+  /** The write would exceed the per-place bound, or the origin's quota. */
+  "QUOTA_EXCEEDED",
+  /** A single place would exceed the configured bound. Refused before writing. */
+  "PLACE_TOO_LARGE",
+  /** IndexedDB is absent or blocked — a private window, or a disabled API. */
+  "STORAGE_UNAVAILABLE",
+  /** The place asked for is not in the store. */
+  "RECORD_NOT_FOUND",
+  /** A stored record does not match the schema this build reads. */
+  "MALFORMED_RECORD",
+  /** Anything the classifier could not place. */
+  "UNCLASSIFIED",
+] as const;
+
+export type StoreCode = (typeof STORE_CODES)[number];
+
+export interface StoreFailure {
+  readonly kind: "failed";
+  readonly code: StoreCode;
+  /** Diagnostic only. Never branched on — see SPEC-0009 REQ "Error Handling Standards". */
+  readonly message: string;
+}
+
+export type StoreResult<T> = { readonly kind: "ok"; readonly value: T } | StoreFailure;
+
+export function failure(code: StoreCode, message: string): StoreFailure {
+  return { kind: "failed", code, message };
+}
+
+export function ok<T>(value: T): StoreResult<T> {
+  return { kind: "ok", value };
+}
+
+/**
+ * Map a thrown value onto a sentinel.
+ *
+ * A pure function so the mapping is testable without provoking the
+ * condition. Filling a real disk to observe a quota failure is not a test
+ * anyone will run twice, and the interesting question — does a
+ * QuotaExceededError reach the caller as the quota sentinel rather than as
+ * UNCLASSIFIED — is answerable here.
+ */
+export function classify(error: unknown, context: string): StoreFailure {
+  const name = error instanceof DOMException ? error.name : "";
+  const detail = error instanceof Error ? error.message : String(error);
+  const message = `${context}: ${detail}`;
+
+  switch (name) {
+    case "QuotaExceededError":
+      return failure("QUOTA_EXCEEDED", message);
+    case "InvalidStateError":
+    case "SecurityError":
+    case "UnknownError":
+      /*
+       * A private window with storage blocked, or an origin the browser
+       * refuses to persist for. Distinct from a quota failure: there is no
+       * amount of freeing up that helps.
+       */
+      return failure("STORAGE_UNAVAILABLE", message);
+    case "NotFoundError":
+      return failure("RECORD_NOT_FOUND", message);
+    default:
+      return failure("UNCLASSIFIED", message);
+  }
+}

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -1,0 +1,27 @@
+/*
+ * The store's public surface.
+ *
+ * Governing: ADR-0008 (durable user data), SPEC-0009
+ *
+ * Consumers import from here. `durable-store.ts` internals — the request
+ * promisifiers, the store names, the record validator — are implementation.
+ */
+
+export { DurableStore, type StoreOptions } from "./durable-store";
+export {
+  STORE_CODES,
+  type StoreCode,
+  type StoreFailure,
+  type StoreResult,
+} from "./errors";
+export { MAX_PLACE_BYTES, MEASURED_PLACE_BYTES, serializedBytes } from "./limits";
+export {
+  emptyWorkspace,
+  isPlaceKind,
+  PLACE_KINDS,
+  SCHEMA_VERSION,
+  type PlaceKind,
+  type PlaceRecord,
+  type Workspace,
+  type WorkspaceRecord,
+} from "./schema";

--- a/web/src/store/limits.ts
+++ b/web/src/store/limits.ts
@@ -1,0 +1,50 @@
+/*
+ * The per-place size bound.
+ *
+ * Governing: ADR-0008 (durable user data), SPEC-0009 § Security
+ * Requirements → Request Body Size Limits
+ *
+ * SPEC-0005 recorded this value as unchosen and SPEC-0009 requires it be
+ * "derived from measurement rather than guessed" and "recorded with the
+ * sizes it was derived from". Here are the sizes.
+ *
+ * Measured against the 108-entry parts catalog in `data/tier1.json`, with
+ * realistic natural-language notes rather than compressible filler — the
+ * distinction that mattered when ADR-0008 measured the URL-hash case and a
+ * first pass using `"x" * 400` reported figures four times too small:
+ *
+ *   ticks  stocked  tags   JSON bytes
+ *      40       20     4        1,677   typical, part-way through a build
+ *     108       20     4        2,966   every catalogue part ticked
+ *     108      200    20        6,156   heavy: long tag list, deep stock
+ *
+ * So a text place tops out near 6 KB. The bound is 64 KiB — an order of
+ * magnitude above the heavy case, which leaves room for fields this schema
+ * does not have yet while still refusing something pathological: a document
+ * pasted into a note, or a data URL somebody tried to smuggle in as text.
+ *
+ * Images are NOT in scope. ADR-0008 defers blob storage to a later ADR on
+ * measured grounds — one capture is 1.5–3 MB against 596 KB for a 200-place
+ * text workspace — so this bound is a text bound, and a store that starts
+ * holding images needs it revisited rather than inherited.
+ */
+
+/** 64 KiB. See the measurements above. */
+export const MAX_PLACE_BYTES = 64 * 1024;
+
+/** The measurements the bound was set from, so a future change can argue with them. */
+export const MEASURED_PLACE_BYTES = Object.freeze({
+  typical: 1_677,
+  everyPartTicked: 2_966,
+  heavy: 6_156,
+});
+
+/**
+ * The serialized size of a value, in bytes.
+ *
+ * UTF-8 rather than string length: a note in a language outside Latin-1
+ * costs more bytes than characters, and the quota is counted in bytes.
+ */
+export function serializedBytes(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).length;
+}

--- a/web/src/store/schema.ts
+++ b/web/src/store/schema.ts
@@ -1,0 +1,96 @@
+/*
+ * What the store holds.
+ *
+ * Governing: ADR-0008 (durable user data, local-first), SPEC-0009 REQ "A
+ * Workspace Owns Places", REQ "A Place Is One Record Type, Whatever Its
+ * Kind", REQ "Versioned, and Fails Legibly"
+ *
+ * Three fields here are written from version 1 and read by nothing:
+ * `ownerId`, `updatedAt` and `revision`. That is deliberate and it is the
+ * whole reason ADR-0008 settled ownership and the sharing unit before any
+ * sharing was built.
+ *
+ * Sign-in attaches an `ownerId` to a workspace that already carries the
+ * field; it does not re-key records. A field added in version 2 cannot do
+ * that for data written under version 1, and the player who ticked fifty
+ * construction items before signing up is exactly who that migration is
+ * for. `revision` is the same argument for multi-device ordering: a store
+ * that adds it later cannot order edits made before it existed.
+ */
+
+/** The schema this build understands. */
+export const SCHEMA_VERSION = 1;
+
+/**
+ * One record type for all three surfaces.
+ *
+ * ADR-0006 and ADR-0007 make freighters and settlements their own surfaces
+ * because their domain content differs. None of that reaches durable user
+ * data — a note is a note and a tick is a tick — and ADR-0008 settled the
+ * sharing unit as "one place", which only reads coherently if a place is
+ * one thing.
+ */
+export type PlaceKind = "base" | "freighter" | "settlement";
+
+export const PLACE_KINDS: readonly PlaceKind[] = ["base", "freighter", "settlement"];
+
+export interface PlaceRecord {
+  /** Generated at creation. Independent of any save file and any account. */
+  readonly id: string;
+  readonly kind: PlaceKind;
+  readonly schemaVersion: number;
+
+  /** Player-assigned. Absent until the player names it. */
+  readonly name?: string;
+  readonly notes?: string;
+  readonly tags?: readonly string[];
+  /** Construction items ticked off, keyed by part id. */
+  readonly ticks?: Readonly<Record<string, boolean>>;
+  /** Stocked quantities, keyed by item id. Exact strings, never numbers. */
+  readonly stocked?: Readonly<Record<string, string>>;
+
+  /*
+   * Reserved for ADR-0012 (multi-device sync and conflict resolution).
+   * Written on every mutation; nothing reads them in stage 1.
+   */
+  readonly updatedAt: string;
+  readonly revision: number;
+}
+
+export interface WorkspaceRecord {
+  readonly schemaVersion: number;
+
+  /**
+   * Null in stage 1, where no account exists.
+   *
+   * Present and null rather than absent — SPEC-0009 REQ "A Workspace Owns
+   * Places" requires the distinction, because the field being there from
+   * version 1 is what makes sign-in an attachment rather than a migration.
+   */
+  readonly ownerId: string | null;
+
+  /** View-local preferences. SPEC-0005 permits the view to hold these. */
+  readonly preferences?: Readonly<Record<string, string | boolean>>;
+
+  readonly updatedAt: string;
+}
+
+export interface Workspace {
+  readonly workspace: WorkspaceRecord;
+  readonly places: readonly PlaceRecord[];
+}
+
+export function isPlaceKind(value: unknown): value is PlaceKind {
+  return typeof value === "string" && (PLACE_KINDS as readonly string[]).includes(value);
+}
+
+/**
+ * A workspace as it exists on a device that has never used the store.
+ *
+ * Not an error and not a failure — SPEC-0009 REQ "An Empty Store Is a
+ * Designed State" makes this the ordinary condition on a fresh device, a
+ * private window, or after the player cleared their storage.
+ */
+export function emptyWorkspace(now: string): WorkspaceRecord {
+  return { schemaVersion: SCHEMA_VERSION, ownerId: null, updatedAt: now };
+}

--- a/web/tests/boundary/discipline.spec.ts
+++ b/web/tests/boundary/discipline.spec.ts
@@ -24,6 +24,15 @@ import {
  */
 
 const BOUNDARY = path.join(import.meta.dirname, "..", "..", "src", "boundary");
+
+/*
+ * The store holds the same discipline for the same reason. SPEC-0009 REQ
+ * "Error Handling Standards" requires its sentinels be "selectable by
+ * identity rather than by message text", which is the boundary's rule with
+ * a different set of codes — so it is checked by the same checker rather
+ * than by a second copy of it.
+ */
+const STORE = path.join(import.meta.dirname, "..", "..", "src", "store");
 const TESTS = import.meta.dirname;
 
 function sourcesIn(directory: string): { file: string; source: string }[] {
@@ -46,6 +55,30 @@ test("the boundary sources exist and were actually read", () => {
 test("no boundary source branches on an error message", () => {
   for (const { file, source } of sourcesIn(BOUNDARY)) {
     expect(messageInspections(file, source), `${file} inspects a message`).toEqual([]);
+  }
+});
+
+test("no store source branches on an error message either", () => {
+  const sources = sourcesIn(STORE);
+  expect(sources.length, "the store sources were not found").toBeGreaterThanOrEqual(4);
+  for (const { file, source } of sources) {
+    expect(messageInspections(file, source), `store/${file} inspects a message`).toEqual(
+      [],
+    );
+  }
+});
+
+test("no store source turns a stored quantity into a number", () => {
+  /*
+   * Stocked quantities are exact strings for the same reason node totals
+   * are. A store that parsed one to compare it would have left the
+   * exactness contract at the point the value is most durable.
+   */
+  for (const { file, source } of sourcesIn(STORE)) {
+    expect(
+      numericConversions(file, source),
+      `store/${file} converts to a number`,
+    ).toEqual([]);
   }
 });
 

--- a/web/tests/fixtures/store-harness.ts
+++ b/web/tests/fixtures/store-harness.ts
@@ -1,0 +1,120 @@
+/*
+ * Test harness for the durable store.
+ *
+ * Governing: SPEC-0009
+ *
+ * IndexedDB exists only in a browser, so the store's tests are page tests
+ * rather than Node ones. Each test gets its own database name so they can
+ * run in parallel without sharing state — the store is a singleton per
+ * origin in production and deliberately not here.
+ */
+
+import { classify } from "../../src/store/errors";
+import { DurableStore } from "../../src/store";
+import type { PlaceRecord, StoreResult, Workspace } from "../../src/store";
+
+type NewPlace = Omit<PlaceRecord, "schemaVersion" | "updatedAt" | "revision">;
+
+declare global {
+  interface Window {
+    __store: {
+      open: (database: string, now?: string) => Promise<StoreResult<void>>;
+      load: (database: string) => Promise<StoreResult<Workspace>>;
+      putPlace: (database: string, place: NewPlace) => Promise<StoreResult<PlaceRecord>>;
+      putPreferences: (
+        database: string,
+        preferences: Record<string, string | boolean>,
+      ) => Promise<StoreResult<void>>;
+      deleteAll: (database: string) => Promise<StoreResult<void>>;
+      close: (database: string) => void;
+      /** Write a record straight past the store, to plant a bad version. */
+      plant: (
+        database: string,
+        store: string,
+        key: string | null,
+        value: unknown,
+      ) => Promise<void>;
+      /** Open a raw connection at a higher version, to test versionchange. */
+      upgrade: (database: string, version: number) => Promise<"upgraded" | "blocked">;
+      /** The pure error classifier, for conditions a test cannot provoke. */
+      classify: (name: string) => string;
+    };
+  }
+}
+
+const stores = new Map<string, DurableStore>();
+
+function get(database: string, now?: string): DurableStore {
+  let store = stores.get(database);
+  if (!store) {
+    store = new DurableStore(
+      now ? { databaseName: database, now: () => now } : { databaseName: database },
+    );
+    stores.set(database, store);
+  }
+  return store;
+}
+
+window.__store = {
+  open: async (database, now) => get(database, now).open(),
+  load: async (database) => get(database).load(),
+  putPlace: async (database, place) => get(database).putPlace(place),
+  putPreferences: async (database, preferences) =>
+    get(database).putPreferences(preferences),
+  deleteAll: async (database) => get(database).deleteAll(),
+  close: (database) => {
+    get(database).close();
+    stores.delete(database);
+  },
+
+  plant: async (database, store, key, value) =>
+    new Promise((resolve, reject) => {
+      const opening = indexedDB.open(database);
+      opening.onsuccess = () => {
+        const db = opening.result;
+        const transaction = db.transaction(store, "readwrite");
+        const target = transaction.objectStore(store);
+        if (key === null) target.put(value);
+        else target.put(value, key);
+        transaction.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+        transaction.onerror = () => {
+          db.close();
+          reject(transaction.error ?? new Error("plant failed"));
+        };
+      };
+      opening.onerror = () => {
+        reject(opening.error ?? new Error("plant open failed"));
+      };
+    }),
+
+  upgrade: async (database, version) =>
+    new Promise((resolve) => {
+      const opening = indexedDB.open(database, version);
+      let blocked = false;
+      opening.onblocked = () => {
+        blocked = true;
+      };
+      opening.onsuccess = () => {
+        opening.result.close();
+        resolve(blocked ? "blocked" : "upgraded");
+      };
+      opening.onerror = () => {
+        resolve("blocked");
+      };
+      /*
+       * A `blocked` event does not settle the request — the open stays
+       * pending until the holding connection closes. Without this the test
+       * would hang rather than report the condition it is checking for.
+       */
+      setTimeout(() => {
+        resolve(blocked ? "blocked" : "upgraded");
+      }, 2000);
+    }),
+
+  classify: (name) => classify(new DOMException("planted", name), "test").code,
+};
+
+document.body.dataset["ready"] = "true";

--- a/web/tests/fixtures/store.html
+++ b/web/tests/fixtures/store.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Durable store fixture</title>
+  </head>
+  <body>
+    <!--
+      Governing: SPEC-0009
+
+      The store runs in a browser because IndexedDB only exists in one.
+      Nothing here styles anything: the store has no surface, and its one
+      presentation requirement constrains consumers rather than rendering.
+    -->
+    <script type="module" src="./store-harness.ts"></script>
+  </body>
+</html>

--- a/web/tests/store/durable-store.spec.ts
+++ b/web/tests/store/durable-store.spec.ts
@@ -1,0 +1,499 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { MAX_PLACE_BYTES, MEASURED_PLACE_BYTES, SCHEMA_VERSION } from "../../src/store";
+
+/*
+ * Governing: ADR-0008 (durable user data, local-first), SPEC-0009
+ *
+ * The store, in a real browser. IndexedDB exists nowhere else, and a fake
+ * would be a test of the fake.
+ *
+ * Each test uses its own database name so they run in parallel without
+ * sharing state. The store is a singleton per origin in production and
+ * deliberately not here.
+ */
+
+const FIXTURE = "/tests/fixtures/store.html";
+
+let counter = 0;
+function freshDatabase(): string {
+  counter += 1;
+  return `test-store-${String(counter)}-${String(Math.floor(performance.now()))}`;
+}
+
+async function openStore(page: Page, database: string, now?: string): Promise<void> {
+  const opened = await page.evaluate(
+    async ([db, at]) => window.__store.open(db, at || undefined),
+    [database, now ?? ""] as const,
+  );
+  expect(opened.kind, `opening the store failed`).toBe("ok");
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(FIXTURE, { waitUntil: "load" });
+  await expect(page.locator("body")).toHaveAttribute("data-ready", "true");
+});
+
+/* ----------------------------------------------------------------------
+ * The workspace and its reserved fields
+ * ------------------------------------------------------------------- */
+
+test("a device that has never used the store gets an empty workspace, not a failure", async ({
+  page,
+}) => {
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  const loaded = await page.evaluate((db) => window.__store.load(db), database);
+  expect(loaded.kind).toBe("ok");
+  if (loaded.kind !== "ok") return;
+
+  expect(loaded.value.places).toEqual([]);
+  expect(loaded.value.workspace.schemaVersion).toBe(SCHEMA_VERSION);
+});
+
+test("ownerId is present and null, not absent", async ({ page }) => {
+  /*
+   * The distinction SPEC-0009 REQ "A Workspace Owns Places" requires.
+   * ADR-0008's migration works because sign-in attaches an owner to a
+   * workspace that already carries the field; a field added in version 2
+   * cannot do that for data written under version 1.
+   */
+  const database = freshDatabase();
+  await openStore(page, database);
+  await page.evaluate(
+    (db) => window.__store.putPlace(db, { id: "p1", kind: "base", name: "Verdant" }),
+    database,
+  );
+
+  const shape = await page.evaluate(async (db) => {
+    const loaded = await window.__store.load(db);
+    if (loaded.kind !== "ok") return null;
+    return {
+      hasOwnerId: "ownerId" in loaded.value.workspace,
+      ownerId: loaded.value.workspace.ownerId,
+    };
+  }, database);
+
+  expect(shape?.hasOwnerId, "ownerId must be a present field").toBe(true);
+  expect(shape?.ownerId).toBeNull();
+});
+
+test("updatedAt and revision are written even though nothing reads them", async ({
+  page,
+}) => {
+  /*
+   * Reserved for ADR-0012. A reviewer who has not read ADR-0008 will
+   * reasonably ask why three unused fields exist, so this asserts them
+   * rather than leaving it to judgement: a store that adds ordering later
+   * cannot order edits made before it existed.
+   */
+  const database = freshDatabase();
+  await openStore(page, database, "2026-08-28T06:00:00.000Z");
+
+  const written = await page.evaluate(
+    (db) => window.__store.putPlace(db, { id: "p1", kind: "base" }),
+    database,
+  );
+
+  expect(written.kind).toBe("ok");
+  if (written.kind !== "ok") return;
+  expect(written.value.updatedAt).toBe("2026-08-28T06:00:00.000Z");
+  expect(written.value.revision).toBe(1);
+  expect(written.value.schemaVersion).toBe(SCHEMA_VERSION);
+});
+
+test("revision advances on every write", async ({ page }) => {
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  const revisions = await page.evaluate(async (db) => {
+    const out: number[] = [];
+    for (const name of ["first", "second", "third"]) {
+      const result = await window.__store.putPlace(db, { id: "p1", kind: "base", name });
+      if (result.kind === "ok") out.push(result.value.revision);
+    }
+    return out;
+  }, database);
+
+  expect(revisions).toEqual([1, 2, 3]);
+});
+
+test("a place id is stable, not derived from its contents", async ({ page }) => {
+  /*
+   * SPEC-0009: the id is generated at creation, independent of any save
+   * file. Re-importing a base from a changed save must not produce a second
+   * record — which is what a content-derived id would do.
+   */
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  const result = await page.evaluate(async (db) => {
+    await window.__store.putPlace(db, { id: "p1", kind: "base", name: "Original" });
+    await window.__store.putPlace(db, { id: "p1", kind: "base", name: "Renamed" });
+    const loaded = await window.__store.load(db);
+    return loaded.kind === "ok"
+      ? { count: loaded.value.places.length, name: loaded.value.places[0]?.name }
+      : null;
+  }, database);
+
+  expect(result?.count, "a changed name created a second record").toBe(1);
+  expect(result?.name).toBe("Renamed");
+});
+
+test("all three kinds are one record type", async ({ page }) => {
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  const kinds = await page.evaluate(async (db) => {
+    for (const kind of ["base", "freighter", "settlement"] as const) {
+      await window.__store.putPlace(db, { id: kind, kind });
+    }
+    const loaded = await window.__store.load(db);
+    return loaded.kind === "ok"
+      ? loaded.value.places.map((place) => place.kind).sort()
+      : [];
+  }, database);
+
+  expect(kinds).toEqual(["base", "freighter", "settlement"]);
+});
+
+/* ----------------------------------------------------------------------
+ * Versioning
+ * ------------------------------------------------------------------- */
+
+test("a future workspace version loads nothing and names both versions", async ({
+  page,
+}) => {
+  const database = freshDatabase();
+  await openStore(page, database);
+  await page.evaluate(
+    (db) => window.__store.putPlace(db, { id: "p1", kind: "base" }),
+    database,
+  );
+
+  const failed = await page.evaluate(async (db) => {
+    await window.__store.plant(db, "workspace", "self", {
+      schemaVersion: 99,
+      ownerId: null,
+      updatedAt: "2026-08-28T00:00:00.000Z",
+    });
+    return window.__store.load(db);
+  }, database);
+
+  expect(failed.kind).toBe("failed");
+  if (failed.kind !== "failed") return;
+  expect(failed.code).toBe("UNSUPPORTED_VERSION");
+  expect(failed.message).toContain("99");
+  expect(failed.message).toContain(String(SCHEMA_VERSION));
+});
+
+test("one unreadable place fails the whole load, not just that record", async ({
+  page,
+}) => {
+  /*
+   * The case that tempts a partial load. A workspace missing four of
+   * eleven bases is indistinguishable to the player from a complete one,
+   * and they plan against what is there.
+   */
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  const failed = await page.evaluate(async (db) => {
+    await window.__store.putPlace(db, { id: "good", kind: "base" });
+    await window.__store.plant(db, "places", null, {
+      id: "future",
+      kind: "base",
+      schemaVersion: 99,
+      updatedAt: "2026-08-28T00:00:00.000Z",
+      revision: 1,
+    });
+    return window.__store.load(db);
+  }, database);
+
+  expect(failed.kind, "a readable subset was returned").toBe("failed");
+  if (failed.kind !== "failed") return;
+  expect(failed.code).toBe("UNSUPPORTED_VERSION");
+});
+
+test("places without a workspace record are a failure, not an empty store", async ({
+  page,
+}) => {
+  /*
+   * The bug this test found on its first run.
+   *
+   * `load()` treated a missing workspace record as "a device that has never
+   * used the store" and returned an empty workspace — dropping every
+   * planted place silently. That is worse than the partial load SPEC-0009
+   * forbids: it is a total one, reported as success.
+   */
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  const failed = await page.evaluate(async (db) => {
+    await window.__store.plant(db, "places", null, {
+      id: "orphan",
+      kind: "base",
+      schemaVersion: 1,
+      updatedAt: "2026-08-28T00:00:00.000Z",
+      revision: 1,
+    });
+    return window.__store.load(db);
+  }, database);
+
+  expect(failed.kind, "places were dropped and the store reported success").toBe(
+    "failed",
+  );
+  if (failed.kind !== "failed") return;
+  expect(failed.code).toBe("MALFORMED_RECORD");
+});
+
+test("a malformed record is distinguishable from an unsupported version", async ({
+  page,
+}) => {
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  const failed = await page.evaluate(async (db) => {
+    await window.__store.putPlace(db, { id: "good", kind: "base" });
+    await window.__store.plant(db, "places", null, { id: "broken", kind: "base" });
+    return window.__store.load(db);
+  }, database);
+
+  expect(failed.kind).toBe("failed");
+  if (failed.kind !== "failed") return;
+  expect(failed.code).toBe("MALFORMED_RECORD");
+});
+
+/* ----------------------------------------------------------------------
+ * Size bound
+ * ------------------------------------------------------------------- */
+
+test("the bound is set from the recorded measurements, with headroom", () => {
+  /*
+   * SPEC-0009 § Request Body Size Limits requires the value be derived from
+   * measurement rather than guessed, and recorded with the sizes it came
+   * from. This asserts the relationship rather than the number, so changing
+   * the bound without revisiting the measurements fails here.
+   */
+  expect(MEASURED_PLACE_BYTES.heavy).toBeGreaterThan(
+    MEASURED_PLACE_BYTES.everyPartTicked,
+  );
+  expect(MEASURED_PLACE_BYTES.everyPartTicked).toBeGreaterThan(
+    MEASURED_PLACE_BYTES.typical,
+  );
+  expect(
+    MAX_PLACE_BYTES / MEASURED_PLACE_BYTES.heavy,
+    "the bound should leave an order of magnitude over the heaviest measured place",
+  ).toBeGreaterThan(10);
+});
+
+test("an oversized place is refused before it is written", async ({ page }) => {
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  const result = await page.evaluate(
+    async ([db, limit]) => {
+      const notes = "x".repeat(Number(limit) + 1000);
+      const refused = await window.__store.putPlace(db, {
+        id: "huge",
+        kind: "base",
+        notes,
+      });
+      const loaded = await window.__store.load(db);
+      return {
+        refused,
+        stored: loaded.kind === "ok" ? loaded.value.places.length : -1,
+      };
+    },
+    [database, String(MAX_PLACE_BYTES)] as const,
+  );
+
+  expect(result.refused.kind).toBe("failed");
+  if (result.refused.kind !== "failed") return;
+  expect(result.refused.code).toBe("PLACE_TOO_LARGE");
+  expect(result.stored, "the oversized place was written anyway").toBe(0);
+});
+
+test("a place at the heaviest measured size is comfortably accepted", async ({
+  page,
+}) => {
+  /*
+   * The companion. A bound that refused real data would pass the test above
+   * and make the store unusable.
+   */
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  const result = await page.evaluate(
+    async ([db, size]) => {
+      const notes = "x".repeat(Number(size));
+      return window.__store.putPlace(db, { id: "heavy", kind: "base", notes });
+    },
+    [database, String(MEASURED_PLACE_BYTES.heavy)] as const,
+  );
+
+  expect(result.kind).toBe("ok");
+});
+
+/* ----------------------------------------------------------------------
+ * Transactions and connection lifecycle
+ * ------------------------------------------------------------------- */
+
+test("a place and the workspace move together", async ({ page }) => {
+  const database = freshDatabase();
+  await openStore(page, database, "2026-08-28T07:00:00.000Z");
+
+  const after = await page.evaluate(async (db) => {
+    await window.__store.putPlace(db, { id: "p1", kind: "base" });
+    const loaded = await window.__store.load(db);
+    return loaded.kind === "ok"
+      ? {
+          places: loaded.value.places.length,
+          workspaceUpdatedAt: loaded.value.workspace.updatedAt,
+        }
+      : null;
+  }, database);
+
+  expect(after?.places).toBe(1);
+  expect(after?.workspaceUpdatedAt).toBe("2026-08-28T07:00:00.000Z");
+});
+
+test("a write that fails partway leaves the store as it was", async ({ page }) => {
+  /*
+   * A place with no id violates the object store's keyPath, which throws
+   * inside the transaction and aborts it. The assertion is that the
+   * workspace's timestamp did not move either — if the two were separate
+   * transactions, it would have.
+   */
+  const database = freshDatabase();
+  await openStore(page, database, "2026-08-28T07:00:00.000Z");
+
+  const state = await page.evaluate(async (db) => {
+    await window.__store.putPlace(db, { id: "p1", kind: "base" });
+    const before = await window.__store.load(db);
+
+    const broken = await window.__store.putPlace(db, { kind: "base" } as unknown as {
+      id: string;
+      kind: "base";
+    });
+
+    const after = await window.__store.load(db);
+    return {
+      broken,
+      beforeCount: before.kind === "ok" ? before.value.places.length : -1,
+      afterCount: after.kind === "ok" ? after.value.places.length : -1,
+      beforeStamp: before.kind === "ok" ? before.value.workspace.updatedAt : "",
+      afterStamp: after.kind === "ok" ? after.value.workspace.updatedAt : "",
+    };
+  }, database);
+
+  expect(state.broken.kind).toBe("failed");
+  expect(state.afterCount, "the failed write changed the place set").toBe(
+    state.beforeCount,
+  );
+  expect(state.afterStamp, "the failed write moved the workspace timestamp").toBe(
+    state.beforeStamp,
+  );
+});
+
+test("another tab's upgrade is not blocked by this connection", async ({ page }) => {
+  /*
+   * The failure SPEC-0009 names because its symptom points nowhere near its
+   * cause: an unhandled versionchange leaves the other tab's open pending
+   * forever, and the application presents as hanging on load rather than as
+   * a storage error.
+   */
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  const outcome = await page.evaluate((db) => window.__store.upgrade(db, 2), database);
+  expect(outcome, "the open connection blocked the upgrade").toBe("upgraded");
+});
+
+/* ----------------------------------------------------------------------
+ * Errors and deletion
+ * ------------------------------------------------------------------- */
+
+test("a quota failure reaches the caller as the quota sentinel", async ({ page }) => {
+  /*
+   * Tested through the pure classifier rather than by filling a disk.
+   * Provoking a real quota exhaustion is not a test anyone runs twice, and
+   * the question worth answering — does QuotaExceededError arrive as
+   * QUOTA_EXCEEDED rather than UNCLASSIFIED — is answerable here.
+   *
+   * The end-to-end path is asserted by the size bound above, which SPEC-0009
+   * requires precisely so a quota failure is not how a player finds out.
+   */
+  const codes = await page.evaluate(() =>
+    [
+      "QuotaExceededError",
+      "InvalidStateError",
+      "SecurityError",
+      "NotFoundError",
+      "TypeError",
+    ].map((name) => window.__store.classify(name)),
+  );
+
+  expect(codes).toEqual([
+    "QUOTA_EXCEEDED",
+    "STORAGE_UNAVAILABLE",
+    "STORAGE_UNAVAILABLE",
+    "RECORD_NOT_FOUND",
+    "UNCLASSIFIED",
+  ]);
+});
+
+test("operations on an unopened store fail rather than throwing", async ({ page }) => {
+  const failed = await page.evaluate(() => window.__store.load("never-opened"));
+  expect(failed.kind).toBe("failed");
+  if (failed.kind !== "failed") return;
+  expect(failed.code).toBe("STORAGE_UNAVAILABLE");
+});
+
+test("deletion removes everything and leaves the designed empty state", async ({
+  page,
+}) => {
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  const after = await page.evaluate(async (db) => {
+    await window.__store.putPlace(db, { id: "p1", kind: "base" });
+    await window.__store.putPlace(db, { id: "p2", kind: "freighter" });
+    await window.__store.putPreferences(db, { groupSeparator: "," });
+
+    const deleted = await window.__store.deleteAll(db);
+    const loaded = await window.__store.load(db);
+    return {
+      deleted,
+      loaded,
+      places: loaded.kind === "ok" ? loaded.value.places.length : -1,
+    };
+  }, database);
+
+  expect(after.deleted.kind).toBe("ok");
+  expect(after.loaded.kind, "deletion left the store in an error state").toBe("ok");
+  expect(after.places).toBe(0);
+});
+
+test("preferences round-trip without becoming place records", async ({ page }) => {
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  const result = await page.evaluate(async (db) => {
+    await window.__store.putPreferences(db, {
+      groupSeparator: ",",
+      showUnverified: true,
+    });
+    const loaded = await window.__store.load(db);
+    return loaded.kind === "ok"
+      ? {
+          preferences: loaded.value.workspace.preferences,
+          places: loaded.value.places.length,
+        }
+      : null;
+  }, database);
+
+  expect(result?.preferences).toEqual({ groupSeparator: ",", showUnverified: true });
+  expect(result?.places, "preferences created a place record").toBe(0);
+});


### PR DESCRIPTION
Closes #111
Part of #110

Implements SPEC-0009 REQ "A Workspace Owns Places", REQ "A Place Is One Record Type, Whatever Its Kind", REQ "Versioned, and Fails Legibly", REQ "Error Handling Standards", REQ "Storage Operation Standards".

SPEC-0009 stage 1: local IndexedDB, no account, no server, no network. **The first code in this project that legitimately holds durable state.**

`web/src/store/` — 20 new tests, all in a real browser because IndexedDB exists nowhere else and a fake would be a test of the fake.

## The rules that kept state out are not loosened

`ViewState` still has no field a graph could go in. `ResultCache` still holds one deep-frozen entry. Nothing here stores a plan, a resolved graph, or a derived quantity — and the message-text discipline check now scans `src/store` alongside `src/boundary`, so the store is held to the same rule by the same checker rather than a second copy of it.

IndexedDB rather than localStorage, and the distinction matters: the design README's prohibition names localStorage *specifically*, so satisfying its letter while overturning its spirit would have been the worse outcome. localStorage is synchronous on the thread the WASM module runs on, string-only, and capped near 5 MB.

## Three fields nothing reads, asserted rather than assumed

`ownerId`, `updatedAt`, `revision` — written from version 1, unset or trivially set. A test asserts each, because a reviewer who has not read ADR-0008 will reasonably ask why. Sign-in attaches an owner to a workspace that *already carries the field*; a field added in version 2 cannot do that for data written under version 1, and the player who ticked fifty items before signing up is who that migration is for.

## The size bound is measured, and recorded beside itself

64 KiB, from real measurement against the 108-entry parts catalog with natural-language notes rather than compressible filler:

| | ticks | stocked | tags | bytes |
|---|---:|---:|---:|---:|
| typical | 40 | 20 | 4 | 1,677 |
| every part ticked | 108 | 20 | 4 | 2,966 |
| heavy | 108 | 200 | 20 | 6,156 |

A test asserts the bound keeps **an order of magnitude** over the heaviest measured place, so changing the number without revisiting the measurements fails. There's a companion test that a place at the heavy size is comfortably accepted — a bound that refused real data would pass the refusal test and make the store unusable. Images are explicitly out of scope; ADR-0013 owns them, and this is a text bound a store holding blobs must revisit rather than inherit.

## Two failures named individually

**An oversized write is refused before it is attempted.** SPEC-0009 requires this because a quota failure is shared with everything else the origin stores, and discovering the limit that way is worse than being told.

**The `versionchange` handler closes this connection** so another tab's upgrade proceeds. Unhandled, that leaves the other tab's open pending forever and presents as the application hanging on load — a symptom pointing nowhere near its cause, which is exactly why the spec names it. Tested by opening a raw connection at a higher version and asserting it upgrades rather than blocking.

## The tests found a real bug on their first run

`load()` treated a missing workspace record as "a device that has never used the store" and returned an empty workspace — **silently dropping every place present**.

That is worse than the partial load SPEC-0009 forbids: it is a total one, reported as success. A missing workspace record with places present is now a malformed store, and the test that caught it is kept as its own case rather than folded away.

## And the linter surfaced a design smell worth fixing

`readPlace` returned `PlaceRecord | StoreFailure`. Both carry a `kind` field — a place's is its type, a failure's is the literal `"failed"` — so narrowing on it happened to work and read as though it were designed. Either type changing would have broken it silently. It returns a `StoreResult` now, which is what made the assertion the linter flagged unnecessary in the first place.

## What is honestly not tested

**Real quota exhaustion.** It is tested through the pure `classify()` function — `QuotaExceededError` → `QUOTA_EXCEEDED`, `InvalidStateError`/`SecurityError` → `STORAGE_UNAVAILABLE`, and an unrecognised name → `UNCLASSIFIED`. Filling a disk to observe the real condition is not a test anyone runs twice, and the question worth answering is whether the error reaches the caller as the right sentinel. The end-to-end path is covered by the size bound, which SPEC-0009 requires precisely so a quota failure is not how a player finds out.

## Note on #112

#111's acceptance criteria said "#96 makes it mechanical" about the message-text check. That was a wrong issue number in the planning — #96 is a SPEC-0007 card story. The mechanical check belongs to **#112** (store discipline), and since extending the existing checker to `src/store` was three lines, I did it here rather than leave the criterion unmet. #112 still owns the network and sync-flag checks, which are the substantial half.

## Verified locally

`npm run lint`, `lint:css`, `typecheck`, `format:check`, `check:tokens`, `npm run build`, `npm test` (162 passed, up from 142), `npm run test:mutation` (21/21 still red).

Pushed over HTTPS — the SSH agent is still refusing. No workflow files touched.
