### PR TITLE
test(web): store discipline — no network, nothing marked for sync

### DIFF
--- a/web/scripts/mutation-check.sh
+++ b/web/scripts/mutation-check.sh
@@ -34,8 +34,9 @@ TRAP="src/a11y/useFocusTrap.ts"
 LIVE="src/a11y/useLiveRegion.ts"
 SHELL="src/shell/AppShell.tsx"
 BADGE="src/shell/StatusBadge.tsx"
+STORE="src/store/durable-store.ts"
 
-MUTABLE="$BASE $TOKENS $TRAP $LIVE $SHELL $BADGE"
+MUTABLE="$BASE $TOKENS $TRAP $LIVE $SHELL $BADGE $STORE"
 
 # shellcheck disable=SC2086
 restore() { git checkout -- $MUTABLE 2>/dev/null || true; }
@@ -218,6 +219,54 @@ check "a control is named only by a glyph" \
   '        <button type="submit" className="control control-primary interactive">
           →
         </button>'
+
+# ----------------------------------------------------------------------
+# The durable store's two absences.
+#
+# SPEC-0009 REQ "Stage 1 Reaches No Network" and REQ "Nothing Is Marked for
+# Synchronization" are both claims that something never happens, and a suite
+# that only exercises the store cannot distinguish "no request was issued"
+# from "no test looked". These two are the ones issue #112 names.
+#
+# Both mutations are type errors the compiler would reject. That is not a
+# gap: vite strips types without checking them, so the mutated store runs,
+# and a rule that only `tsc` enforces is a rule that stops being enforced
+# the moment someone reaches for `as unknown as`.
+# ----------------------------------------------------------------------
+
+check "the store fetches something on write" \
+  tests/store/discipline.spec.ts "$STORE" \
+  '      const now = this.#now();
+      const transaction = db.transaction([WORKSPACE_STORE, PLACES_STORE], "readwrite");' \
+  '      const now = this.#now();
+      await fetch("/api/places", { method: "POST", body: place.id });
+      const transaction = db.transaction([WORKSPACE_STORE, PLACES_STORE], "readwrite");'
+
+# The one that earns the runtime layer its place. Both mutations above trip
+# the source scan *and* the runtime check, so neither shows the runtime check
+# is doing anything. This one is invisible to any regex — verified: with it
+# applied, "no store source reaches for a network primitive" passes and
+# "nothing goes out" fails. Delete the runtime check and this goes green.
+check "the store fetches through a name the source scan cannot see" \
+  tests/store/discipline.spec.ts "$STORE" \
+  '      const now = this.#now();
+      const transaction = db.transaction([WORKSPACE_STORE, PLACES_STORE], "readwrite");' \
+  '      const now = this.#now();
+      const send = (globalThis as Record<string, unknown>)["fet" + "ch"] as (
+        url: string,
+      ) => Promise<unknown>;
+      await send("/api/places");
+      const transaction = db.transaction([WORKSPACE_STORE, PLACES_STORE], "readwrite");'
+
+check "a written place is pre-marked as synced" \
+  tests/store/discipline.spec.ts "$STORE" \
+  "      const record: PlaceRecord = {
+        ...place,
+        schemaVersion: SCHEMA_VERSION," \
+  "      const record: PlaceRecord = {
+        ...place,
+        synced: false,
+        schemaVersion: SCHEMA_VERSION,"
 
 echo
 if [ "$failures" -gt 0 ]; then

--- a/web/tests/fixtures/store-discipline-harness.ts
+++ b/web/tests/fixtures/store-discipline-harness.ts
@@ -1,0 +1,229 @@
+/*
+ * Fixture for the store's two discipline requirements.
+ *
+ * Governing: SPEC-0009 REQ "Stage 1 Reaches No Network", REQ "Nothing Is
+ * Marked for Synchronization"
+ *
+ * Separate from `store-harness.ts` on purpose. This page has to wrap the
+ * network primitives *before* any store code runs, and a fixture that both
+ * instruments globals and serves the behavioural suite would leave every
+ * test in that suite running against patched globals for no reason.
+ *
+ * The records are read back with a raw IndexedDB connection rather than
+ * through `DurableStore.load`, because `load` returns typed records and the
+ * question here is what keys are actually on disk. A field the store's own
+ * reader drops is still a field that was written.
+ */
+
+import { DurableStore } from "../../src/store";
+import { attributedTo, type NetworkAttempt } from "../helpers/network-attribution";
+
+const STORE_PATH = "/src/store/";
+const HARNESS_PATH = "store-discipline-harness";
+
+const attempts: NetworkAttempt[] = [];
+
+function record(kind: string): void {
+  attempts.push({ kind, stack: new Error().stack ?? "" });
+}
+
+/*
+ * Wrap every way this page could reach the network.
+ *
+ * Installed at module scope so nothing runs ahead of it. Each wrapper
+ * records and then delegates: a recorder that swallowed the call would make
+ * the unrelated-traffic test pass for the wrong reason, since the request it
+ * is supposed to observe would never happen.
+ */
+const realFetch = window.fetch.bind(window);
+window.fetch = (...args: Parameters<typeof fetch>) => {
+  record("fetch");
+  return realFetch(...args);
+};
+
+/*
+ * Capturing `open` off the prototype is the whole point — it is re-invoked
+ * below with `.call(this, ...)`, which is the correct receiver and the one
+ * the rule cannot see. Rebinding it would break every XHR on the page.
+ */
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const realOpen = XMLHttpRequest.prototype.open;
+/*
+ * Spelled out rather than spread, because `open` is overloaded: the
+ * two-argument form and the five-argument form are separate signatures, and
+ * a rest parameter satisfies neither.
+ */
+XMLHttpRequest.prototype.open = function open(
+  this: XMLHttpRequest,
+  method: string,
+  url: string | URL,
+  async?: boolean,
+  username?: string | null,
+  password?: string | null,
+): void {
+  record("xhr");
+  /*
+   * `async` defaults to true in the two-argument form, so passing it
+   * through explicitly preserves the semantics. `.call` on an overloaded
+   * function resolves to the last overload, which is the five-argument one.
+   */
+  realOpen.call(this, method, url, async ?? true, username, password);
+};
+
+if (typeof navigator.sendBeacon === "function") {
+  const realBeacon = navigator.sendBeacon.bind(navigator);
+  navigator.sendBeacon = ((...args: Parameters<typeof realBeacon>) => {
+    record("beacon");
+    return realBeacon(...args);
+  }) as typeof navigator.sendBeacon;
+}
+
+/*
+ * Constructors go through a Proxy rather than a subclass: `super()` has to
+ * be the first statement in a derived constructor, so a subclass could only
+ * record *after* the socket had already been opened.
+ */
+window.WebSocket = new Proxy(window.WebSocket, {
+  construct: (target, args: ConstructorParameters<typeof WebSocket>) => {
+    record("websocket");
+    return Reflect.construct(target, args);
+  },
+});
+
+window.EventSource = new Proxy(window.EventSource, {
+  construct: (target, args: ConstructorParameters<typeof EventSource>) => {
+    record("eventsource");
+    return Reflect.construct(target, args);
+  },
+});
+
+function readRaw(database: string, store: string): Promise<unknown[]> {
+  return new Promise((resolve, reject) => {
+    const opening = indexedDB.open(database);
+    opening.onsuccess = () => {
+      const db = opening.result;
+      if (!db.objectStoreNames.contains(store)) {
+        db.close();
+        resolve([]);
+        return;
+      }
+      const transaction = db.transaction(store, "readonly");
+      const all = transaction.objectStore(store).getAll();
+      all.onsuccess = () => {
+        db.close();
+        resolve(all.result);
+      };
+      all.onerror = () => {
+        db.close();
+        reject(all.error ?? new Error("raw read failed"));
+      };
+    };
+    opening.onerror = () => {
+      reject(opening.error ?? new Error("raw open failed"));
+    };
+  });
+}
+
+declare global {
+  interface Window {
+    __discipline: {
+      /** Drive every store call path: open, load, write, prefer, reload, delete. */
+      exercise: (database: string) => Promise<string[]>;
+      /** Write a place and preferences and leave them there, for the raw reads. */
+      seed: (database: string) => Promise<string[]>;
+      /** A request from code that is not the store, as any real page has. */
+      unrelated: () => Promise<void>;
+      /** Every attempt seen, tagged with where it came from. */
+      attempts: () => { kind: string; fromStore: boolean; fromHarness: boolean }[];
+      reset: () => void;
+      /** Records as they sit on disk, not as the store's reader returns them. */
+      raw: (database: string, store: string) => Promise<unknown[]>;
+    };
+  }
+}
+
+window.__discipline = {
+  exercise: async (database) => {
+    const store = new DurableStore({ databaseName: database });
+    const outcomes: string[] = [];
+    const note = (label: string, result: { kind: string }) => {
+      outcomes.push(`${label}:${result.kind}`);
+    };
+
+    note("open", await store.open());
+    note("load", await store.load());
+    note(
+      "putPlace",
+      await store.putPlace({
+        id: "place-1",
+        kind: "base",
+        name: "Aurora Flats",
+        notes: "Landing pad on the north ridge, near the copper.",
+        tags: ["copper", "temperate"],
+        ticks: { "part-1": true },
+        stocked: { "item-1": "120" },
+      }),
+    );
+    note("putPreferences", await store.putPreferences({ groupSeparator: true }));
+    note("reload", await store.load());
+    note("deleteAll", await store.deleteAll());
+    store.close();
+    return outcomes;
+  },
+
+  seed: async (database) => {
+    /*
+     * `exercise` deletes everything at the end, which is the right shape
+     * for the network tests and the wrong one for the record tests. This
+     * writes and leaves it written, so the raw reads have something to
+     * look at.
+     */
+    const store = new DurableStore({ databaseName: database });
+    const outcomes: string[] = [];
+    const note = (label: string, result: { kind: string }) => {
+      outcomes.push(`${label}:${result.kind}`);
+    };
+
+    note("open", await store.open());
+    note(
+      "putPlace",
+      await store.putPlace({
+        id: "kept",
+        kind: "settlement",
+        name: "Kept",
+        stocked: { "item-1": "7/2" },
+      }),
+    );
+    note("putPreferences", await store.putPreferences({ showUnverified: false }));
+    store.close();
+    return outcomes;
+  },
+
+  unrelated: async () => {
+    /*
+     * Deliberately a real request from a path that is not the store. It is
+     * allowed to fail — a 404 still travels, and travelling is the whole
+     * point. What must not happen is it being attributed to the store.
+     */
+    try {
+      await fetch("/favicon.ico?unrelated=1");
+    } catch {
+      /* offline, blocked, whatever — it was still attempted, and recorded */
+    }
+  },
+
+  attempts: () =>
+    attempts.map((attempt) => ({
+      kind: attempt.kind,
+      fromStore: attributedTo(attempt.stack, STORE_PATH),
+      fromHarness: attributedTo(attempt.stack, HARNESS_PATH),
+    })),
+
+  reset: () => {
+    attempts.length = 0;
+  },
+
+  raw: readRaw,
+};
+
+document.body.dataset["ready"] = "true";

--- a/web/tests/fixtures/store-discipline.html
+++ b/web/tests/fixtures/store-discipline.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Store discipline fixture</title>
+  </head>
+  <body>
+    <!--
+      Governing: SPEC-0009 REQ "Stage 1 Reaches No Network", REQ "Nothing Is
+      Marked for Synchronization"
+
+      Its own page rather than a reuse of store.html, because the harness
+      here patches fetch, XMLHttpRequest, sendBeacon, WebSocket and
+      EventSource at module scope. Every other store test should run against
+      the real ones.
+    -->
+    <script type="module" src="./store-discipline-harness.ts"></script>
+  </body>
+</html>

--- a/web/tests/helpers/network-attribution.ts
+++ b/web/tests/helpers/network-attribution.ts
@@ -1,0 +1,56 @@
+/*
+ * Attributing a network attempt to the code that made it.
+ *
+ * Governing: SPEC-0009 REQ "Stage 1 Reaches No Network"
+ *
+ * The requirement's second scenario is the awkward one: "WHEN the
+ * application also contains code that makes network requests for unrelated
+ * reasons THEN the assertion still holds". A recorder that counts every
+ * request the page makes cannot satisfy that — it goes red the day anything
+ * else on the page fetches something, and the fix would be to loosen it
+ * until it stopped complaining.
+ *
+ * So each recorded attempt carries the stack it was made from, and the
+ * question asked of it is "did this come from a store path", not "did this
+ * happen". That is the difference the acceptance criterion is drawing when
+ * it says the check must assert on "this capability's own call paths rather
+ * than on the absence of network code in the application bundle".
+ *
+ * A limit worth stating plainly: a synchronous frame is always visible, but
+ * a continuation resumed after `await` depends on the engine's async stack
+ * tagging, which is present in Chromium and is not guaranteed everywhere.
+ * The suite does not rest on this alone — `tests/store/discipline.spec.ts`
+ * also asserts that a quiet page running only store operations records no
+ * attempt of any kind, which needs no stack at all. Attribution is what
+ * lets that assertion survive the arrival of stage 2's network code
+ * instead of being weakened to accommodate it.
+ */
+
+export interface NetworkAttempt {
+  /** Which primitive was reached for: fetch, xhr, beacon, websocket, eventsource. */
+  readonly kind: string;
+  /** The stack captured at the call, header line included. */
+  readonly stack: string;
+}
+
+/**
+ * Does any frame of this stack sit inside `fragment`?
+ *
+ * The header line is dropped before matching. `new Error().stack` opens
+ * with "Error" and, were a message ever added, matching it would attribute
+ * a request to whatever the message happened to mention.
+ */
+export function attributedTo(stack: string, fragment: string): boolean {
+  return stack
+    .split("\n")
+    .slice(1)
+    .some((frame) => frame.includes(fragment));
+}
+
+/** Attempts whose stack reaches into `fragment`. */
+export function attemptsFrom(
+  attempts: readonly NetworkAttempt[],
+  fragment: string,
+): NetworkAttempt[] {
+  return attempts.filter((attempt) => attributedTo(attempt.stack, fragment));
+}

--- a/web/tests/helpers/source-checks.ts
+++ b/web/tests/helpers/source-checks.ts
@@ -93,3 +93,53 @@ const NAVIGATION =
 export function navigations(file: string, source: string): Finding[] {
   return scan(file, source, NAVIGATION);
 }
+
+/*
+ * Issuing a network request.
+ *
+ * SPEC-0009 REQ "Stage 1 Reaches No Network": nothing in the durable store
+ * "MUST issue a network request", and the absence "MUST be checkable
+ * mechanically rather than by review".
+ *
+ * This is the source half. It is deliberately the weaker of the two checks
+ * and exists because it is the one that names the offending line: a source
+ * scan says `durable-store.ts:212 fetch(...)`, where the runtime check can
+ * only say that something under `src/store` reached the network.
+ *
+ * The runtime half in `tests/store/discipline.spec.ts` is what actually
+ * carries the requirement, because a request can be issued through a
+ * reference this pattern cannot see — `const f = globalThis["fet" + "ch"]`
+ * defeats every regex ever written. Neither check is sufficient alone.
+ *
+ * `new Request(...)` and `new Response(...)` are not matched: constructing
+ * either issues nothing, and a checker that fired on them would be reported
+ * as a false positive and switched off within a week.
+ */
+const NETWORK_CALL =
+  /\bfetch\s*\(|\bXMLHttpRequest\b|\bWebSocket\b|\bEventSource\b|\bsendBeacon\s*\(|\bimportScripts\s*\(|\baxios\s*\./;
+
+export function networkCalls(file: string, source: string): Finding[] {
+  return scan(file, source, NETWORK_CALL);
+}
+
+/*
+ * Marking a record as shared, synced, or queued for upload.
+ *
+ * SPEC-0009 REQ "Nothing Is Marked for Synchronization". This is a source
+ * scan over key names and, like the one above, it is the weaker half — the
+ * requirement is about what ends up *written*, and a field set through a
+ * computed key would not appear here. `tests/store/discipline.spec.ts`
+ * asserts on records read back out of IndexedDB for that reason.
+ *
+ * `updatedAt` and `revision` are NOT matched, and that is the point of the
+ * requirement rather than an oversight in the pattern. ADR-0012 reserves
+ * both, SPEC-0009 requires they be "present and unset rather than absent",
+ * and a checker that treated a reserved-and-empty field as a marked one
+ * would be arguing with the schema.
+ */
+const SYNC_MARKER =
+  /\b(?:isShared|shared|isSynced|synced|syncState|syncedAt|pendingUpload|pendingSync|needsUpload|needsSync|uploadedAt|remoteId|publishedAt)\s*[:=]/;
+
+export function syncMarkers(file: string, source: string): Finding[] {
+  return scan(file, source, SYNC_MARKER);
+}

--- a/web/tests/store/discipline.spec.ts
+++ b/web/tests/store/discipline.spec.ts
@@ -1,0 +1,281 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { expect, test, type Page } from "@playwright/test";
+
+import { networkCalls, syncMarkers } from "../helpers/source-checks";
+
+/*
+ * Governing: ADR-0008 (durable user data, local-first), SPEC-0009 REQ
+ * "Stage 1 Reaches No Network", REQ "Nothing Is Marked for Synchronization"
+ *
+ * Two requirements that are both absences.
+ *
+ * `tests/boundary/discipline.spec.ts` established why that needs its own
+ * treatment: exercising a path shows that the paths someone thought of
+ * behave, and the failure mode is always the path nobody thought of. The
+ * same argument, with a second layer — these absences are also checked at
+ * runtime, because a request can be issued through a reference no regex can
+ * see, and a field can be written under a computed key no source scan reads.
+ *
+ * The network requirement is checked three ways, and the ordering matters:
+ *
+ *   1. A quiet page runs every store call path and records no attempt of
+ *      any kind. This is the assertion with teeth and it needs no stack.
+ *   2. A page with unrelated traffic records that traffic and still
+ *      attributes nothing to a store path — the requirement's second
+ *      scenario, and the reason the check is phrased against call paths
+ *      rather than against the bundle.
+ *   3. The source scan, which names the offending line when 1 goes red.
+ */
+
+const FIXTURE = "/tests/fixtures/store-discipline.html";
+const STORE = path.join(import.meta.dirname, "..", "..", "src", "store");
+
+let counter = 0;
+function freshDatabase(): string {
+  counter += 1;
+  return `discipline-${String(counter)}-${String(Math.floor(performance.now()))}`;
+}
+
+/** The one record written, or a failure naming the fact that none was. */
+function only(
+  records: Record<string, unknown>[],
+  label: string,
+): Record<string, unknown> {
+  const [record] = records;
+  if (!record) throw new Error(`no ${label} was written, so nothing was checked`);
+  return record;
+}
+
+function sourcesIn(directory: string): { file: string; source: string }[] {
+  return readdirSync(directory)
+    .filter((name) => name.endsWith(".ts"))
+    .map((name) => ({
+      file: name,
+      source: readFileSync(path.join(directory, name), "utf8"),
+    }));
+}
+
+async function exercise(page: Page, database: string): Promise<string[]> {
+  const outcomes = await page.evaluate(
+    (db) => window.__discipline.exercise(db),
+    database,
+  );
+  /*
+   * Every operation has to have succeeded. A store that failed to open
+   * issues no requests either, and would satisfy the network assertion
+   * while proving nothing at all.
+   */
+  for (const outcome of outcomes) {
+    expect(outcome, `a store operation failed: ${outcome}`).toMatch(/:ok$/);
+  }
+  return outcomes;
+}
+
+/* ----------------------------------------------------------------------
+ * The source half
+ * ------------------------------------------------------------------- */
+
+test("the store sources exist and were actually read", () => {
+  /*
+   * Every scan below is satisfied by an empty directory. This is what
+   * separates "nothing is wrong" from "nothing was looked at".
+   */
+  expect(sourcesIn(STORE).length).toBeGreaterThanOrEqual(5);
+});
+
+test("no store source reaches for a network primitive", () => {
+  for (const { file, source } of sourcesIn(STORE)) {
+    expect(networkCalls(file, source), `store/${file} issues a request`).toEqual([]);
+  }
+});
+
+test("no store source marks a record for synchronization", () => {
+  for (const { file, source } of sourcesIn(STORE)) {
+    expect(syncMarkers(file, source), `store/${file} marks a record`).toEqual([]);
+  }
+});
+
+test("the checks reject source broken on purpose", () => {
+  /*
+   * A checker that has quietly stopped matching passes every assertion
+   * above forever. These are the snippets it exists to catch.
+   */
+  expect(networkCalls("x.ts", `const r = await fetch("/api/places");`)).toHaveLength(1);
+  expect(networkCalls("x.ts", `const x = new XMLHttpRequest();`)).toHaveLength(1);
+  expect(networkCalls("x.ts", `const s = new WebSocket("wss://sync");`)).toHaveLength(1);
+  expect(networkCalls("x.ts", `const e = new EventSource("/stream");`)).toHaveLength(1);
+  expect(networkCalls("x.ts", `navigator.sendBeacon("/telemetry", body);`)).toHaveLength(
+    1,
+  );
+  expect(networkCalls("x.ts", `await axios.post("/places", record);`)).toHaveLength(1);
+
+  expect(syncMarkers("x.ts", `const record = { ...place, synced: true };`)).toHaveLength(
+    1,
+  );
+  expect(syncMarkers("x.ts", `record.pendingUpload = true;`)).toHaveLength(1);
+  expect(syncMarkers("x.ts", `return { ...place, isShared: false };`)).toHaveLength(1);
+  expect(syncMarkers("x.ts", `const next = { syncState: "dirty" };`)).toHaveLength(1);
+});
+
+test("the checks do not fire on legitimate code", () => {
+  /*
+   * The companion. A checker that matched everything would satisfy every
+   * assertion above and make the suite useless.
+   */
+  expect(networkCalls("x.ts", `const cached = prefetched.get(key);`)).toEqual([]);
+  expect(networkCalls("x.ts", `const body = new Request(url);`)).toEqual([]);
+  expect(networkCalls("x.ts", `const socket = pipe.connect(target);`)).toEqual([]);
+
+  /*
+   * The reserved fields. ADR-0012 has `updatedAt` and `revision` written
+   * from version 1 and read by nothing, and SPEC-0009 requires they be
+   * "present and unset rather than absent" — a checker that read a
+   * reserved-and-empty field as a marked one would be arguing with the
+   * schema rather than enforcing it.
+   */
+  expect(
+    syncMarkers("x.ts", `const record = { ...place, updatedAt: now, revision };`),
+  ).toEqual([]);
+  expect(
+    syncMarkers("x.ts", `return { schemaVersion, ownerId: null, updatedAt };`),
+  ).toEqual([]);
+});
+
+/* ----------------------------------------------------------------------
+ * The runtime half
+ * ------------------------------------------------------------------- */
+
+test.describe("in a real browser", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(FIXTURE, { waitUntil: "load" });
+    await expect(page.locator("body")).toHaveAttribute("data-ready", "true");
+    await page.evaluate(() => {
+      window.__discipline.reset();
+    });
+  });
+
+  test("every store call path runs and nothing goes out", async ({ page }) => {
+    const outcomes = await exercise(page, freshDatabase());
+
+    /*
+     * Named rather than counted, so a refactor that silently stops
+     * exercising a path fails here instead of narrowing the test.
+     */
+    expect(outcomes.map((entry) => entry.split(":")[0])).toEqual([
+      "open",
+      "load",
+      "putPlace",
+      "putPreferences",
+      "reload",
+      "deleteAll",
+    ]);
+
+    const attempts = await page.evaluate(() => window.__discipline.attempts());
+    expect(attempts, "the store reached the network").toEqual([]);
+  });
+
+  test("the recorder is live, and unrelated traffic is not the store's", async ({
+    page,
+  }) => {
+    /*
+     * The requirement's second scenario, and the reason the assertion is
+     * phrased against call paths. Once ADR-0008 stage 2 ships, the page
+     * will contain network code by design; a check that counted every
+     * request would have to be weakened then, and would go on reporting a
+     * guarantee it had stopped making.
+     */
+    await page.evaluate(() => window.__discipline.unrelated());
+
+    const afterUnrelated = await page.evaluate(() => window.__discipline.attempts());
+    expect(
+      afterUnrelated.length,
+      "the recorder saw nothing, so it is not wired to anything",
+    ).toBeGreaterThan(0);
+    expect(
+      afterUnrelated.some((attempt) => attempt.fromHarness),
+      "no attempt was attributed to the code that made it",
+    ).toBe(true);
+
+    await exercise(page, freshDatabase());
+
+    const attempts = await page.evaluate(() => window.__discipline.attempts());
+    expect(attempts.filter((attempt) => attempt.fromStore)).toEqual([]);
+    expect(
+      attempts.length,
+      "the unrelated request went missing, so the window is wrong",
+    ).toBeGreaterThan(0);
+  });
+
+  test("no written record is marked shared, synced, or pending upload", async ({
+    page,
+  }) => {
+    /*
+     * Read raw, past the store's own reader. The criterion is about what
+     * ends up written: a field set by a code path the source scan did not
+     * read is still a field that was set, and a field the store's reader
+     * drops on the way out is still on disk.
+     */
+    const database = freshDatabase();
+    const seeded = await page.evaluate((db) => window.__discipline.seed(db), database);
+    for (const outcome of seeded) {
+      expect(outcome, `seeding failed: ${outcome}`).toMatch(/:ok$/);
+    }
+
+    const places = (await page.evaluate(
+      (db) => window.__discipline.raw(db, "places"),
+      database,
+    )) as Record<string, unknown>[];
+    const workspaces = (await page.evaluate(
+      (db) => window.__discipline.raw(db, "workspace"),
+      database,
+    )) as Record<string, unknown>[];
+
+    expect(places.length, "nothing was written, so nothing was checked").toBe(1);
+    expect(workspaces.length).toBe(1);
+
+    const FORBIDDEN =
+      /^(?:isShared|shared|isSynced|synced|syncState|syncedAt|pendingUpload|pendingSync|needsUpload|needsSync|uploadedAt|remoteId|publishedAt)$/;
+    for (const record of [...places, ...workspaces]) {
+      const marked = Object.keys(record).filter((key) => FORBIDDEN.test(key));
+      expect(marked, `a written record carries ${marked.join(", ")}`).toEqual([]);
+    }
+  });
+
+  test("the fields reserved for later stages are present and unset", async ({ page }) => {
+    /*
+     * SPEC-0009: "Where the schema carries fields serving stages 2 and 3
+     * they MUST be present and unset rather than absent." Absent would make
+     * sign-in a migration over records written before the field existed —
+     * which is the case ADR-0008 settled ownership early to avoid.
+     */
+    const database = freshDatabase();
+    const seeded = await page.evaluate((db) => window.__discipline.seed(db), database);
+    for (const outcome of seeded) {
+      expect(outcome, `seeding failed: ${outcome}`).toMatch(/:ok$/);
+    }
+
+    const place = only(
+      (await page.evaluate(
+        (db) => window.__discipline.raw(db, "places"),
+        database,
+      )) as Record<string, unknown>[],
+      "place",
+    );
+    const workspace = only(
+      (await page.evaluate(
+        (db) => window.__discipline.raw(db, "workspace"),
+        database,
+      )) as Record<string, unknown>[],
+      "workspace",
+    );
+
+    expect(Object.hasOwn(workspace, "ownerId"), "ownerId is absent").toBe(true);
+    expect(workspace["ownerId"], "ownerId is set in stage 1").toBeNull();
+
+    expect(Object.hasOwn(place, "updatedAt")).toBe(true);
+    expect(Object.hasOwn(place, "revision")).toBe(true);
+    expect(place["revision"]).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #112
Part of #110

Implements SPEC-0009 REQ "Stage 1 Reaches No Network", REQ "Nothing Is Marked for Synchronization".

## Two absences, two layers

Both requirements are claims that something never happens, and exercising a path only shows that the paths someone thought of behave. So each is checked twice, and the layering is the point rather than belt-and-braces.

**The source scan** (`networkCalls`, `syncMarkers` in `tests/helpers/source-checks.ts`) is the weaker half. It exists because it names the offending line.

**The runtime check** (`tests/store/discipline.spec.ts`) is what carries the requirement. A request can be issued through a reference no regex can see; a field can be written under a computed key no source scan reads.

## Why the network check is phrased against call paths

The acceptance criterion is explicit that a check phrased against the bundle would have to be weakened once ADR-0008 stage 2 ships network code by design — and would then go on reporting a guarantee it had stopped making.

So each recorded attempt carries the stack it was made from, and the question asked is *did this come from a store path*, not *did this happen*. Three tests:

1. A quiet page runs every store call path and records **no attempt of any kind**. This one needs no stack and is where the teeth are.
2. A page with unrelated traffic records that traffic and still attributes nothing to a store path — the requirement's second scenario.
3. The source scan.

A limit stated in the code rather than papered over: a continuation resumed after `await` depends on the engine's async stack tagging. Test 1 is why the suite does not rest on attribution alone.

## The sync check reads disk, not source

Records are read back through a raw IndexedDB connection rather than `DurableStore.load`, because the criterion is about what ends up written. A field the store's own reader drops on the way out is still a field on disk.

`updatedAt` and `revision` are deliberately **not** treated as sync markers. ADR-0012 reserves both and SPEC-0009 requires they be "present and unset rather than absent"; a checker that read a reserved-and-empty field as a marked one would be arguing with the schema. A separate test asserts `ownerId` is present and null.

## Mutations

`scripts/mutation-check.sh` goes 21 → 24, all verified red:

| Mutation | Catches |
|---|---|
| the store fetches something on write | source scan + runtime |
| **the store fetches through a name the source scan cannot see** | runtime only |
| a written place is pre-marked as synced | source scan + runtime |

The middle one earns the runtime layer its place. Verified by hand before adding it: with `["fet" + "ch"]` applied, *"no store source reaches for a network primitive"* **passes** and *"nothing goes out"* **fails**. Delete the runtime check and that mutation goes green.

Both store mutations are type errors `tsc` would reject. That is not a gap — vite strips types without checking them, so the mutated store runs, and a rule only the compiler enforces stops being enforced the moment someone reaches for `as unknown as`.

## Gates

lint, lint:css, typecheck, format:check, check:tokens, build all clean. **171 tests pass** (up from 162). **24/24 mutations red.**

No protected paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)