### PR TITLE
feat(web): data custody — deletion, eviction honesty, and images

### DIFF
--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -15,6 +15,7 @@ import { usePlanResolution, type Resolution } from "../state/usePlanResolution";
 import { useStoredData } from "../state/useStoredData";
 import { DurableStore } from "../store";
 import { StatusBadge } from "./StatusBadge";
+import { DataCustody } from "./DataCustody";
 import { StoredPlaces } from "./StoredPlaces";
 import { ViewPreferences } from "./ViewPreferences";
 
@@ -246,6 +247,10 @@ function Chrome({
 
         <section className="panel" aria-label="Saved places">
           <StoredPlaces data={stored} target={state.inputs.target} />
+        </section>
+
+        <section className="panel" aria-label="Your data">
+          <DataCustody data={stored} />
         </section>
 
         {/*

--- a/web/src/shell/DataCustody.tsx
+++ b/web/src/shell/DataCustody.tsx
@@ -1,0 +1,93 @@
+import { useCallback, useId, useState, type ReactNode } from "react";
+
+import { Popover } from "../a11y/Popover";
+import { useLiveRegion } from "../a11y/useLiveRegion";
+import type { StoredData } from "../state/useStoredData";
+
+/*
+ * What the player is told about their data, and what they can do about it.
+ *
+ * Governing: ADR-0008 (durable user data, local-first), SPEC-0009 REQ
+ * "Deletion Is a First-Class Operation", REQ "Storage Is Evictable and the
+ * Application Must Not Imply Otherwise", REQ "Screenshots Are Local-Only"
+ *
+ * ADR-0002 banked "needs no upload endpoint, retention policy, or deletion
+ * story" as a benefit of holding nothing. This spends the third of those
+ * the moment the first byte is written: once data is held, the player is
+ * owed a way to remove it that is not browser developer tools.
+ *
+ * The wording below is load-bearing and is checked mechanically by
+ * tests/helpers/claim-checks.ts. Browsers evict origin storage under
+ * pressure, private windows discard it on close, and until an account
+ * exists there is no recovery path — so "saved" on its own is a stronger
+ * claim than the storage makes, and "backed up" or "synced" would be false.
+ * There is no technical mitigation at stage 1; being accurate about the
+ * scope IS the mitigation, which is why this is a labelling requirement.
+ *
+ * No share or upload control appears here, and that is a requirement rather
+ * than an omission. ADR-0008 excluded blobs on measured grounds — one
+ * capture is 1.5-3 MB against 596 KB for a 200-place text workspace — and
+ * deferred them to ADR-0013. Until that decision exists there is nowhere
+ * for an image to go, so there is no control to send it there.
+ */
+export function DataCustody({ data }: { readonly data: StoredData }): ReactNode {
+  const [confirming, setConfirming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const headingId = useId();
+  const { announce } = useLiveRegion();
+
+  const close = useCallback(() => {
+    setConfirming(false);
+  }, []);
+
+  const confirm = useCallback(() => {
+    setDeleting(true);
+    void data.deleteEverything().finally(() => {
+      setDeleting(false);
+      setConfirming(false);
+      announce("Stored data deleted. Nothing is saved on this device.");
+    });
+  }, [data, announce]);
+
+  return (
+    <>
+      <p className="label">
+        Kept on this device, in this browser. Clearing site data removes it, and a browser
+        short of space can remove it on its own.
+      </p>
+
+      <button
+        type="button"
+        className="control control-sm interactive"
+        onClick={() => {
+          setConfirming(true);
+        }}
+      >
+        Delete stored data
+      </button>
+
+      {/*
+        The shell's Popover, not a bespoke dialog. Its focus trap restores
+        focus in the effect cleanup, so Escape, the backdrop and the close
+        control all converge on the same line — a dialog written here would
+        have to reimplement that, and would get one of the three routes
+        wrong. SPEC-0009's criterion names #82's trap for exactly this.
+      */}
+      <Popover open={confirming} onClose={close} labelledBy={headingId}>
+        <h3 id={headingId}>Delete stored data?</h3>
+        <p className="label">
+          This removes every place kept on this device, and the display settings stored
+          with them. It cannot be undone.
+        </p>
+        <button
+          type="button"
+          className="control control-primary interactive"
+          disabled={deleting}
+          onClick={confirm}
+        >
+          {deleting ? "Deleting" : "Delete everything"}
+        </button>
+      </Popover>
+    </>
+  );
+}

--- a/web/src/state/useStoredData.ts
+++ b/web/src/state/useStoredData.ts
@@ -20,12 +20,13 @@
  * quantity, and `ViewState` gains no field.
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { DurableStore } from "../store";
 import type { PlaceRecord } from "../store";
 import { differ, fromStored, toStored, type Preferences } from "./preferences";
 import { useViewDispatch, useViewState } from "./useViewState";
+import { INITIAL_VIEW_STATE } from "./view-state";
 
 export type StoreStatus =
   /** The first read has not finished. Not empty, and not a failure. */
@@ -56,13 +57,25 @@ export interface StoredData {
    * also exactly what a player does when they set something and leave.
    */
   readonly saving: boolean;
+  /**
+   * Remove everything the store holds.
+   *
+   * Governing: SPEC-0009 REQ "Deletion Is a First-Class Operation". The
+   * confirmation is the caller's — this is the operation, not the prompt.
+   */
+  readonly deleteEverything: () => Promise<void>;
 }
+
+const NOOP = async (): Promise<void> => {
+  /* replaced by the real operation once the hook has run */
+};
 
 const LOADING: StoredData = Object.freeze({
   status: "loading",
   places: Object.freeze([]),
   empty: false,
   saving: false,
+  deleteEverything: NOOP,
 });
 
 export function useStoredData(store: DurableStore): StoredData {
@@ -94,14 +107,26 @@ export function useStoredData(store: DurableStore): StoredData {
       const opened = await store.open();
       if (!live) return;
       if (opened.kind !== "ok") {
-        setData({ status: "unavailable", places: [], empty: false, saving: false });
+        setData({
+          status: "unavailable",
+          places: [],
+          empty: false,
+          saving: false,
+          deleteEverything: NOOP,
+        });
         return;
       }
 
       const loaded = await store.load();
       if (!live) return;
       if (loaded.kind !== "ok") {
-        setData({ status: "unavailable", places: [], empty: false, saving: false });
+        setData({
+          status: "unavailable",
+          places: [],
+          empty: false,
+          saving: false,
+          deleteEverything: NOOP,
+        });
         return;
       }
 
@@ -130,6 +155,7 @@ export function useStoredData(store: DurableStore): StoredData {
         places: loaded.value.places,
         empty: loaded.value.places.length === 0,
         saving: false,
+        deleteEverything: NOOP,
       });
     };
 
@@ -160,5 +186,48 @@ export function useStoredData(store: DurableStore): StoredData {
     });
   }, [store, preferences]);
 
-  return saving === data.saving ? data : { ...data, saving };
+  const deleteEverything = useCallback(async (): Promise<void> => {
+    const removed = await store.deleteAll();
+    if (removed.kind !== "ok") {
+      setData((previous) => ({ ...previous, status: "unavailable" }));
+      return;
+    }
+
+    /*
+     * Preferences live on the workspace record, so deletion took them too.
+     * The view is reset to match rather than left showing settings whose
+     * stored copy no longer exists — a screen that disagrees with the store
+     * is how "I deleted my data" becomes "did I?".
+     *
+     * `written.current` is set *before* dispatching, so the write effect
+     * sees no difference and does not immediately recreate the workspace
+     * record that was just removed. Deletion that undoes itself one tick
+     * later is the obvious failure here and it is silent.
+     */
+    written.current = INITIAL_VIEW_STATE.preferences;
+    dispatch({
+      type: "setPreference",
+      field: "groupSeparator",
+      value: INITIAL_VIEW_STATE.preferences.groupSeparator,
+    });
+    dispatch({
+      type: "setPreference",
+      field: "showUnverified",
+      value: INITIAL_VIEW_STATE.preferences.showUnverified,
+    });
+
+    /*
+     * Ready and empty, not a failure. SPEC-0009: deletion "MUST leave the
+     * application in the designed empty state rather than in an error
+     * state" — deleting your data is a thing you chose.
+     */
+    setData((previous) => ({
+      ...previous,
+      status: "ready",
+      places: [],
+      empty: true,
+    }));
+  }, [store, dispatch]);
+
+  return { ...data, saving, deleteEverything };
 }

--- a/web/tests/helpers/claim-checks.ts
+++ b/web/tests/helpers/claim-checks.ts
@@ -1,0 +1,59 @@
+/*
+ * Claims the storage does not make.
+ *
+ * Governing: SPEC-0009 REQ "Storage Is Evictable and the Application Must
+ * Not Imply Otherwise", REQ "Screenshots Are Local-Only"
+ *
+ * Both requirements are about what the interface says, not what it does,
+ * and that is unusual enough to be worth stating. There is no technical
+ * mitigation at stage 1: browsers evict origin storage under pressure,
+ * private windows discard it on close, and until an account exists there is
+ * no recovery path. Being accurate about the scope IS the mitigation. So
+ * the check is on the words.
+ *
+ * These are pure functions over text rather than over source, because the
+ * requirement is about what reaches the player. A component can hold the
+ * string "backed up" in a comment explaining why it must not say that —
+ * this file's own regex is the extreme case — and scanning source would
+ * make the explanation the offence. The suite runs these over the rendered
+ * page's visible text, where a false positive is impossible by
+ * construction.
+ */
+
+/**
+ * Phrases that promise more than local storage can deliver.
+ *
+ * "Saved" alone is deliberately absent. It is the ordinary word for what
+ * happened and banning it would push the interface toward circumlocution,
+ * which reads as evasive rather than as honest. What is banned is the
+ * claim that the data is somewhere *else* as well, or that it cannot be
+ * lost — those are the two things that are false.
+ *
+ * `cloud` is matched bare rather than as part of a phrase. The first draft
+ * matched "in the cloud" and missed "saved to the cloud", which is the same
+ * claim with a different preposition — the kind of gap a phrase list always
+ * has. The word has no legitimate use in a planner that reaches no network.
+ */
+const DURABILITY_CLAIM =
+  /\b(?:backed[ -]?up|back(?:ing)?[ -]up|backups?|synced?|syncing|synchroni[sz]\w*|cloud|never lose|cannot lose|can't lose|won't lose|safely stored|stored safely|kept safe|permanently stored|stored forever|always available|guaranteed)\b/gi;
+
+/** Every durability claim in a piece of visible text. */
+export function durabilityClaims(text: string): string[] {
+  return [...text.matchAll(DURABILITY_CLAIM)].map((match) => match[0]);
+}
+
+/**
+ * Control names whose effect would be to send something off the device.
+ *
+ * "Export" and "Download" are not matched, and the distinction is real:
+ * both hand a file to the player, and neither transmits it anywhere. What
+ * is matched is publishing and uploading — the operations ADR-0013 has not
+ * been written yet to authorise.
+ */
+const SHARING_CONTROL =
+  /\b(?:share|sharing|upload|uploading|publish|publishing|post to|send to|copy link|share link|invite)\b/i;
+
+/** The subset of these control names that would share or upload. */
+export function sharingControls(names: readonly string[]): string[] {
+  return names.filter((name) => SHARING_CONTROL.test(name));
+}

--- a/web/tests/shell/data-custody.spec.ts
+++ b/web/tests/shell/data-custody.spec.ts
@@ -1,0 +1,395 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+import { durabilityClaims, sharingControls } from "../helpers/claim-checks";
+import type { PlaceRecord } from "../../src/store";
+
+/*
+ * Governing: ADR-0008 (durable user data), SPEC-0009 REQ "Deletion Is a
+ * First-Class Operation", REQ "Storage Is Evictable and the Application
+ * Must Not Imply Otherwise", REQ "Screenshots Are Local-Only"
+ *
+ * Three requirements about custody rather than storage: what the player is
+ * told about their data, and what they can do about it.
+ *
+ * Against the real application at "/", because two of the three are claims
+ * about what reaches the player. A fixture could satisfy them while the
+ * shipped page said something else.
+ */
+
+const DATABASE = "nms-planner";
+
+async function plant(page: Page, places: PlaceRecord[]): Promise<void> {
+  await page.evaluate(
+    ([database, records]) =>
+      new Promise<void>((resolve, reject) => {
+        const opening = indexedDB.open(database, 1);
+        opening.onupgradeneeded = () => {
+          const db = opening.result;
+          if (!db.objectStoreNames.contains("workspace"))
+            db.createObjectStore("workspace");
+          if (!db.objectStoreNames.contains("places"))
+            db.createObjectStore("places", { keyPath: "id" });
+        };
+        opening.onsuccess = () => {
+          const db = opening.result;
+          const transaction = db.transaction(["workspace", "places"], "readwrite");
+          transaction
+            .objectStore("workspace")
+            .put(
+              { schemaVersion: 1, ownerId: null, updatedAt: "2026-01-01T00:00:00.000Z" },
+              "self",
+            );
+          for (const record of records) transaction.objectStore("places").put(record);
+          transaction.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          transaction.onerror = () => {
+            db.close();
+            reject(transaction.error ?? new Error("plant failed"));
+          };
+        };
+        opening.onerror = () => {
+          reject(opening.error ?? new Error("plant open failed"));
+        };
+      }),
+    [DATABASE, places] as const,
+  );
+}
+
+/** What is actually on disk, read past the application. */
+async function storedCounts(page: Page): Promise<{ places: number; workspace: number }> {
+  return page.evaluate(
+    (database) =>
+      new Promise<{ places: number; workspace: number }>((resolve, reject) => {
+        const opening = indexedDB.open(database);
+        opening.onsuccess = () => {
+          const db = opening.result;
+          if (!db.objectStoreNames.contains("places")) {
+            db.close();
+            resolve({ places: 0, workspace: 0 });
+            return;
+          }
+          const transaction = db.transaction(["places", "workspace"], "readonly");
+          const places = transaction.objectStore("places").count();
+          const workspace = transaction.objectStore("workspace").count();
+          transaction.oncomplete = () => {
+            db.close();
+            resolve({ places: places.result, workspace: workspace.result });
+          };
+          transaction.onerror = () => {
+            db.close();
+            reject(transaction.error ?? new Error("count failed"));
+          };
+        };
+        opening.onerror = () => {
+          reject(opening.error ?? new Error("count open failed"));
+        };
+      }),
+    DATABASE,
+  );
+}
+
+/**
+ * Wait until a preference change has actually reached the store.
+ *
+ * Polls the record rather than the `data-saving` attribute. That attribute
+ * reads "false" before the write effect runs as well as after it settles,
+ * so a wait on it can be satisfied by the state preceding the write — which
+ * is how the same helper in stored-preferences.spec.ts passed locally and
+ * failed twice in CI.
+ */
+async function preferencePersisted(
+  page: Page,
+  expected: Record<string, unknown>,
+): Promise<void> {
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(
+          (database) =>
+            new Promise<Record<string, unknown>>((resolve) => {
+              const opening = indexedDB.open(database);
+              opening.onsuccess = () => {
+                const db = opening.result;
+                if (!db.objectStoreNames.contains("workspace")) {
+                  db.close();
+                  resolve({});
+                  return;
+                }
+                const read = db.transaction("workspace", "readonly");
+                const got = read.objectStore("workspace").get("self");
+                got.onsuccess = () => {
+                  db.close();
+                  const record = got.result as {
+                    preferences?: Record<string, unknown>;
+                  };
+                  resolve(record?.preferences ?? {});
+                };
+                got.onerror = () => {
+                  db.close();
+                  resolve({});
+                };
+              };
+              opening.onerror = () => {
+                resolve({});
+              };
+            }),
+          DATABASE,
+        ),
+      { timeout: 10_000 },
+    )
+    .toMatchObject(expected);
+}
+
+const AURORA: PlaceRecord = {
+  id: "aurora",
+  kind: "base",
+  schemaVersion: 1,
+  name: "Aurora Flats",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  revision: 1,
+};
+
+async function withStoredPlace(page: Page): Promise<void> {
+  await page.goto("/");
+  await plant(page, [AURORA]);
+  await page.reload();
+  await expect(page.getByText("Aurora Flats")).toBeVisible();
+}
+
+/* ----------------------------------------------------------------------
+ * The checkers, against text they must and must not catch
+ * ------------------------------------------------------------------- */
+
+test("the claim checker catches the claims the storage cannot make", () => {
+  expect(durabilityClaims("Your bases are backed up.")).toHaveLength(1);
+  expect(durabilityClaims("Changes are synced across your devices.")).toHaveLength(1);
+  expect(durabilityClaims("Saved to the cloud")).toHaveLength(1);
+  expect(durabilityClaims("You'll never lose your progress")).toHaveLength(1);
+  expect(durabilityClaims("Stored safely on our servers")).toHaveLength(1);
+  expect(durabilityClaims("Your data is always available")).toHaveLength(1);
+});
+
+test("the claim checker leaves accurate wording alone", () => {
+  /*
+   * The companion. A checker that matched everything would satisfy every
+   * assertion above and force the interface into silence.
+   *
+   * "Saved" is deliberately allowed. It is the ordinary word for what
+   * happened, and banning it would push the copy toward circumlocution,
+   * which reads as evasive rather than as honest. What is banned is the
+   * claim that the data is somewhere else as well, or that it cannot be
+   * lost.
+   */
+  expect(durabilityClaims("Kept on this device, in this browser.")).toEqual([]);
+  expect(durabilityClaims("Saved on this device.")).toEqual([]);
+  expect(
+    durabilityClaims(
+      "Clearing site data removes it, and a browser short of space can remove it on its own.",
+    ),
+  ).toEqual([]);
+});
+
+test("the sharing checker separates handing over a file from transmitting it", () => {
+  expect(sharingControls(["Share screenshot"])).toHaveLength(1);
+  expect(sharingControls(["Upload image"])).toHaveLength(1);
+  expect(sharingControls(["Copy link to this base"])).toHaveLength(1);
+  expect(sharingControls(["Publish"])).toHaveLength(1);
+
+  /*
+   * Neither of these transmits anything. ADR-0013 is owed a decision about
+   * sharing images; handing the player their own file is not that.
+   */
+  expect(sharingControls(["Export as JSON", "Download", "Delete stored data"])).toEqual(
+    [],
+  );
+});
+
+/* ----------------------------------------------------------------------
+ * The application
+ * ------------------------------------------------------------------- */
+
+test("nothing on the page claims the data is backed up or synchronized", async ({
+  page,
+}) => {
+  await withStoredPlace(page);
+
+  const text = await page.locator("body").innerText();
+  expect(
+    text.length,
+    "the page rendered nothing, so nothing was checked",
+  ).toBeGreaterThan(50);
+  expect(durabilityClaims(text), "the page overpromises").toEqual([]);
+});
+
+test("the page is accurate about the scope, rather than merely silent", async ({
+  page,
+}) => {
+  /*
+   * The requirement is that where the application indicates data is stored,
+   * the indication is accurate about its scope. A page that said nothing at
+   * all would pass the check above and leave the player with no idea their
+   * data is one cache clear from gone.
+   */
+  await page.goto("/");
+  const custody = page.getByRole("region", { name: "Your data" });
+  await expect(custody).toContainText(/this device/i);
+  await expect(custody).toContainText(/remove/i);
+});
+
+test("no control anywhere would share or upload", async ({ page }) => {
+  await withStoredPlace(page);
+
+  const names = await page
+    .getByRole("button")
+    .evaluateAll((nodes) => nodes.map((node) => node.textContent ?? ""));
+  const links = await page
+    .getByRole("link")
+    .evaluateAll((nodes) => nodes.map((node) => node.textContent ?? ""));
+
+  expect(names.length, "no controls were found, so nothing was checked").toBeGreaterThan(
+    0,
+  );
+  expect(sharingControls([...names, ...links])).toEqual([]);
+});
+
+test("deletion is reachable without developer tools", async ({ page }) => {
+  await withStoredPlace(page);
+  await expect(page.getByRole("button", { name: "Delete stored data" })).toBeVisible();
+});
+
+test("deletion is confirmed before anything is removed", async ({ page }) => {
+  await withStoredPlace(page);
+
+  await page.getByRole("button", { name: "Delete stored data" }).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+
+  /*
+   * The half that matters. A confirmation that has already deleted by the
+   * time it asks is not a confirmation.
+   */
+  expect(await storedCounts(page)).toEqual({ places: 1, workspace: 1 });
+  await expect(page.getByText("Aurora Flats")).toBeVisible();
+});
+
+test("dismissing the confirmation removes nothing", async ({ page }) => {
+  await withStoredPlace(page);
+
+  await page.getByRole("button", { name: "Delete stored data" }).click();
+  await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
+
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  expect(await storedCounts(page)).toEqual({ places: 1, workspace: 1 });
+});
+
+test("confirming removes the workspace and every place, and leaves the empty state", async ({
+  page,
+}) => {
+  await withStoredPlace(page);
+
+  await page.getByRole("button", { name: "Delete stored data" }).click();
+  await page.getByRole("button", { name: "Delete everything" }).click();
+
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+
+  const saved = page.getByRole("region", { name: "Saved places" });
+  await expect(saved.getByText(/Nothing saved on this device yet/)).toBeVisible();
+
+  /*
+   * The designed empty state, not an error state. Deleting your data is a
+   * thing you chose, not a fault.
+   */
+  await expect(saved.getByText(/could not|failed|error|unavailable/i)).toHaveCount(0);
+
+  await expect
+    .poll(async () => storedCounts(page), { timeout: 5000 })
+    .toEqual({ places: 0, workspace: 0 });
+});
+
+test("deletion does not immediately recreate the workspace it just removed", async ({
+  page,
+}) => {
+  /*
+   * Preferences live on the workspace record, so the reset that follows
+   * deletion could write a fresh one back one tick later. That would be
+   * silent, and the player would have been told their data was gone.
+   *
+   * A preference is changed away from its default first, and that is the
+   * whole test rather than setup. Without it the post-deletion reset is a
+   * no-op, the write effect sees no difference, and the test passes against
+   * an implementation that has no protection at all — which is exactly what
+   * it did until removing the guard failed to turn it red.
+   */
+  await withStoredPlace(page);
+  await page.getByLabel("Group digits").uncheck();
+  await preferencePersisted(page, { groupSeparator: "" });
+  expect(await storedCounts(page)).toEqual({ places: 1, workspace: 1 });
+
+  await page.getByRole("button", { name: "Delete stored data" }).click();
+  await page.getByRole("button", { name: "Delete everything" }).click();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+
+  await expect
+    .poll(async () => storedCounts(page), { timeout: 5000 })
+    .toEqual({ places: 0, workspace: 0 });
+
+  await page.reload();
+  await expect(
+    page.getByRole("region", { name: "Saved places" }).getByText(/Nothing saved/),
+  ).toBeVisible();
+  expect(await storedCounts(page)).toEqual({ places: 0, workspace: 0 });
+});
+
+test("the confirmation returns focus to the control that opened it", async ({ page }) => {
+  /*
+   * Every close route, because that is where this breaks. #82's trap
+   * restores in the effect cleanup so all three converge; a bespoke dialog
+   * would restore in its Escape handler and leave the other two stranded.
+   */
+  await withStoredPlace(page);
+  const opener = page.getByRole("button", { name: "Delete stored data" });
+
+  for (const close of [
+    async () => {
+      await page.keyboard.press("Escape");
+    },
+    async () => {
+      await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
+    },
+  ]) {
+    await opener.click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await close();
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await expect(opener).toBeFocused();
+  }
+});
+
+test("the confirmation traps focus while it is open", async ({ page }) => {
+  await withStoredPlace(page);
+  await page.getByRole("button", { name: "Delete stored data" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+
+  for (let i = 0; i < 6; i += 1) {
+    await page.keyboard.press("Tab");
+    await expect(
+      dialog.locator(":focus"),
+      "focus left the dialog on tab " + String(i),
+    ).toHaveCount(1);
+  }
+});
+
+test("the data custody surface passes the accessibility audit", async ({ page }) => {
+  await withStoredPlace(page);
+  await page.getByRole("button", { name: "Delete stored data" }).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+  expect(results.violations).toEqual([]);
+});


### PR DESCRIPTION
Closes #114
Part of #110

Implements SPEC-0009 REQ "Deletion Is a First-Class Operation", REQ "Storage Is Evictable and the Application Must Not Imply Otherwise", REQ "Screenshots Are Local-Only".

> **Stacked on #121.** Base is `feat/113-preferences-persist-and-empty-state`, not `main`. The deletion criterion requires landing in *the designed empty state*, which is #113's deliverable, and both stories touch `AppShell.tsx`. Branching from main would have meant reimplementing that state and a guaranteed conflict. **Merge #121 first**, then this retargets to main cleanly.

## Deletion

Reachable from the page, confirmed before it runs, and it lands in the designed empty state rather than an error state — deleting your data is a thing you chose, not a fault.

The confirmation is the shell's `Popover`, so the focus trap restores focus in the **effect cleanup**. That is why Escape, the backdrop and the close control cannot disagree. A bespoke dialog would have restored inside its Escape handler and stranded the other two, which is the failure the accessibility story was worded around. Both routes are tested separately, not as one "close the dialog" case.

## Eviction honesty

A labelling requirement, because at stage 1 there is no technical mitigation. Browsers evict origin storage under pressure, private windows discard it on close, and until an account exists there is no recovery path. Being accurate about the scope **is** the mitigation.

The check runs over the **rendered page's visible text**, not over source. A component can hold "backed up" in a comment explaining why it must not say that — this repo's own checker file is the extreme case — and scanning source would make the explanation the offence.

Two calibrations, both with negative controls:

- **"Saved" is allowed.** It is the ordinary word for what happened; banning it pushes the copy toward circumlocution, which reads as evasive rather than honest. What is banned is the claim the data is somewhere *else* as well, or that it cannot be lost.
- **Export and download are not sharing.** Both hand the player their own file; neither transmits it. What is refused is uploading and publishing, which ADR-0013 has not been written to authorise.

A companion test asserts the page is *accurate about the scope* rather than merely silent — a page that said nothing would pass the claim check and leave the player unaware their data is one cache clear from gone.

## A test that had no teeth

"Deletion does not immediately recreate the workspace" **passed with the guard removed**. The test never changed a preference away from its default, so the post-deletion reset was a no-op and the write effect had nothing to fire on. It changes one first now, and goes red without the guard.

That guard matters: preferences live on the workspace record, so the reset following deletion can write a fresh workspace back one tick later — silently, after the player has been told their data is gone.

## Verification

**189 tests pass.** lint, lint:css, typecheck, format:check, check:tokens, build all clean.

Four probes, each confirmed red before being accepted:

| Probe | Test that must fail |
|---|---|
| delete without confirming | deletion is confirmed before anything is removed |
| copy claims backup and sync | nothing on the page claims the data is backed up |
| a "Share screenshot" control appears | no control anywhere would share or upload |
| the post-deletion guard removed | deletion does not immediately recreate the workspace |

`scripts/mutation-check.sh` is deliberately untouched, to avoid conflicting with #120 which extends the same file. These four are owed to it once #120 lands.

No protected paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)