### PR TITLE
feat(web): card composition, identity, and producer sections

### DIFF
--- a/web/src/card/BasePlannerCard.tsx
+++ b/web/src/card/BasePlannerCard.tsx
@@ -1,0 +1,242 @@
+import type { ReactNode } from "react";
+
+import {
+  formatQuantity,
+  type BaseBuild,
+  type ExtractorRow,
+  type FarmRow,
+  type KitchenStep,
+  type NoBuildRow,
+  type Quantity,
+  type RanchRow,
+} from "../boundary";
+import { StatusBadge } from "../shell/StatusBadge";
+
+import { PRODUCER_HEADING, presentKinds, type ProducerKind } from "./sections";
+
+/*
+ * One base's construction instructions.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0007 REQ "Card Composition
+ * From the Build Payload", REQ "Base Identity and Selection", REQ "Producer
+ * Sections", REQ "Byproducts Are Shown, Not Omitted", SPEC-0005 REQ "The
+ * View Computes No Domain Values", REQ "Component Styling Discipline"
+ *
+ * Every number rendered here arrives as a Quantity and leaves through
+ * formatQuantity, which only groups digits. There is no division, no
+ * rounding and no Number() in this file, and tests/card/discipline.spec.ts
+ * asserts that mechanically rather than trusting this comment — SPEC-0007
+ * forbids computing a count from a quantity and a rate *even where both are
+ * in the payload*, which is precisely the tempting case: a farm row carries
+ * both `required` and `yieldPerPlant`, and `plants` is already the answer.
+ *
+ * `nutrientProcessors` and `pelletFeeders` are rendered once, on the section
+ * that owns them, and never inside a row. They are base-level figures: a
+ * base with three kitchen steps has one processor count, and summing a
+ * per-row value would report three times the build.
+ *
+ * The card takes its identity slot as a prop because base identity metadata
+ * has no source yet — SPEC-0007's overview names it as one of three things
+ * this card displays that nothing built or specified provides. Absent a
+ * slot the card says so, with the dashed frame *and* a badge, because
+ * SPEC-0005 forbids colour carrying a distinction alone.
+ */
+
+/** 1-6 map to the categorical base palette; absent means no identity assigned. */
+export type IdentitySlot = 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface BasePlannerCardProps {
+  readonly base: BaseBuild;
+  readonly identity?: IdentitySlot;
+  readonly selected?: boolean;
+  readonly onSelect?: (base: string) => void;
+}
+
+/** Digits grouped, magnitude untouched. The only formatting SPEC-0005 permits. */
+function q(value: Quantity): string {
+  return formatQuantity(value);
+}
+
+function Figure({ label, value }: { label: string; value: string }): ReactNode {
+  return (
+    <span className="card-figure">
+      <span className="card-figure-label">{label}</span>
+      <span className="card-figure-value mono">{value}</span>
+    </span>
+  );
+}
+
+function FarmRowView({ row }: { row: FarmRow }): ReactNode {
+  return (
+    <li className="card-row" data-row="farm" data-item={row.itemId}>
+      <span className="card-row-name">{row.name}</span>
+      <span className="card-row-figures">
+        <Figure label="Required" value={q(row.required)} />
+        {/* What to build. SPEC-0007: never the required quantity alone. */}
+        <Figure label="Plants" value={q(row.plants)} />
+        <Figure label="Biodomes" value={q(row.biodomes)} />
+        {/*
+          Both bounds, always together. The domain sized `plants` on the
+          pessimistic one; showing the optimistic bound by itself would
+          present a planning figure that produces a build that does not work.
+        */}
+        <Figure
+          label="Yield/plant"
+          value={`${q(row.yieldPerPlant.min)}–${q(row.yieldPerPlant.max)}`}
+        />
+        <Figure label="Growth (s)" value={q(row.growthSeconds)} />
+      </span>
+    </li>
+  );
+}
+
+function ExtractorRowView({ row }: { row: ExtractorRow }): ReactNode {
+  return (
+    <li className="card-row" data-row="extractor" data-item={row.itemId}>
+      <span className="card-row-name">
+        {row.name} <span className="card-row-class">{row.class}</span>
+      </span>
+      <span className="card-row-figures">
+        <Figure label="Required" value={q(row.required)} />
+        <Figure label="Extractors" value={q(row.extractorCount)} />
+        <Figure label="Depots" value={q(row.depots)} />
+        <Figure label="Rate/s" value={q(row.ratePerSecond)} />
+        <Figure label="Fill (s)" value={q(row.fillSeconds)} />
+      </span>
+    </li>
+  );
+}
+
+function RanchRowView({ row }: { row: RanchRow }): ReactNode {
+  return (
+    <li className="card-row" data-row="ranch" data-item={row.itemId}>
+      <span className="card-row-name">{row.name}</span>
+      <span className="card-row-figures">
+        <Figure label="Required" value={q(row.required)} />
+        <Figure label="Fauna" value={q(row.fauna)} />
+        <Figure label="Cycle (s)" value={q(row.cycleSeconds)} />
+      </span>
+    </li>
+  );
+}
+
+function KitchenRowView({ row }: { row: KitchenStep }): ReactNode {
+  return (
+    <li className="card-row" data-row="kitchen" data-item={row.itemId}>
+      <span className="card-row-name">
+        {row.name} <span className="card-row-class">{row.recipe}</span>
+      </span>
+      <span className="card-row-figures">
+        <Figure label="Required" value={q(row.required)} />
+        <Figure label="Process (s)" value={q(row.processSeconds)} />
+      </span>
+    </li>
+  );
+}
+
+function NoBuildRowView({ row }: { row: NoBuildRow }): ReactNode {
+  return (
+    <li className="card-row" data-row="no-build" data-item={row.itemId}>
+      <span className="card-row-name">{row.name}</span>
+      <span className="card-row-figures">
+        <Figure label="Demand" value={q(row.required)} />
+        <Figure label="Covered by" value={row.from} />
+        {/*
+          A word, not a style. An omitted row is indistinguishable from an
+          overlooked requirement, and a row distinguished only by being
+          greyed out is indistinguishable to anyone not seeing the grey.
+        */}
+        <span className="card-nothing-to-build">Nothing to build</span>
+      </span>
+    </li>
+  );
+}
+
+/** Base-level counts belong to a section, never to a row inside it. */
+function sectionFigure(base: BaseBuild, kind: ProducerKind): ReactNode {
+  if (kind === "kitchen") {
+    return <Figure label="Nutrient processors" value={q(base.nutrientProcessors)} />;
+  }
+  if (kind === "ranch") {
+    return <Figure label="Pellet feeders" value={q(base.pelletFeeders)} />;
+  }
+  return null;
+}
+
+function rowsFor(base: BaseBuild, kind: ProducerKind): ReactNode {
+  switch (kind) {
+    case "farm":
+      return base.farms.map((row) => <FarmRowView key={row.itemId} row={row} />);
+    case "extractor":
+      return base.extractors.map((row) => (
+        <ExtractorRowView key={row.itemId} row={row} />
+      ));
+    case "ranch":
+      return base.ranches.map((row) => <RanchRowView key={row.itemId} row={row} />);
+    case "kitchen":
+      return base.kitchen.map((row) => <KitchenRowView key={row.itemId} row={row} />);
+  }
+}
+
+export function BasePlannerCard({
+  base,
+  identity,
+  selected = false,
+  onSelect,
+}: BasePlannerCardProps): ReactNode {
+  const kinds = presentKinds(base);
+  const identityClass =
+    identity === undefined ? "identity-unassigned" : `identity-${String(identity)}`;
+
+  return (
+    <article
+      className={`card identity ${identityClass} selectable`}
+      data-selected={selected ? "true" : "false"}
+      data-base={base.base}
+    >
+      <header className="card-head">
+        <h3 className="card-name">
+          {/*
+            A real button. SPEC-0007: "A generic element given a tab index
+            MUST NOT be used" — the semantics are what a screen reader reads,
+            and a div that behaves correctly still announces nothing. The
+            base's name is the button's accessible name, which is also what
+            makes the card identifiable with colour removed entirely.
+          */}
+          <button
+            type="button"
+            className="card-select interactive"
+            aria-pressed={selected}
+            onClick={() => onSelect?.(base.base)}
+          >
+            {base.base}
+          </button>
+        </h3>
+        {identity === undefined ? (
+          <StatusBadge status="warning" detail="no identity assigned" />
+        ) : null}
+      </header>
+
+      {kinds.map((kind) => (
+        <section className="card-section" key={kind} data-section={kind}>
+          <h4 className="card-section-head">
+            {PRODUCER_HEADING[kind]}
+            {sectionFigure(base, kind)}
+          </h4>
+          <ul className="card-rows">{rowsFor(base, kind)}</ul>
+        </section>
+      ))}
+
+      {base.noBuild.length > 0 ? (
+        <section className="card-section" data-section="no-build">
+          <h4 className="card-section-head">Covered by byproduct</h4>
+          <ul className="card-rows">
+            {base.noBuild.map((row) => (
+              <NoBuildRowView key={row.itemId} row={row} />
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </article>
+  );
+}

--- a/web/src/card/sections.ts
+++ b/web/src/card/sections.ts
@@ -1,0 +1,59 @@
+/*
+ * Which producer sections a base's payload actually carries.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0007 REQ "Producer Sections",
+ * SPEC-0005 REQ "The View Computes No Domain Values"
+ *
+ * The order is fixed here rather than in the component so a section cannot
+ * be added to the card without appearing in the table a test enumerates —
+ * the same reason StatusBadge exports STATUSES. A group the payload does not
+ * carry is absent from the card rather than rendered empty, which SPEC-0007
+ * requires and which `present` is the whole of: an absent group and a group
+ * with no rows are the same fact, and the card must not draw a heading over
+ * nothing.
+ *
+ * Nothing here reads a quantity. Presence is a property of the row list, not
+ * of any figure in it, so this module never touches a domain value.
+ */
+
+import type { BaseBuild } from "../boundary";
+
+export type ProducerKind = "farm" | "extractor" | "ranch" | "kitchen";
+
+/** Fixed presentation order. Exported so a test enumerates rather than samples. */
+export const PRODUCER_ORDER: readonly ProducerKind[] = [
+  "farm",
+  "extractor",
+  "ranch",
+  "kitchen",
+];
+
+export const PRODUCER_HEADING: Record<ProducerKind, string> = {
+  farm: "Farm",
+  extractor: "Extractors",
+  ranch: "Ranch",
+  kitchen: "Kitchen",
+};
+
+/** The payload list backing each kind. */
+function rowsFor(base: BaseBuild, kind: ProducerKind): readonly unknown[] {
+  switch (kind) {
+    case "farm":
+      return base.farms;
+    case "extractor":
+      return base.extractors;
+    case "ranch":
+      return base.ranches;
+    case "kitchen":
+      return base.kitchen;
+  }
+}
+
+export function isPresent(base: BaseBuild, kind: ProducerKind): boolean {
+  return rowsFor(base, kind).length > 0;
+}
+
+/** The kinds this base carries, in presentation order. */
+export function presentKinds(base: BaseBuild): readonly ProducerKind[] {
+  return PRODUCER_ORDER.filter((kind) => isPresent(base, kind));
+}

--- a/web/src/styles/card.css
+++ b/web/src/styles/card.css
@@ -1,0 +1,135 @@
+/*
+ * The base planner card.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0005 REQ "Token Discipline",
+ * REQ "Component Styling Discipline", SPEC-0007 REQ "Base Identity and
+ * Selection"
+ *
+ * Nothing here writes to `border`. The 3px identity frame is the base's, and
+ * `.identity` in base.css owns it; selection is the inboard overlay ring on
+ * `.selectable`, and focus is the outboard outline on `.interactive`. All
+ * three already exist — this stylesheet lays the card out and styles nothing
+ * that carries a state.
+ *
+ * Every colour resolves through a custom property. There is no literal here,
+ * stylelint rejects one, and tests/stylesheet.spec.ts checks this file
+ * without being told it exists.
+ */
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--panel);
+  border-radius: var(--radius-panel);
+}
+
+.card-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.card-name {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: var(--text-h3);
+}
+
+/*
+ * The button carries the name, so it must not look like a control bolted
+ * next to one. It is transparent and inherits its type — but it is still a
+ * button, which is the half that matters to a screen reader.
+ */
+.card-select {
+  padding: 0;
+  font: inherit;
+  color: var(--text-bright);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.card-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.card-section-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin: 0;
+  padding-bottom: var(--space-1);
+  font-family: var(--font-display);
+  font-size: var(--text-label);
+  letter-spacing: var(--label-tracking);
+  text-transform: uppercase;
+  color: var(--text-muted);
+  border-bottom: var(--border-width) solid var(--divider);
+}
+
+.card-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.card-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-1) var(--space-3);
+  padding: var(--space-1) 0;
+}
+
+.card-row-name {
+  color: var(--text);
+}
+
+.card-row-class {
+  color: var(--text-muted);
+  font-size: var(--text-meta);
+}
+
+.card-row-figures {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-3);
+  align-items: baseline;
+}
+
+.card-figure {
+  display: inline-flex;
+  gap: var(--space-1);
+  align-items: baseline;
+}
+
+.card-figure-label {
+  font-size: var(--text-meta);
+  letter-spacing: var(--label-tracking);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.card-figure-value {
+  font-family: var(--font-mono);
+  color: var(--text-bright);
+  font-variant-numeric: tabular-nums;
+}
+
+/* A word, because a colour alone would not survive being unable to see it. */
+.card-nothing-to-build {
+  font-size: var(--text-meta);
+  color: var(--text-muted);
+}

--- a/web/tests/card/composition.spec.ts
+++ b/web/tests/card/composition.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test } from "@playwright/test";
+
+/*
+ * Governing: SPEC-0007 REQ "Card Composition From the Build Payload",
+ * REQ "Base Identity and Selection", REQ "Producer Sections",
+ * REQ "Byproducts Are Shown, Not Omitted"
+ *
+ * The card's acceptance criteria, each as the case that catches its own
+ * violation rather than as a sample of correct behaviour. The three that
+ * matter most are the ones where a wrong implementation still looks right:
+ * a summed base-level count is only wrong when a base carries more than one
+ * step, an absent producer group is only distinguishable from an empty one
+ * when a base is missing a group, and an omitted byproduct row is invisible
+ * by construction.
+ */
+
+const FIXTURE = "/tests/fixtures/card.html";
+
+const FULL = '[data-base="Verdant Shelf"]';
+const SPARSE = '[data-base="Rime Outpost"]';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(FIXTURE, { waitUntil: "load" });
+});
+
+test("all four producer groups render when the payload carries all four", async ({
+  page,
+}) => {
+  const sections = page.locator(`${FULL} .card-section[data-section]`);
+  await expect(sections).toHaveCount(5); // four producers + byproducts
+  for (const kind of ["farm", "extractor", "ranch", "kitchen"]) {
+    await expect(page.locator(`${FULL} [data-section="${kind}"]`)).toHaveCount(1);
+  }
+});
+
+test("a group absent from the payload is absent, not empty", async ({ page }) => {
+  /*
+   * The sparse base carries extractors only. An implementation that rendered
+   * every group unconditionally passes the test above and fails this one,
+   * which is the only reason this base exists.
+   */
+  await expect(page.locator(`${SPARSE} [data-section="extractor"]`)).toHaveCount(1);
+  for (const kind of ["farm", "ranch", "kitchen"]) {
+    await expect(page.locator(`${SPARSE} [data-section="${kind}"]`)).toHaveCount(0);
+  }
+});
+
+test("a base-level count is shown once, not once per row", async ({ page }) => {
+  /*
+   * Three kitchen steps, one nutrient processor figure. Summing per row
+   * would report three times the build, and this is the case that catches
+   * it: with one step, a summed figure and a base-level figure agree.
+   */
+  await expect(page.locator(`${FULL} [data-section="kitchen"] .card-row`)).toHaveCount(3);
+  const processors = page.locator(
+    `${FULL} [data-section="kitchen"] .card-section-head .card-figure`,
+  );
+  await expect(processors).toHaveCount(1);
+  await expect(processors).toContainText("Nutrient processors");
+  await expect(processors).toContainText("2");
+
+  // And never inside a row.
+  await expect(
+    page.locator(`${FULL} [data-section="kitchen"] .card-row`, {
+      hasText: "Nutrient processors",
+    }),
+  ).toHaveCount(0);
+});
+
+test("a farm row shows what to build, not the required quantity alone", async ({
+  page,
+}) => {
+  const row = page.locator(`${FULL} [data-row="farm"]`);
+  await expect(row).toContainText("Plants");
+  await expect(row).toContainText("Biodomes");
+  await expect(row).toContainText("Required");
+});
+
+test("a yield range shows both bounds, never the optimistic one alone", async ({
+  page,
+}) => {
+  /*
+   * The domain sized `plants` on the pessimistic bound. A card presenting 30
+   * as the planning figure describes a build that does not work.
+   */
+  const yieldFigure = page.locator(`${FULL} [data-row="farm"] .card-figure`, {
+    hasText: "Yield/plant",
+  });
+  await expect(yieldFigure).toContainText("20");
+  await expect(yieldFigure).toContainText("30");
+});
+
+test("a byproduct-covered demand is a row, marked as needing nothing built", async ({
+  page,
+}) => {
+  const row = page.locator(`${FULL} [data-row="no-build"]`);
+  await expect(row).toHaveCount(1);
+  await expect(row).toContainText("Condensed Carbon");
+  await expect(row).toContainText("200");
+  await expect(row).toContainText("Gas refine byproduct");
+  // A word, not a colour: the distinction has to survive not seeing it.
+  await expect(row).toContainText("Nothing to build");
+});
+
+test("the selection control is a real control, not a div with a tab index", async ({
+  page,
+}) => {
+  const control = page.locator(`${FULL} .card-select`);
+  await expect(control).toHaveRole("button");
+  await expect(control).toHaveAttribute("aria-pressed", "true");
+  // Reachable by keyboard because it is a button, not because of a tabindex.
+  await expect(control).not.toHaveAttribute("tabindex", /.*/);
+});
+
+test("the card is identifiable by name with colour removed entirely", async ({
+  page,
+}) => {
+  /*
+   * SPEC-0005 forbids colour carrying a distinction alone, and SPEC-0007
+   * makes the name the primary identifier. Stripping every colour in the
+   * document is the only way to assert the name is doing the work.
+   */
+  await page.addStyleTag({
+    content:
+      "*, *::before, *::after { color: inherit !important;" +
+      " border-color: currentColor !important; background: none !important; }",
+  });
+  await expect(page.locator(`${FULL} .card-name`)).toContainText("Verdant Shelf");
+  await expect(page.locator(`${SPARSE} .card-name`)).toContainText("Rime Outpost");
+});
+
+test("selection leaves the identity frame intact and rings inboard", async ({ page }) => {
+  const card = page.locator(FULL);
+  await expect(card).toHaveAttribute("data-selected", "true");
+  await expect(card).toHaveClass(/identity/);
+  await expect(card).toHaveClass(/selectable/);
+
+  const ring = await card.evaluate((el) => {
+    const after = getComputedStyle(el, "::after");
+    return { width: after.borderTopWidth, style: after.borderTopStyle };
+  });
+  expect(ring.style).toBe("solid");
+  expect(ring.width).not.toBe("0px");
+});
+
+test("a base with no identity slot says so rather than inventing one", async ({
+  page,
+}) => {
+  const card = page.locator(SPARSE);
+  await expect(card).toHaveClass(/identity-unassigned/);
+  // The dashed frame AND the badge. base.css: never the frame alone.
+  await expect(card.locator(".status-badge")).toContainText("Unassigned");
+});

--- a/web/tests/card/discipline.spec.ts
+++ b/web/tests/card/discipline.spec.ts
@@ -1,0 +1,67 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+import { numericConversions } from "../helpers/source-checks";
+
+/*
+ * Governing: SPEC-0007 REQ "Card Composition From the Build Payload",
+ * SPEC-0005 REQ "The View Computes No Domain Values"
+ *
+ * "No quantity-divided-by-rate appears anywhere in the card's source —
+ * checkable mechanically, the way tests/boundary/discipline.spec.ts already
+ * checks the boundary."
+ *
+ * This is the same claim about an absence that the boundary's suite makes,
+ * so it runs the same checker rather than a second copy of it: a rule
+ * enforced by two regexes drifts the moment one is improved. What differs is
+ * the directory and the extension — the card is .tsx, and the boundary's
+ * scan is .ts only.
+ *
+ * The temptation this catches is specific and real. A farm row carries both
+ * `required` and `yieldPerPlant`, so `required / yieldPerPlant.min` looks
+ * like the plant count and is not: SPEC-0007 requires the domain's `plants`
+ * "even where both are present in the payload", because the engine sizes on
+ * the pessimistic bound and rounds where the domain says to round.
+ */
+
+const CARD = path.join(import.meta.dirname, "..", "..", "src", "card");
+
+function cardSources(): { file: string; source: string }[] {
+  return readdirSync(CARD)
+    .filter((name) => name.endsWith(".ts") || name.endsWith(".tsx"))
+    .map((name) => ({
+      file: name,
+      source: readFileSync(path.join(CARD, name), "utf8"),
+    }));
+}
+
+test("there are card sources to check", () => {
+  /*
+   * Every assertion below is vacuously satisfied by an empty directory.
+   * This separates "the card does no arithmetic" from "nothing was read".
+   */
+  const files = cardSources().map(({ file }) => file);
+  expect(files.length).toBeGreaterThan(0);
+  expect(files).toContain("BasePlannerCard.tsx");
+});
+
+test("no card source converts a quantity to a number or rounds one", () => {
+  const findings = cardSources().flatMap(({ file, source }) =>
+    numericConversions(file, source),
+  );
+  expect(findings).toEqual([]);
+});
+
+test("the checker still catches the mistake it exists to catch", () => {
+  /*
+   * The negative control. A checker that returned an empty array
+   * unconditionally passes the assertion above and fails this one, which is
+   * the only way to tell a working check from one that has quietly stopped
+   * matching. The snippet is the exact error: deriving a plant count from a
+   * required quantity and a yield.
+   */
+  const broken = `const plants = Math.ceil(Number(row.required) / Number(row.yieldPerPlant.min));`;
+  expect(numericConversions("broken.tsx", broken).length).toBeGreaterThan(0);
+});

--- a/web/tests/fixtures/card-harness.tsx
+++ b/web/tests/fixtures/card-harness.tsx
@@ -1,0 +1,157 @@
+/*
+ * Renders the real card against a payload shaped like the boundary's.
+ *
+ * Governing: SPEC-0007 REQ "Card Composition From the Build Payload",
+ * REQ "Producer Sections", REQ "Byproducts Are Shown, Not Omitted"
+ *
+ * The fixture builds a BaseBuild rather than reaching through the WASM
+ * boundary: this suite is about what the card does with a payload, and
+ * driving the engine to produce three kitchen steps at one base would test
+ * the engine's scheduling as much as the card's rendering. The shape is the
+ * boundary's own exported type, so a payload change that breaks the card
+ * fails to compile here rather than passing against a private copy.
+ *
+ * `full` carries all four groups, three kitchen steps — the overcount case —
+ * and a byproduct-covered demand. `sparse` carries one group and no identity
+ * slot, which is the only way to tell an absent section from an empty one.
+ */
+
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { asQuantity, type BaseBuild, type Quantity } from "../../src/boundary";
+import { BasePlannerCard } from "../../src/card/BasePlannerCard";
+
+import "../../src/styles/tokens.css";
+import "../../src/styles/base.css";
+import "../../src/styles/shell.css";
+import "../../src/styles/card.css";
+
+/** Exact strings in, exact strings out. A bad literal fails the fixture loudly. */
+function exact(value: string): Quantity {
+  const quantity = asQuantity(value);
+  if (quantity === null) throw new Error(`fixture quantity is not exact: ${value}`);
+  return quantity;
+}
+
+const full: BaseBuild = {
+  base: "Verdant Shelf",
+  site: { extractorClass: "C", fillSeconds: exact("3600") },
+  farms: [
+    {
+      itemId: "starbulb",
+      name: "Star Bulb",
+      required: exact("480"),
+      plants: exact("24"),
+      biodomes: exact("2"),
+      yieldPerPlant: { min: exact("20"), max: exact("30") },
+      growthSeconds: exact("1800"),
+      verified: true,
+    },
+  ],
+  extractors: [
+    {
+      itemId: "dihydrogen",
+      name: "Di-hydrogen",
+      class: "C",
+      required: exact("1250"),
+      extractorCount: exact("3"),
+      depots: exact("2"),
+      ratePerSecond: exact("1/4"),
+      fillSeconds: exact("3600"),
+      verified: true,
+    },
+  ],
+  ranches: [
+    {
+      itemId: "creaturepellets",
+      name: "Livestock Unit",
+      required: exact("60"),
+      fauna: exact("4"),
+      cycleSeconds: exact("900"),
+      verified: true,
+    },
+  ],
+  /* Three steps, one base. The count that must not be summed. */
+  kitchen: [
+    {
+      itemId: "creamysauce",
+      name: "Creamy Sauce",
+      recipe: "milk",
+      required: exact("30"),
+      processSeconds: exact("300"),
+      final: false,
+      verified: true,
+      inputs: [{ itemId: "milk", perOutput: exact("1") }],
+    },
+    {
+      itemId: "sweetenedcream",
+      name: "Sweetened Cream",
+      recipe: "sugar",
+      required: exact("20"),
+      processSeconds: exact("300"),
+      final: false,
+      verified: true,
+      inputs: [{ itemId: "creamysauce", perOutput: exact("1") }],
+    },
+    {
+      itemId: "cakeslice",
+      name: "Cake Slice",
+      recipe: "bake",
+      required: exact("10"),
+      processSeconds: exact("600"),
+      final: true,
+      verified: true,
+      inputs: [{ itemId: "sweetenedcream", perOutput: exact("2") }],
+    },
+  ],
+  /* Base-level. Rendered once even though the kitchen carries three steps. */
+  nutrientProcessors: exact("2"),
+  pelletFeeders: exact("1"),
+  noBuild: [
+    {
+      itemId: "condensedcarbon",
+      name: "Condensed Carbon",
+      from: "Gas refine byproduct",
+      required: exact("200"),
+      verified: true,
+    },
+  ],
+  verified: true,
+};
+
+/* One group only, and no identity slot. */
+const sparse: BaseBuild = {
+  base: "Rime Outpost",
+  site: { extractorClass: "A", fillSeconds: exact("1800") },
+  farms: [],
+  extractors: [
+    {
+      itemId: "cobalt",
+      name: "Cobalt",
+      class: "A",
+      required: exact("500"),
+      extractorCount: exact("1"),
+      depots: exact("1"),
+      ratePerSecond: exact("1/2"),
+      fillSeconds: exact("1800"),
+      verified: true,
+    },
+  ],
+  ranches: [],
+  kitchen: [],
+  nutrientProcessors: exact("0"),
+  pelletFeeders: exact("0"),
+  noBuild: [],
+  verified: true,
+};
+
+const root = document.getElementById("root");
+if (!root) throw new Error("card.html is missing #root");
+
+createRoot(root).render(
+  <StrictMode>
+    <BasePlannerCard base={full} identity={2} selected={true} />
+    <BasePlannerCard base={sparse} />
+  </StrictMode>,
+);

--- a/web/tests/fixtures/card.html
+++ b/web/tests/fixtures/card.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Base planner card fixture</title>
+  </head>
+  <body>
+    <!--
+      Governing: SPEC-0007 REQ "Card Composition From the Build Payload",
+      REQ "Base Identity and Selection", REQ "Producer Sections",
+      REQ "Byproducts Are Shown, Not Omitted"
+
+      Two bases through the real component: one carrying all four producer
+      groups, three kitchen steps and a byproduct-covered demand, and one
+      carrying a single group and no identity slot. The second is what
+      separates "an absent group is absent" from "an absent group renders
+      empty", which no assertion on the first base can distinguish.
+    -->
+    <div id="root"></div>
+    <script type="module" src="./card-harness.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #96
Part of #94

Implements SPEC-0007 REQ "Card Composition From the Build Payload", REQ "Base Identity and Selection", REQ "Producer Sections", REQ "Byproducts Are Shown, Not Omitted".

## What this adds

`src/card/BasePlannerCard.tsx` renders one base's construction instructions from the stage 2 payload #95 made reachable, plus `src/card/sections.ts`, `src/styles/card.css`, a fixture, and two test files. 835 lines, no existing file modified.

## The four requirements, and the case that catches each

**Every count is the domain's.** A farm row carries both `required` and `yieldPerPlant`, so `required / yieldPerPlant.min` looks like the plant count and is not — SPEC-0007 requires the domain's `plants` *"even where both are present in the payload"*, because the engine sizes on the pessimistic bound. `tests/card/discipline.spec.ts` asserts that absence mechanically, the way the acceptance criteria asked for. It **reuses `numericConversions` from `tests/helpers/source-checks.ts`** rather than writing a second checker: a rule enforced by two regexes drifts the moment one is improved. It carries a negative control, so a checker that stops matching fails there rather than passing forever.

**Base-level counts stay base-level.** `nutrientProcessors` and `pelletFeeders` render once, on the section that owns them, never inside a row. The fixture gives one base **three kitchen steps** because that is the only case that catches a per-row sum — with one step, a summed figure and a base-level figure agree.

**A group absent from the payload is absent, not empty.** The fixture carries a second base with extractors only. An implementation rendering every group unconditionally passes the all-four test and fails this one, which is the entire reason that base exists.

**Byproducts are shown.** `noBuild` rows render with demand and what covers them, marked "Nothing to build" — a word, not a colour, since the distinction has to survive not seeing it.

## Selection and identity

The selection control is a real `<button aria-pressed>`. A `div` with `tabIndex` fails the criterion even when it behaves correctly. The 3px identity frame and the inboard overlay ring are SPEC-0005's and already on main — this uses them and rebuilds neither, and a test asserts the frame survives selection.

Base identity metadata still has no source, which SPEC-0007's overview names. The card takes an identity slot as a prop rather than inventing one; absent a slot it says so with a dashed frame **and** a badge, since colour may not carry a distinction alone.

## Scope note: sibling PR #124

#124 (issue #85, tree canvas) has open claims on `App.tsx`, `AppShell.tsx`, `package.json` and `mutation-check.sh`. Rather than contend for them, the card mounts through its own fixture the way `StatusBadge` does, and touches none of the four. Wiring it into the shell belongs with the panel that arranges cards, which SPEC-0007 explicitly puts out of scope and which has no spec yet. This PR and #124 should merge in either order without a rebase.

Provenance display is left to #99, which owns it.

## Validation

Run against `e04a04a`:

- `npm run typecheck`, `lint`, `lint:css`, `format:check`, `check:tokens` — all clean
- `npm test` — **214 passed**, including the 13 new card tests and the `card.css` token/inset-box-shadow checks that `stylesheet.spec.ts` picks up by directory scan without being told the file exists
- `npm run test:mutation` — every mutation still turns the suite red

One caveat on the local run: this container ships Chromium build 1194 and `@playwright/test` 1.57 expects 1234, so the browser path was bridged in the container to let the repo's own config run unmodified. No repo file encodes that — CI installs its own browser normally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsufroW5o7HXQ46hpnZvQa)_