### PR TITLE
docs(web): correct the ADR-0012 citations and bound --text-muted at the label

### DIFF
--- a/web/src/store/schema.ts
+++ b/web/src/store/schema.ts
@@ -50,7 +50,12 @@ export interface PlaceRecord {
   readonly stocked?: Readonly<Record<string, string>>;
 
   /*
-   * Reserved for ADR-0012 (multi-device sync and conflict resolution).
+   * Reserved by ADR-0008, which defers multi-device sync and conflict
+   * resolution to a later ADR (numbered 0012 in its forward table, and not
+   * yet written) and keeps the schema room deliberately. SPEC-0009 makes it
+   * normative: both MUST be written from the first version, because a store
+   * that adds them later cannot order edits made before they existed.
+   *
    * Written on every mutation; nothing reads them in stage 1.
    */
   readonly updatedAt: string;

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -58,11 +58,33 @@ h3 {
   font-variant-numeric: tabular-nums;
 }
 
+/*
+ * The micro-label. `--text-muted` at 11.5px, which is safe on every surface
+ * the app currently uses and NOT safe on two it does not:
+ *
+ *   --bg-canvas  5.90     --panel-raised  4.17   below AA for normal text
+ *   --bg         5.30     --input-bg      3.68   below AA, and a surface
+ *   --panel      4.72                            the handoff never measures
+ *
+ * The theme handoff states the `--panel-raised` rule (>=17px there, or use
+ * `--text`). It never measures `--input-bg`, which is lighter than all
+ * three surfaces it does measure and is therefore the worse case.
+ *
+ * Use `.label-strong` on a raised or input surface. This is not enforced
+ * here — the axe audit in tests/shell/shell.spec.ts catches it, verified by
+ * putting a .label on --input-bg and watching both audits fail — so the
+ * note exists to save an author the round trip, not to substitute for it.
+ */
 .label {
   font-size: var(--text-label);
   letter-spacing: var(--label-tracking);
   text-transform: uppercase;
   color: var(--text-muted);
+}
+
+/* A micro-label on a surface where `--text-muted` does not clear AA. */
+.label-strong {
+  color: var(--text);
 }
 
 /* The canvas surface carries the 24px grid rather than the scanline. */

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -42,6 +42,10 @@
    *
    *   --text-muted is 4.17:1 on --panel-raised, below AA for normal text.
    *   Against that surface, use it only at 17px or larger, or use --text.
+   *   It is 3.68:1 on --input-bg — worse, and a surface the handoff never
+   *   validates it against, because the three it measures are all darker.
+   *   Treat --input-bg as out of range rather than extrapolating from the
+   *   published figures.
    *
    *   --text-dim is decorative at 18px or larger only, and must never be
    *   the sole carrier of information available nowhere else.

--- a/web/tests/helpers/source-checks.ts
+++ b/web/tests/helpers/source-checks.ts
@@ -132,10 +132,10 @@ export function networkCalls(file: string, source: string): Finding[] {
  * asserts on records read back out of IndexedDB for that reason.
  *
  * `updatedAt` and `revision` are NOT matched, and that is the point of the
- * requirement rather than an oversight in the pattern. ADR-0012 reserves
- * both, SPEC-0009 requires they be "present and unset rather than absent",
- * and a checker that treated a reserved-and-empty field as a marked one
- * would be arguing with the schema.
+ * requirement rather than an oversight in the pattern. ADR-0008 reserves
+ * both for a later sync ADR, SPEC-0009 requires they be written from the
+ * first version, and a checker that treated a reserved field as a marked
+ * one would be arguing with the schema rather than enforcing it.
  */
 const SYNC_MARKER =
   /\b(?:isShared|shared|isSynced|synced|syncState|syncedAt|pendingUpload|pendingSync|needsUpload|needsSync|uploadedAt|remoteId|publishedAt)\s*[:=]/;

--- a/web/tests/store/discipline.spec.ts
+++ b/web/tests/store/discipline.spec.ts
@@ -129,11 +129,11 @@ test("the checks do not fire on legitimate code", () => {
   expect(networkCalls("x.ts", `const socket = pipe.connect(target);`)).toEqual([]);
 
   /*
-   * The reserved fields. ADR-0012 has `updatedAt` and `revision` written
-   * from version 1 and read by nothing, and SPEC-0009 requires they be
-   * "present and unset rather than absent" — a checker that read a
-   * reserved-and-empty field as a marked one would be arguing with the
-   * schema rather than enforcing it.
+   * The reserved fields. ADR-0008 reserves `updatedAt` and `revision` for
+   * the sync ADR it defers to, and SPEC-0009 requires they be written from
+   * version 1 even though nothing reads them — so a checker that read a
+   * reserved field as a marked one would be arguing with the schema rather
+   * than enforcing it.
    */
   expect(
     syncMarkers("x.ts", `const record = { ...place, updatedAt: now, revision };`),

--- a/web/tests/store/durable-store.spec.ts
+++ b/web/tests/store/durable-store.spec.ts
@@ -83,7 +83,8 @@ test("updatedAt and revision are written even though nothing reads them", async 
   page,
 }) => {
   /*
-   * Reserved for ADR-0012. A reviewer who has not read ADR-0008 will
+   * Reserved by ADR-0008 for the sync ADR it defers to. A reviewer who has
+   * not read ADR-0008 will
    * reasonably ask why three unused fields exist, so this asserts them
    * rather than leaving it to judgement: a store that adds ordering later
    * cannot order edits made before it existed.


### PR DESCRIPTION
Two corrections found reviewing #119, #120 and #121. Comments and one CSS modifier — no behaviour change.

## ADR-0012 does not exist

`docs/adrs/` holds ADR-0001 through ADR-0008. ADR-0012 is a **planned** ADR that ADR-0008 forward-references in its own table:

> `| ADR-0012 | Multi-device sync and conflict resolution — schema room is reserved here (updatedAt, revision) |`

So ADR-0008 does the reserving, and SPEC-0009 line 49 carries the normative requirement: *"`updatedAt` and `revision` MUST be written from the first version even though stage 1 has nothing to reconcile."*

Four comments cited ADR-0012 as though it were readable — one saying it *"has `updatedAt` and `revision` written"*, which it cannot, having no content:

| File | Was |
|---|---|
| `src/store/schema.ts` | "Reserved for ADR-0012 (multi-device sync…)" |
| `tests/helpers/source-checks.ts` | "ADR-0012 reserves both" |
| `tests/store/discipline.spec.ts` | "ADR-0012 has `updatedAt` and `revision` written" |
| `tests/store/durable-store.spec.ts` | "Reserved for ADR-0012" |

The substance was right every time and only the attribution was wrong. It matters because `/sdd:audit` traces governing comments, so a pointer at a nonexistent artifact is noise in the tool meant to catch drift — the same class as #93's inherited REQ reference.

The forward reference is kept where it is useful, phrased so a reader knows it is not yet written rather than going looking for it.

## `--text-muted` at label size, and the surface nobody measured

`.label` is `--text-muted` at 11.5px. Measured against every surface in the token file:

```
--bg-canvas  5.90     --panel-raised  4.17   below AA for normal text
--bg         5.30     --input-bg      3.68   below AA, and unmeasured
--panel      4.72
```

Safe on all three surfaces the app uses today, unsafe on the two it does not. The theme handoff states the `--panel-raised` rule; it never measures `--input-bg` at all, because the three surfaces it does measure are all darker — so its published figures cannot be extrapolated to it. That is now stated at the token as well as at `.label`.

`.label-strong` gives an author the way out.

## No new check, and I verified that rather than assuming it

The obvious move is a test enumerating `.label` elements and asserting contrast. **The axe audit already does this.** I put a `.label` on `--input-bg` and both audits failed:

```
2 failed
  the shell passes a WCAG 2.1 AA audit before any figures exist
  the shell passes a WCAG 2.1 AA audit with figures on screen
```

A second, worse version of a check that already exists would have been the wrong fix. The comment says where the guard is, so the next person does not add one either.

## A footgun worth knowing about

`scripts/mutation-check.sh` sets `MUTABLE="$BASE $TOKENS $TRAP $LIVE $SHELL $BADGE $STORE"` and restores with `git checkout -- $MUTABLE`. Running it **silently discarded my uncommitted edits to `base.css` and `tokens.css`** — the two files I was editing — and the first push of this branch went out missing them.

Not a defect in the script's job, and the trap-based restore is right for what it does. But anyone editing a mutated file has one command between their work and `git checkout --`, with no warning. Worth a `git diff --quiet` guard on the mutable set before the first mutation, refusing to run against a dirty tree. Happy to open an issue if that seems worth doing.

## Verified

```
typecheck  PASS    check:tokens  PASS    184 tests passed
lint       PASS    build         PASS    24/24 mutations red
lint:css   PASS    format:check  PASS    tree clean after mutation restore
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)