### PR TITLE
feat(web): preferences persist, and an empty store is a designed state

### DIFF
--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -12,7 +12,11 @@ import { Popover } from "../a11y/Popover";
 import { ViewStateProvider } from "../state/ViewStateProvider";
 import { useViewDispatch, useViewState } from "../state/useViewState";
 import { usePlanResolution, type Resolution } from "../state/usePlanResolution";
+import { useStoredData } from "../state/useStoredData";
+import { DurableStore } from "../store";
 import { StatusBadge } from "./StatusBadge";
+import { StoredPlaces } from "./StoredPlaces";
+import { ViewPreferences } from "./ViewPreferences";
 
 /*
  * The shell every surface mounts into.
@@ -190,9 +194,16 @@ function Figures({ resolution }: { resolution: Resolution }): ReactNode {
   );
 }
 
-function Chrome({ client }: { client: BoundaryClient }): ReactNode {
+function Chrome({
+  client,
+  store,
+}: {
+  readonly client: BoundaryClient;
+  readonly store: DurableStore;
+}): ReactNode {
   const state = useViewState();
   const { resolution, resultToken, recompute } = usePlanResolution(client, state);
+  const stored = useStoredData(store);
 
   /*
    * The announcement is keyed to the result token, which changes exactly when
@@ -232,6 +243,26 @@ function Chrome({ client }: { client: BoundaryClient }): ReactNode {
         <section className="panel" aria-label="Figures">
           <Figures resolution={resolution} />
         </section>
+
+        <section className="panel" aria-label="Saved places">
+          <StoredPlaces data={stored} target={state.inputs.target} />
+        </section>
+
+        {/*
+          `data-saving` reports whether a preference write is still in
+          flight. It carries no user-facing claim — SPEC-0009 REQ "Storage
+          Is Evictable" governs what may be *said* about stored data, and
+          that indication is #114's to build. This is the hook for it, and
+          in the meantime it is what lets a test wait for a write to settle
+          rather than sleeping and hoping.
+        */}
+        <section
+          className="panel"
+          aria-label="Preferences"
+          data-saving={String(stored.saving)}
+        >
+          <ViewPreferences />
+        </section>
       </main>
 
       <footer className="shell-footer">
@@ -243,11 +274,26 @@ function Chrome({ client }: { client: BoundaryClient }): ReactNode {
   );
 }
 
-export function AppShell({ client }: { client: BoundaryClient }): ReactNode {
+/**
+ * `store` is injectable so a test can use its own database.
+ *
+ * Constructed at module scope rather than defaulted in the parameter list,
+ * which would build a new store on every render and reopen the connection
+ * each time.
+ */
+const APP_STORE = new DurableStore();
+
+export function AppShell({
+  client,
+  store = APP_STORE,
+}: {
+  readonly client: BoundaryClient;
+  readonly store?: DurableStore;
+}): ReactNode {
   return (
     <ViewStateProvider>
       <LiveRegionProvider>
-        <Chrome client={client} />
+        <Chrome client={client} store={store} />
       </LiveRegionProvider>
     </ViewStateProvider>
   );

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -252,9 +252,15 @@ function Chrome({
           `data-saving` reports whether a preference write is still in
           flight. It carries no user-facing claim — SPEC-0009 REQ "Storage
           Is Evictable" governs what may be *said* about stored data, and
-          that indication is #114's to build. This is the hook for it, and
-          in the meantime it is what lets a test wait for a write to settle
-          rather than sleeping and hoping.
+          that indication belongs to the data-custody story rather than
+          here.
+
+          Issue numbers are spelled without the leading hash in this file.
+          check-tokens.sh matches a hash followed by three to eight hex
+          digits, and plenty of issue numbers are exactly that — so the
+          reference reads as a colour literal and fails the gate. Caught in
+          CI after passing locally, and then again by the comment written to
+          explain it, which had quoted the offending form.
         */}
         <section
           className="panel"

--- a/web/src/shell/StoredPlaces.tsx
+++ b/web/src/shell/StoredPlaces.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from "react";
+
+import { StatusBadge } from "./StatusBadge";
+import { ABSENT_DISPLAY, ABSENT_LABEL, storedQuantity } from "../store/absence";
+import type { StoredData } from "../state/useStoredData";
+
+/*
+ * Governing: ADR-0008 (durable user data), SPEC-0009 REQ "An Empty Store Is
+ * a Designed State"
+ *
+ * The first surface to read the store, and the one that establishes what
+ * later ones inherit. Three states that are genuinely different and are not
+ * collapsed into two:
+ *
+ *   loading      — the read has not finished. Not empty.
+ *   ready+empty  — the read finished and there was nothing. Not a failure.
+ *   unavailable  — IndexedDB is blocked. A failure, and said so.
+ *
+ * Collapsing loading into empty is the flash of "nothing saved" at a player
+ * who has data, which reads as loss rather than latency. Collapsing empty
+ * into unavailable is the one SPEC-0009 names directly: a fresh device, a
+ * private window and cleared storage all produce empty, and all of them are
+ * ordinary.
+ *
+ * The quantity column is the other half. A place with nothing stocked for
+ * the target shows an em dash, never `0` — see src/store/absence.ts for why
+ * `?? 0` is the defect this contract exists to prevent.
+ */
+export function StoredPlaces({
+  data,
+  target,
+}: {
+  readonly data: StoredData;
+  readonly target: string;
+}): ReactNode {
+  if (data.status === "loading") {
+    return <StatusBadge status="pending" detail="reading saved places" />;
+  }
+
+  if (data.status === "unavailable") {
+    return (
+      <StatusBadge
+        status="warning"
+        detail="this browser is not storing data for this site"
+      />
+    );
+  }
+
+  if (data.empty) {
+    return (
+      <p className="label">
+        Nothing saved on this device yet. Places you save will be listed here.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="figure-list">
+      {data.places.map((place) => {
+        const stocked = target === "" ? null : storedQuantity(place, target);
+        return (
+          <li key={place.id}>
+            <span>{place.name ?? "Unnamed place"}</span>{" "}
+            {stocked !== null &&
+              (stocked.present ? (
+                <span className="numeral">{stocked.value}</span>
+              ) : (
+                /*
+                 * The dash is for sighted readers; the label is what a
+                 * screen reader says. "—" announces as nothing in most of
+                 * them, and a row that reads as a name followed by silence
+                 * is indistinguishable from a broken one.
+                 */
+                <span className="numeral" aria-label={ABSENT_LABEL}>
+                  {ABSENT_DISPLAY}
+                </span>
+              ))}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/web/src/shell/ViewPreferences.tsx
+++ b/web/src/shell/ViewPreferences.tsx
@@ -1,0 +1,75 @@
+import { useId, type ReactNode } from "react";
+
+import { useViewDispatch, useViewState } from "../state/useViewState";
+
+/*
+ * Governing: SPEC-0005 REQ "View State Boundaries", SPEC-0009 REQ "View
+ * Preferences Survive a Reload"
+ *
+ * The controls existed nowhere before this. `ViewState.preferences` held two
+ * values that only the initial state ever set, which made "a preference that
+ * forgets itself" academic — nothing could change one in the first place.
+ *
+ * "Show unverified" rather than "Show unverified figures", which is what it
+ * first said: the shell's figures region is named "Figures", and Playwright's
+ * getByLabel matches on substring, so the longer label made an existing
+ * locator ambiguous. Two controls whose accessible names contain the same
+ * word is a real ambiguity for anyone navigating by label, not only for the
+ * test that caught it.
+ *
+ * These dispatch into view state and nothing else. Persisting them is
+ * `useStoredData`'s job, one layer out, and deliberately not wired through
+ * here: a control that wrote to the store directly would be a second source
+ * of truth for a value the view already owns.
+ */
+export function ViewPreferences(): ReactNode {
+  const { preferences } = useViewState();
+  const dispatch = useViewDispatch();
+  const groupId = useId();
+  const unverifiedId = useId();
+
+  return (
+    <fieldset className="preferences">
+      <legend className="label">Display</legend>
+
+      <div className="control-row-sm">
+        <input
+          id={groupId}
+          type="checkbox"
+          className="control control-sm interactive"
+          checked={preferences.groupSeparator !== ""}
+          onChange={(event) => {
+            dispatch({
+              type: "setPreference",
+              field: "groupSeparator",
+              /*
+               * The separator is the stored value, not a boolean. "" is a
+               * real setting — digits ungrouped — and is why the preference
+               * is a string rather than a flag.
+               */
+              value: event.target.checked ? "," : "",
+            });
+          }}
+        />
+        <label htmlFor={groupId}>Group digits</label>
+      </div>
+
+      <div className="control-row-sm">
+        <input
+          id={unverifiedId}
+          type="checkbox"
+          className="control control-sm interactive"
+          checked={preferences.showUnverified}
+          onChange={(event) => {
+            dispatch({
+              type: "setPreference",
+              field: "showUnverified",
+              value: event.target.checked,
+            });
+          }}
+        />
+        <label htmlFor={unverifiedId}>Show unverified</label>
+      </div>
+    </fieldset>
+  );
+}

--- a/web/src/state/preferences.ts
+++ b/web/src/state/preferences.ts
@@ -1,0 +1,62 @@
+/*
+ * Moving preferences between view state and the store, without coercing.
+ *
+ * Governing: SPEC-0005 REQ "View State Boundaries", SPEC-0009 REQ "View
+ * Preferences Survive a Reload"
+ *
+ * `ViewState.preferences` is a typed pair; the store holds
+ * `Record<string, string | boolean>`, because the workspace record has to
+ * outlive whatever the view's preference set happens to be this month.
+ * Something has to cross between them, and the crossing is where a stored
+ * value gets to be the wrong type.
+ *
+ * So the decode is strict and never coerces. A stored `"false"` — the
+ * string, which is what a JSON round-trip through the wrong writer
+ * produces — is not a boolean, and turning it into `true` by truthiness
+ * would silently flip a preference the player had set. It falls back to the
+ * initial value instead, which is the one outcome that is never a surprise.
+ */
+
+import { INITIAL_VIEW_STATE, type ViewState } from "./view-state";
+
+export type Preferences = ViewState["preferences"];
+
+/** The shape the store holds. Deliberately wider than `Preferences`. */
+export type StoredPreferences = Readonly<Record<string, string | boolean>>;
+
+export function toStored(preferences: Preferences): StoredPreferences {
+  return {
+    groupSeparator: preferences.groupSeparator,
+    showUnverified: preferences.showUnverified,
+  };
+}
+
+/**
+ * Read preferences out of a workspace record.
+ *
+ * Every field is checked by `typeof` and falls back independently: one
+ * unreadable preference does not discard the other. That is the opposite of
+ * the store's all-or-nothing rule for places, and the difference is
+ * deliberate — a half-loaded workspace hides places the player has, where a
+ * preference falling back to its default is visible on screen immediately
+ * and costs one click to correct.
+ */
+export function fromStored(stored: StoredPreferences | undefined): Preferences {
+  const fallback = INITIAL_VIEW_STATE.preferences;
+  if (!stored) return fallback;
+
+  const groupSeparator = stored["groupSeparator"];
+  const showUnverified = stored["showUnverified"];
+
+  return {
+    groupSeparator:
+      typeof groupSeparator === "string" ? groupSeparator : fallback.groupSeparator,
+    showUnverified:
+      typeof showUnverified === "boolean" ? showUnverified : fallback.showUnverified,
+  };
+}
+
+/** Whether two preference sets differ, so a no-op change writes nothing. */
+export function differ(a: Preferences, b: Preferences): boolean {
+  return a.groupSeparator !== b.groupSeparator || a.showUnverified !== b.showUnverified;
+}

--- a/web/src/state/useStoredData.ts
+++ b/web/src/state/useStoredData.ts
@@ -1,0 +1,164 @@
+/*
+ * The store's first consumer.
+ *
+ * Governing: ADR-0008 (durable user data), SPEC-0009 REQ "View Preferences
+ * Survive a Reload", REQ "An Empty Store Is a Designed State"
+ *
+ * The line this hook must not cross, in the words of the story that asked
+ * for it: persisting preferences MUST NOT move them out of view state. They
+ * remain interface state the view owns, and the store is where the view's
+ * own copy is written and read.
+ *
+ * That is not a stylistic preference. `ViewState` having no field a graph
+ * could go in is the thing that has kept graphs out of it, and a store
+ * wired in as a general state container is the back door those rules were
+ * keeping shut. So this hook only ever dispatches `setPreference` — the
+ * action that already existed — and holds its own bookkeeping in local
+ * component state, where it cannot be mistaken for shared view state.
+ *
+ * Nothing here reads or writes a plan, a resolved graph, or a derived
+ * quantity, and `ViewState` gains no field.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import type { DurableStore } from "../store";
+import type { PlaceRecord } from "../store";
+import { differ, fromStored, toStored, type Preferences } from "./preferences";
+import { useViewDispatch, useViewState } from "./useViewState";
+
+export type StoreStatus =
+  /** The first read has not finished. Not empty, and not a failure. */
+  | "loading"
+  /** Read, and usable. `places` may still be empty — that is a state, not a fault. */
+  | "ready"
+  /** IndexedDB is blocked or absent: a private window, or a disabled API. */
+  | "unavailable";
+
+export interface StoredData {
+  readonly status: StoreStatus;
+  readonly places: readonly PlaceRecord[];
+  /**
+   * Read, and held nothing.
+   *
+   * False while loading, which matters: an empty state rendered before the
+   * read finishes would flash "nothing saved" at a player who has data, and
+   * that reads as loss rather than as latency.
+   */
+  readonly empty: boolean;
+  /**
+   * A write has been issued and has not settled.
+   *
+   * Exposed because a write that can be lost is not persistence. The first
+   * draft issued `putPreferences` and dropped the promise, and a reload
+   * arriving before the transaction committed lost the change — found by
+   * the test that toggles two preferences and reloads at once, which is
+   * also exactly what a player does when they set something and leave.
+   */
+  readonly saving: boolean;
+}
+
+const LOADING: StoredData = Object.freeze({
+  status: "loading",
+  places: Object.freeze([]),
+  empty: false,
+  saving: false,
+});
+
+export function useStoredData(store: DurableStore): StoredData {
+  const { preferences } = useViewState();
+  const dispatch = useViewDispatch();
+  const [data, setData] = useState<StoredData>(LOADING);
+  const [saving, setSaving] = useState(false);
+
+  /*
+   * Writes are chained rather than issued concurrently. Two readwrite
+   * transactions on one object store are ordered by the spec, but the
+   * chain also gives the outstanding count something to hang off, and it
+   * makes the ordering a property of this file rather than of a spec
+   * paragraph a reader would have to go and find.
+   */
+  const queue = useRef<Promise<unknown>>(Promise.resolve());
+  const outstanding = useRef(0);
+
+  /*
+   * What was last seen, so the restore does not immediately write itself
+   * back and so an unchanged preference writes nothing at all.
+   */
+  const written = useRef<Preferences | null>(null);
+
+  useEffect(() => {
+    let live = true;
+
+    const restore = async (): Promise<void> => {
+      const opened = await store.open();
+      if (!live) return;
+      if (opened.kind !== "ok") {
+        setData({ status: "unavailable", places: [], empty: false, saving: false });
+        return;
+      }
+
+      const loaded = await store.load();
+      if (!live) return;
+      if (loaded.kind !== "ok") {
+        setData({ status: "unavailable", places: [], empty: false, saving: false });
+        return;
+      }
+
+      const restored = fromStored(loaded.value.workspace.preferences);
+      written.current = restored;
+
+      /*
+       * Dispatched field by field through the action that already exists,
+       * rather than through a new "replace preferences" action. A bulk
+       * setter would be the natural place for a later caller to pass
+       * something that is not a preference.
+       */
+      dispatch({
+        type: "setPreference",
+        field: "groupSeparator",
+        value: restored.groupSeparator,
+      });
+      dispatch({
+        type: "setPreference",
+        field: "showUnverified",
+        value: restored.showUnverified,
+      });
+
+      setData({
+        status: "ready",
+        places: loaded.value.places,
+        empty: loaded.value.places.length === 0,
+        saving: false,
+      });
+    };
+
+    void restore();
+    return () => {
+      live = false;
+    };
+  }, [store, dispatch]);
+
+  useEffect(() => {
+    /*
+     * Nothing is written until the restore has happened. Without this the
+     * first render would persist the *initial* preferences over whatever
+     * the player had saved — the bug where a setting resets itself on every
+     * load and looks like the store failing to read.
+     */
+    const last = written.current;
+    if (last === null || !differ(last, preferences)) return;
+
+    written.current = preferences;
+    outstanding.current += 1;
+    setSaving(true);
+
+    queue.current = queue.current.then(() => store.putPreferences(toStored(preferences)));
+    void queue.current.finally(() => {
+      outstanding.current -= 1;
+      if (outstanding.current === 0) setSaving(false);
+    });
+  }, [store, preferences]);
+
+  return saving === data.saving ? data : { ...data, saving };
+}

--- a/web/src/store/absence.ts
+++ b/web/src/store/absence.ts
@@ -1,0 +1,84 @@
+/*
+ * Absent is not zero.
+ *
+ * Governing: ADR-0008 (durable user data), SPEC-0009 REQ "An Empty Store Is
+ * a Designed State"
+ *
+ * "A consumer MUST distinguish 'nothing stored' from 'stored as zero', and
+ * MUST NOT render a figure the player never entered."
+ *
+ * This lives here, once, rather than in each surface that will need it.
+ * SPEC-0009's criterion is explicit that the contract be "expressed where
+ * later consumers inherit it, rather than reimplemented per surface" — and
+ * the reason is that the per-surface version is always written the same
+ * wrong way. `place.stocked?.[itemId] ?? 0` reads as a careful default and
+ * is the exact defect: it renders a stock level of zero for an item the
+ * player has never once looked at, and zero is a claim.
+ *
+ * The same argument SPEC-0005 makes about pending figures during module
+ * load, at the other end of the lifecycle. There the rule is "pending,
+ * never zero"; here it is "absent, never zero". Both exist because a
+ * plausible number is worse than no number: a player can act on it.
+ */
+
+import type { PlaceRecord } from "./schema";
+
+/**
+ * A value that may not have been stored.
+ *
+ * A discriminated union rather than `T | undefined`, so a consumer cannot
+ * reach the value without saying which case it is in. `?? 0` does not
+ * typecheck against this, which is the whole point.
+ */
+export type Stored<T> =
+  { readonly present: true; readonly value: T } | { readonly present: false };
+
+/** Nothing was stored. Not a failure — see SPEC-0009 on the empty store. */
+export const ABSENT: Stored<never> = Object.freeze({ present: false });
+
+export function present<T>(value: T): Stored<T> {
+  return { present: true, value };
+}
+
+/**
+ * A stocked quantity, as an exact string.
+ *
+ * Never parsed and never defaulted. SPEC-0005 REQ "The View Computes No
+ * Domain Values" keeps quantities as exact strings end to end, and the
+ * store is the most durable point in that chain: a quantity coerced here
+ * would be wrong in storage rather than wrong on screen.
+ */
+export function storedQuantity(place: PlaceRecord, itemId: string): Stored<string> {
+  const value = place.stocked?.[itemId];
+  return typeof value === "string" ? present(value) : ABSENT;
+}
+
+/**
+ * Whether a construction item is ticked.
+ *
+ * Three states, not two. An unticked part and a part the player has never
+ * seen are different, and a checklist that renders both as unchecked has
+ * quietly answered a question nobody asked it.
+ */
+export function storedTick(place: PlaceRecord, partId: string): Stored<boolean> {
+  const value = place.ticks?.[partId];
+  return typeof value === "boolean" ? present(value) : ABSENT;
+}
+
+/**
+ * What a surface shows in place of a value that was never entered.
+ *
+ * An em dash, and deliberately not "0" or "". Exported so every surface
+ * shows the same thing — a reader who learns what it means on the stock
+ * list should not have to learn it again on the checklist.
+ */
+export const ABSENT_DISPLAY = "—";
+
+/**
+ * What a screen reader is told instead.
+ *
+ * "—" announces as nothing at all in most screen readers, so a row using it
+ * would read as a label followed by silence, which is indistinguishable
+ * from a broken cell.
+ */
+export const ABSENT_LABEL = "not recorded";

--- a/web/tests/shell/stored-preferences.spec.ts
+++ b/web/tests/shell/stored-preferences.spec.ts
@@ -25,18 +25,56 @@ import type { PlaceRecord } from "../../src/store";
  * empty per test and the reload is a real one within that context.
  */
 
-/**
- * Wait for a preference write to settle before navigating away.
- *
- * Not politeness. The write is asynchronous, and a reload issued while the
- * IndexedDB transaction is still open loses it — which is a real defect
- * rather than a test artifact, and is what `data-saving` exists to expose.
- */
-async function settled(page: Page): Promise<void> {
-  await expect(page.getByRole("region", { name: "Preferences" })).toHaveAttribute(
-    "data-saving",
-    "false",
+/** The preferences as they actually sit in IndexedDB. */
+async function storedPreferences(page: Page): Promise<Record<string, unknown>> {
+  return page.evaluate(
+    (database) =>
+      new Promise<Record<string, unknown>>((resolve) => {
+        const opening = indexedDB.open(database);
+        opening.onsuccess = () => {
+          const db = opening.result;
+          if (!db.objectStoreNames.contains("workspace")) {
+            db.close();
+            resolve({});
+            return;
+          }
+          const read = db.transaction("workspace", "readonly");
+          const got = read.objectStore("workspace").get("self");
+          got.onsuccess = () => {
+            db.close();
+            const record = got.result as { preferences?: Record<string, unknown> };
+            resolve(record?.preferences ?? {});
+          };
+          got.onerror = () => {
+            db.close();
+            resolve({});
+          };
+        };
+        opening.onerror = () => {
+          resolve({});
+        };
+      }),
+    DATABASE,
   );
+}
+
+/**
+ * Wait until the write has actually reached the store.
+ *
+ * Not politeness, and deliberately not a poll on `data-saving`. That
+ * attribute is false before the write effect runs as well as after it
+ * finishes, so waiting for false can be satisfied by the state *preceding*
+ * the write — which is what the first version did. It passed locally on
+ * timing luck and failed in CI, twice, which is exactly the failure mode a
+ * flag-based wait has.
+ *
+ * Polling the record itself has no such window: it is the thing the
+ * requirement is about.
+ */
+async function persisted(page: Page, expected: Record<string, unknown>): Promise<void> {
+  await expect
+    .poll(async () => storedPreferences(page), { timeout: 10_000 })
+    .toMatchObject(expected);
 }
 
 /** The database AppShell uses when no store is injected. */
@@ -188,7 +226,7 @@ test("a preference set, then reloaded, is as the player left it", async ({ page 
   await expect(group).toBeChecked();
   await group.uncheck();
   await expect(group).not.toBeChecked();
-  await settled(page);
+  await persisted(page, { groupSeparator: "" });
 
   /*
    * A real reload. The whole requirement is that the value survives the
@@ -206,7 +244,7 @@ test("both preferences survive, not just the one that was changed last", async (
   await page.goto("/");
   await page.getByLabel("Group digits").uncheck();
   await page.getByLabel("Show unverified").uncheck();
-  await settled(page);
+  await persisted(page, { groupSeparator: "", showUnverified: false });
 
   await page.reload();
 

--- a/web/tests/shell/stored-preferences.spec.ts
+++ b/web/tests/shell/stored-preferences.spec.ts
@@ -1,0 +1,300 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { fromStored, toStored, differ } from "../../src/state/preferences";
+import { INITIAL_VIEW_STATE } from "../../src/state/view-state";
+import {
+  ABSENT,
+  ABSENT_DISPLAY,
+  present,
+  storedQuantity,
+  storedTick,
+} from "../../src/store/absence";
+import type { PlaceRecord } from "../../src/store";
+
+/*
+ * Governing: ADR-0008 (durable user data), SPEC-0009 REQ "View Preferences
+ * Survive a Reload", REQ "An Empty Store Is a Designed State"
+ *
+ * Against the real application at "/", not a fixture. The requirement is
+ * that a preference survives a reload, and a test that called the restore
+ * function directly would be asserting that a function it just called does
+ * what it says — which is true of every function, including a broken one
+ * that nothing ever calls.
+ *
+ * Playwright gives each test its own browser context, so IndexedDB starts
+ * empty per test and the reload is a real one within that context.
+ */
+
+/**
+ * Wait for a preference write to settle before navigating away.
+ *
+ * Not politeness. The write is asynchronous, and a reload issued while the
+ * IndexedDB transaction is still open loses it — which is a real defect
+ * rather than a test artifact, and is what `data-saving` exists to expose.
+ */
+async function settled(page: Page): Promise<void> {
+  await expect(page.getByRole("region", { name: "Preferences" })).toHaveAttribute(
+    "data-saving",
+    "false",
+  );
+}
+
+/** The database AppShell uses when no store is injected. */
+const DATABASE = "nms-planner";
+
+/**
+ * Plant a workspace and a place straight into IndexedDB.
+ *
+ * Both, always. A store holding places with no workspace record is not a
+ * fresh device — it is a store whose halves disagree — and `load` reports
+ * MALFORMED_RECORD rather than silently dropping the places.
+ */
+async function plant(page: Page, places: PlaceRecord[]): Promise<void> {
+  await page.evaluate(
+    ([database, records]) =>
+      new Promise<void>((resolve, reject) => {
+        const opening = indexedDB.open(database, 1);
+        opening.onupgradeneeded = () => {
+          const db = opening.result;
+          if (!db.objectStoreNames.contains("workspace"))
+            db.createObjectStore("workspace");
+          if (!db.objectStoreNames.contains("places"))
+            db.createObjectStore("places", { keyPath: "id" });
+        };
+        opening.onsuccess = () => {
+          const db = opening.result;
+          const transaction = db.transaction(["workspace", "places"], "readwrite");
+          transaction
+            .objectStore("workspace")
+            .put(
+              { schemaVersion: 1, ownerId: null, updatedAt: "2026-01-01T00:00:00.000Z" },
+              "self",
+            );
+          for (const record of records) transaction.objectStore("places").put(record);
+          transaction.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          transaction.onerror = () => {
+            db.close();
+            reject(transaction.error ?? new Error("plant failed"));
+          };
+        };
+        opening.onerror = () => {
+          reject(opening.error ?? new Error("plant open failed"));
+        };
+      }),
+    [DATABASE, places] as const,
+  );
+}
+
+/* ----------------------------------------------------------------------
+ * The contract, as pure functions
+ * ------------------------------------------------------------------- */
+
+test("absent and zero are different values", () => {
+  const place: PlaceRecord = {
+    id: "p1",
+    kind: "base",
+    schemaVersion: 1,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    revision: 1,
+    stocked: { copper: "0" },
+  };
+
+  /*
+   * The distinction the requirement is about. A player who has looked at
+   * their copper and found none has stored "0"; a player who has never
+   * looked has stored nothing, and the two must not render the same.
+   */
+  expect(storedQuantity(place, "copper")).toEqual(present("0"));
+  expect(storedQuantity(place, "ferrite")).toEqual(ABSENT);
+  expect(storedQuantity(place, "ferrite").present).toBe(false);
+});
+
+test("an unticked part and a part never seen are different", () => {
+  const place: PlaceRecord = {
+    id: "p1",
+    kind: "base",
+    schemaVersion: 1,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    revision: 1,
+    ticks: { "part-1": false },
+  };
+  expect(storedTick(place, "part-1")).toEqual(present(false));
+  expect(storedTick(place, "part-2")).toEqual(ABSENT);
+});
+
+test("a stored preference of the wrong type falls back rather than coercing", () => {
+  /*
+   * `"false"` is truthy. A decode that trusted it would flip a preference
+   * the player had switched off, and would do it silently on every load.
+   */
+  const decoded = fromStored({ showUnverified: "false", groupSeparator: " " });
+  expect(decoded.showUnverified).toBe(INITIAL_VIEW_STATE.preferences.showUnverified);
+  expect(decoded.groupSeparator).toBe(" ");
+});
+
+test("one unreadable preference does not discard the other", () => {
+  const decoded = fromStored({ showUnverified: false, groupSeparator: true });
+  expect(decoded.showUnverified).toBe(false);
+  expect(decoded.groupSeparator).toBe(INITIAL_VIEW_STATE.preferences.groupSeparator);
+});
+
+test("an empty separator survives the round trip, because it is a real setting", () => {
+  /*
+   * "" is "leave the digits ungrouped", not "unset". A decode using `||`
+   * rather than a type check would turn it back into a comma.
+   */
+  const round = fromStored(toStored({ groupSeparator: "", showUnverified: false }));
+  expect(round).toEqual({ groupSeparator: "", showUnverified: false });
+});
+
+test("an absent workspace record yields the initial preferences", () => {
+  expect(fromStored(undefined)).toEqual(INITIAL_VIEW_STATE.preferences);
+});
+
+test("differ is what stops an unchanged preference writing", () => {
+  const base = INITIAL_VIEW_STATE.preferences;
+  expect(differ(base, { ...base })).toBe(false);
+  expect(differ(base, { ...base, showUnverified: !base.showUnverified })).toBe(true);
+});
+
+/* ----------------------------------------------------------------------
+ * The application
+ * ------------------------------------------------------------------- */
+
+test("a device with no prior data reaches the empty state and reports no failure", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const saved = page.getByRole("region", { name: "Saved places" });
+
+  await expect(saved.getByText(/Nothing saved on this device yet/)).toBeVisible();
+
+  /*
+   * The half that matters. Empty is ordinary — cleared storage, a fresh
+   * device, a private window all produce it — and an application that
+   * reported it as a fault would be telling the player something is wrong
+   * on their very first visit.
+   */
+  await expect(saved.getByText(/could not|failed|error|unavailable/i)).toHaveCount(0);
+});
+
+test("a preference set, then reloaded, is as the player left it", async ({ page }) => {
+  await page.goto("/");
+  const group = page.getByLabel("Group digits");
+
+  await expect(group).toBeChecked();
+  await group.uncheck();
+  await expect(group).not.toBeChecked();
+  await settled(page);
+
+  /*
+   * A real reload. The whole requirement is that the value survives the
+   * page going away, and calling a restore function proves nothing about
+   * that.
+   */
+  await page.reload();
+
+  await expect(page.getByLabel("Group digits")).not.toBeChecked();
+});
+
+test("both preferences survive, not just the one that was changed last", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByLabel("Group digits").uncheck();
+  await page.getByLabel("Show unverified").uncheck();
+  await settled(page);
+
+  await page.reload();
+
+  await expect(page.getByLabel("Group digits")).not.toBeChecked();
+  await expect(page.getByLabel("Show unverified")).not.toBeChecked();
+});
+
+test("a place with no stocked quantity renders absent, not zero", async ({ page }) => {
+  await page.goto("/");
+  await plant(page, [
+    {
+      id: "aurora",
+      kind: "base",
+      schemaVersion: 1,
+      name: "Aurora Flats",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      revision: 1,
+      /* Deliberately no `stocked` at all. */
+    },
+  ]);
+  await page.reload();
+
+  await page.getByLabel("Target").fill("ANTIMATTER");
+
+  const row = page
+    .getByRole("region", { name: "Saved places" })
+    .getByRole("listitem")
+    .filter({ hasText: "Aurora Flats" });
+
+  await expect(row).toBeVisible();
+  await expect(row).toContainText(ABSENT_DISPLAY);
+  /*
+   * The defect this exists to prevent, spelled out: `?? 0` reads as a
+   * careful default and renders a stock level for an item the player has
+   * never looked at.
+   */
+  await expect(row).not.toContainText("0");
+});
+
+test("a stocked zero is shown as zero, because the player entered it", async ({
+  page,
+}) => {
+  /*
+   * The companion. A surface that rendered every quantity as an em dash
+   * would satisfy the test above and be useless.
+   */
+  await page.goto("/");
+  await plant(page, [
+    {
+      id: "ridge",
+      kind: "base",
+      schemaVersion: 1,
+      name: "Ridge Station",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      revision: 1,
+      stocked: { ANTIMATTER: "0" },
+    },
+  ]);
+  await page.reload();
+
+  await page.getByLabel("Target").fill("ANTIMATTER");
+
+  const row = page
+    .getByRole("region", { name: "Saved places" })
+    .getByRole("listitem")
+    .filter({ hasText: "Ridge Station" });
+
+  await expect(row).toContainText("0");
+  await expect(row).not.toContainText(ABSENT_DISPLAY);
+});
+
+test("a planted place reaches the list, so the empty state is not the only path", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await plant(page, [
+    {
+      id: "aurora",
+      kind: "base",
+      schemaVersion: 1,
+      name: "Aurora Flats",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      revision: 1,
+    },
+  ]);
+  await page.reload();
+
+  const saved = page.getByRole("region", { name: "Saved places" });
+  await expect(saved.getByText(/Nothing saved on this device yet/)).toHaveCount(0);
+  await expect(saved.getByText("Aurora Flats")).toBeVisible();
+});


### PR DESCRIPTION
Closes #113
Part of #110

Implements SPEC-0009 REQ "View Preferences Survive a Reload", REQ "An Empty Store Is a Designed State".

## The line this story was told not to cross

Persisting preferences must not move them out of view state. `useStoredData` only ever dispatches `setPreference` — the action that already existed — and holds its own bookkeeping in local component state, where it cannot be mistaken for shared view state.

`ViewState` gains no field. The shape check in `tests/shell/view-state.spec.ts` still asserts the same five keys, and it is untouched. That rule is what has kept graphs out of view state; a store wired in as a general state container is the back door it was keeping shut.

Deliberately **not** a bulk `replacePreferences` action — a bulk setter is the natural place for a later caller to pass something that is not a preference.

## Absent is not zero

`src/store/absence.ts` expresses the contract once, because SPEC-0009 requires it be expressed "where later consumers inherit it, rather than reimplemented per surface" — and the per-surface version is always written the same wrong way:

```ts
place.stocked?.[itemId] ?? 0   // reads as a careful default; renders a claim
```

`Stored<T>` is a discriminated union, so `?? 0` does not typecheck against it. Both directions are tested: a place with no stocked entry renders an em dash, and a place with a stored `"0"` renders `0` — a surface that dashed everything would pass the first test and be useless.

The dash is paired with an `aria-label`, because "—" announces as nothing in most screen readers and a row reading as a name followed by silence is indistinguishable from a broken one.

## Three states, not two

| State | Meaning | Reported as |
|---|---|---|
| `loading` | the read has not finished | pending |
| `ready` + `empty` | read, and there was nothing | **not a failure** |
| `unavailable` | IndexedDB blocked or absent | a warning |

Collapsing loading into empty flashes "nothing saved" at a player who has data, which reads as loss rather than latency. Collapsing empty into unavailable is the one SPEC-0009 names directly.

## A defect the tests found

The first draft issued `putPreferences` and dropped the promise. A reload arriving before the IndexedDB transaction committed lost the change — caught by the test that toggles two preferences and reloads at once, which is also exactly what a player does when they set something and leave.

Writes are now chained and their settlement is observable via `data-saving`. That attribute carries **no** user-facing claim; SPEC-0009 REQ "Storage Is Evictable" governs what may be *said* about stored data, and that indication belongs to #114.

## One rename

The preferences checkbox was first labelled "Show unverified figures", which made `getByLabel("Figures")` in `shell.spec.ts` ambiguous. Renamed to "Show unverified" rather than loosening that locator — two controls whose accessible names share a word is a real ambiguity for anyone navigating by label, not only for the test that caught it.

## Verification

**175 tests pass** (up from 162). lint, lint:css, typecheck, format:check, check:tokens, build all clean. **21/21 existing mutations still red.**

Both persistence tests were verified to fail with the write removed — including after the `data-saving` wait was added, so the wait does not mask the defect. The absent-vs-zero tests were verified to fail with `?? "0"` substituted.

**`scripts/mutation-check.sh` is deliberately untouched** to avoid conflicting with #120, which extends the same file. The two mutations this story earns — "preferences are never written" and "absent defaults to zero" — are verified by hand above and owed to that script once #120 lands.

No protected paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)