### PR TITLE
feat(web): site and power configuration

### DIFF
--- a/web/src/card/BasePlannerCard.tsx
+++ b/web/src/card/BasePlannerCard.tsx
@@ -7,11 +7,14 @@ import {
   type FarmRow,
   type KitchenStep,
   type NoBuildRow,
+  type PowerBudget,
   type Quantity,
   type RanchRow,
 } from "../boundary";
 import { StatusBadge } from "../shell/StatusBadge";
 
+import { CardControls } from "./CardControls";
+import type { CardConfiguration } from "./configuration";
 import { PRODUCER_HEADING, presentKinds, type ProducerKind } from "./sections";
 
 /*
@@ -50,6 +53,15 @@ export interface BasePlannerCardProps {
   readonly identity?: IdentitySlot;
   readonly selected?: boolean;
   readonly onSelect?: (base: string) => void;
+  /*
+   * Configuration is optional so the card still renders against a payload
+   * alone. SPEC-0007 REQ "Absent Data Is Absent" requires the card render
+   * "using only the plan payloads and the base identifier", and a card that
+   * needed a configuration to draw would make that false.
+   */
+  readonly configuration?: CardConfiguration;
+  readonly onConfigure?: (next: CardConfiguration) => void;
+  readonly budget?: PowerBudget | undefined;
 }
 
 /** Digits grouped, magnitude untouched. The only formatting SPEC-0005 permits. */
@@ -183,6 +195,9 @@ export function BasePlannerCard({
   identity,
   selected = false,
   onSelect,
+  configuration,
+  onConfigure,
+  budget,
 }: BasePlannerCardProps): ReactNode {
   const kinds = presentKinds(base);
   const identityClass =
@@ -216,6 +231,14 @@ export function BasePlannerCard({
           <StatusBadge status="warning" detail="no identity assigned" />
         ) : null}
       </header>
+
+      {configuration !== undefined && onConfigure !== undefined ? (
+        <CardControls
+          configuration={configuration}
+          onConfigure={onConfigure}
+          budget={budget}
+        />
+      ) : null}
 
       {kinds.map((kind) => (
         <section className="card-section" key={kind} data-section={kind}>

--- a/web/src/card/CardControls.tsx
+++ b/web/src/card/CardControls.tsx
@@ -1,0 +1,215 @@
+import { useId, type ReactNode } from "react";
+
+import { formatQuantity, type PowerBudget } from "../boundary";
+
+import {
+  HOTSPOT_CLASSES,
+  WEAKEST_CLASS,
+  hasSolar,
+  withEmClass,
+  withEmGenerators,
+  withExtractorClass,
+  withFillSeconds,
+  withSolarPanels,
+  type CardConfiguration,
+} from "./configuration";
+
+/*
+ * The card's two configuration surfaces.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0007 REQ "Site Configuration",
+ * REQ "Power Configuration Supports Mixed Sources", SPEC-0005 REQ "Component
+ * Styling Discipline", Accessibility Requirements
+ *
+ * Both are per-card. The extractor class is a site control and not a row one
+ * because extractors at one base share a hotspot: a per-row class would let
+ * the view express a configuration the domain cannot model, and the card
+ * would then be showing a plan the engine would never produce.
+ *
+ * Every change here goes out through `onConfigure` and comes back as new
+ * payload. Nothing adjusts a count, a fill time or a draw figure in place —
+ * SPEC-0005 forbids the arithmetic, and #82's frozen ResultCache would throw
+ * rather than let an in-place edit pass quietly.
+ *
+ * The controls follow ViewPreferences' idiom: a real labelled input per
+ * value, `.control` for the scale, `.interactive` for the hover and focus
+ * treatments. Nothing here re-implements a focus ring.
+ */
+
+export interface CardControlsProps {
+  readonly configuration: CardConfiguration;
+  readonly onConfigure: (next: CardConfiguration) => void;
+  /** Stage 3's answer for this base, where one has been computed. */
+  readonly budget?: PowerBudget | undefined;
+}
+
+/** A class picker. Extractors and generators pick from the same domain set. */
+function ClassSelect({
+  label,
+  value,
+  onPick,
+  testid,
+}: {
+  label: string;
+  value: string;
+  onPick: (next: string) => void;
+  testid: string;
+}): ReactNode {
+  const id = useId();
+  return (
+    <div className="control-row-sm">
+      <label htmlFor={id}>{label}</label>
+      <select
+        id={id}
+        className="control control-sm interactive"
+        data-testid={testid}
+        value={value}
+        onChange={(event) => {
+          onPick(event.target.value);
+        }}
+      >
+        {HOTSPOT_CLASSES.map((cls) => (
+          <option key={cls} value={cls}>
+            {cls}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+/*
+ * A count entry.
+ *
+ * The value crosses as an exact string and is validated by `asQuantity` in
+ * the updater, which returns null rather than coercing. A rejected entry
+ * leaves the configuration alone: the control holds what the player typed
+ * and no boundary call goes out for a value the engine would refuse.
+ */
+function QuantityEntry({
+  label,
+  value,
+  onEnter,
+  testid,
+}: {
+  label: string;
+  value: string;
+  onEnter: (raw: string) => void;
+  testid: string;
+}): ReactNode {
+  const id = useId();
+  return (
+    <div className="control-row-sm">
+      <label htmlFor={id}>{label}</label>
+      <input
+        id={id}
+        type="number"
+        min="0"
+        step="1"
+        inputMode="numeric"
+        className="control control-sm interactive card-entry"
+        data-testid={testid}
+        value={value}
+        onChange={(event) => {
+          onEnter(event.target.value);
+        }}
+      />
+    </div>
+  );
+}
+
+export function CardControls({
+  configuration,
+  onConfigure,
+  budget,
+}: CardControlsProps): ReactNode {
+  const { site, power } = configuration;
+
+  /** Applies an updater that may reject the entry. */
+  const apply = (next: CardConfiguration | null): void => {
+    if (next !== null) onConfigure(next);
+  };
+
+  return (
+    <div className="card-config">
+      <fieldset className="card-fieldset" data-config="site">
+        <legend className="label">Site</legend>
+        {/*
+          One class control for the whole card. A base with three extractor
+          rows has exactly one of these, and no row carries its own.
+        */}
+        <ClassSelect
+          label="Extractor class"
+          value={site.extractorClass}
+          testid="extractor-class"
+          onPick={(cls) => {
+            onConfigure(withExtractorClass(configuration, cls));
+          }}
+        />
+        {/*
+          Exposed, not implied. Extractor counts are sized to this duration,
+          and a count shown without the patience it assumes is not something
+          a player can act on.
+        */}
+        <QuantityEntry
+          label="Fill duration (s)"
+          value={site.fillSeconds}
+          testid="fill-seconds"
+          onEnter={(raw) => {
+            apply(withFillSeconds(configuration, raw));
+          }}
+        />
+      </fieldset>
+
+      <fieldset className="card-fieldset" data-config="power">
+        <legend className="label">Generation</legend>
+        {/*
+          Three independent values, not a mode switch. A base may run
+          electromagnetic generators and solar panels together, and the
+          domain computes that; an EM-or-solar toggle cannot express it.
+        */}
+        <QuantityEntry
+          label="EM generators"
+          value={power.emGenerators ?? ""}
+          testid="em-generators"
+          onEnter={(raw) => {
+            apply(withEmGenerators(configuration, raw));
+          }}
+        />
+        <ClassSelect
+          label="Generator class"
+          value={power.emClass ?? WEAKEST_CLASS}
+          testid="em-class"
+          onPick={(cls) => {
+            onConfigure(withEmClass(configuration, cls));
+          }}
+        />
+        <QuantityEntry
+          label="Solar panels"
+          value={power.solarPanels ?? ""}
+          testid="solar-panels"
+          onEnter={(raw) => {
+            apply(withSolarPanels(configuration, raw));
+          }}
+        />
+        {/*
+          No solar class control, anywhere. The domain's solar output is
+          classless and a picker here would imply a computation it does not
+          perform. There is also no field to write one into.
+
+          Batteries are the domain's count for night coverage, shown because
+          solar is configured and read from the payload rather than derived
+          from the panel count.
+        */}
+        {hasSolar(configuration) && budget !== undefined ? (
+          <p className="card-batteries">
+            <span className="card-figure-label">Batteries</span>{" "}
+            <span className="card-figure-value mono" data-testid="batteries">
+              {formatQuantity(budget.batteries)}
+            </span>
+          </p>
+        ) : null}
+      </fieldset>
+    </div>
+  );
+}

--- a/web/src/card/configuration.ts
+++ b/web/src/card/configuration.ts
@@ -1,0 +1,103 @@
+/*
+ * One base's configuration: its site, and its generation setup.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0007 REQ "Site Configuration",
+ * REQ "Power Configuration Supports Mixed Sources", SPEC-0005 REQ "The View
+ * Computes No Domain Values"
+ *
+ * Both shapes are the boundary's own request types, re-exported rather than
+ * redefined: `SiteConfig` and `PowerGeneration` already exist in
+ * src/boundary/requests.ts, and a second copy here would be one refactor away
+ * from disagreeing with the wire format the engine reads.
+ *
+ * `PowerGeneration` carries `emGenerators`, `emClass` and `solarPanels` as
+ * three independent optional fields, which is the whole of REQ "Power
+ * Configuration Supports Mixed Sources" expressed in a type: a base running
+ * both sources is representable, and there is no field in which a mode could
+ * be recorded. The prototype's EM-or-solar toggle could not express it, and
+ * the handoff's own open questions concede the point.
+ *
+ * Nothing in this module reads a quantity's value. Configuration is carried,
+ * not computed.
+ */
+
+import { asQuantity, type PowerGeneration, type SiteConfig } from "../boundary";
+
+/**
+ * The hotspot classes the domain accepts, weakest first.
+ *
+ * `internal/domain/rollup.go` defines C, B, A and S and rejects anything
+ * else. Exported so a test enumerates the set rather than sampling it, and so
+ * the extractor and generator controls offer the same list — they are the
+ * same `HotspotClass` on the Go side, and two lists here would drift.
+ */
+export const WEAKEST_CLASS = "C";
+export const HOTSPOT_CLASSES: readonly string[] = [WEAKEST_CLASS, "B", "A", "S"];
+
+export interface CardConfiguration {
+  readonly site: SiteConfig;
+  readonly power: PowerGeneration;
+}
+
+/*
+ * The updaters below return a new configuration and never mutate one. Each
+ * takes the raw control value as a string and validates it through
+ * `asQuantity`, which parses without arithmetic: an exact string passes
+ * through unchanged and anything else is rejected rather than coerced.
+ */
+
+export function withExtractorClass(
+  configuration: CardConfiguration,
+  extractorClass: string,
+): CardConfiguration {
+  return { ...configuration, site: { ...configuration.site, extractorClass } };
+}
+
+/** Returns null when the entry is not an exact quantity, so the caller can hold. */
+export function withFillSeconds(
+  configuration: CardConfiguration,
+  raw: string,
+): CardConfiguration | null {
+  const fillSeconds = asQuantity(raw);
+  if (fillSeconds === null) return null;
+  return { ...configuration, site: { ...configuration.site, fillSeconds } };
+}
+
+export function withEmClass(
+  configuration: CardConfiguration,
+  emClass: string,
+): CardConfiguration {
+  return { ...configuration, power: { ...configuration.power, emClass } };
+}
+
+export function withEmGenerators(
+  configuration: CardConfiguration,
+  raw: string,
+): CardConfiguration | null {
+  const emGenerators = asQuantity(raw);
+  if (emGenerators === null) return null;
+  return { ...configuration, power: { ...configuration.power, emGenerators } };
+}
+
+export function withSolarPanels(
+  configuration: CardConfiguration,
+  raw: string,
+): CardConfiguration | null {
+  const solarPanels = asQuantity(raw);
+  if (solarPanels === null) return null;
+  return { ...configuration, power: { ...configuration.power, solarPanels } };
+}
+
+/*
+ * Solar has no `withSolarClass`, and its absence is the requirement rather
+ * than an omission: "Solar MUST NOT be presented as carrying a class. The
+ * domain's solar output is classless, and offering a class control for it
+ * would imply a computation it does not perform." There is no field on
+ * PowerGeneration to write one into either, so the rule is kept by the shape
+ * and not only by the control set.
+ */
+
+/** True where the player has configured any solar at this base. */
+export function hasSolar(configuration: CardConfiguration): boolean {
+  return configuration.power.solarPanels !== undefined;
+}

--- a/web/src/card/useConfiguredBase.ts
+++ b/web/src/card/useConfiguredBase.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { Curated, PowerRequest, RollupRequest } from "../boundary";
+
+import type { CardConfiguration } from "./configuration";
+
+/*
+ * Configuration in, recomputation out.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0007 REQ "Site Configuration",
+ * REQ "Power Configuration Supports Mixed Sources", SPEC-0005 REQ "The View
+ * Computes No Domain Values", REQ "Boundary Client"
+ *
+ * SPEC-0007: "Changing either MUST recompute through the boundary. The card
+ * MUST NOT adjust counts, fill times or power draw itself." This hook is
+ * where that is true or not — it holds the configuration, and every change
+ * to it issues stage 2 and stage 3 calls rather than editing a figure the
+ * previous call returned.
+ *
+ * Both stages go out together on every change, and neither is skipped on the
+ * grounds that a change "only affects" one of them. The extractor class
+ * resizes extractor counts (stage 2) and their draw (stage 3); a generator
+ * count moves generation (stage 3) while leaving the build alone. Deciding
+ * per-field which stage to re-run would be the view reasoning about the
+ * domain's dependency graph, and getting it wrong shows up as a stale figure
+ * rather than as an error.
+ *
+ * Out-of-order completion is handled the way usePlanResolution handles it:
+ * each dispatch takes a sequence number and a late reply for a superseded
+ * configuration is dropped. Without it, typing in the fill-duration entry
+ * settles on whichever call the module happened to finish last.
+ */
+
+export interface ConfiguredBase {
+  readonly configuration: CardConfiguration;
+  readonly configure: (next: CardConfiguration) => void;
+  /** How many boundary round-trips this hook has dispatched. */
+  readonly dispatches: number;
+}
+
+/*
+ * Only the two stages this hook issues.
+ *
+ * Narrower than BoundaryClient on purpose: the hook needs no readiness, no
+ * subscription and no resolve, and depending on the whole client would make
+ * it untestable without a running WASM module. `BoundaryClient` satisfies
+ * this structurally, so production passes the real one and nothing adapts.
+ */
+export interface RecomputeClient {
+  rollup: (request: RollupRequest) => Promise<unknown>;
+  power: (request: PowerRequest) => Promise<unknown>;
+}
+
+export interface ConfiguredBaseOptions {
+  readonly client: RecomputeClient;
+  readonly base: string;
+  readonly initial: CardConfiguration;
+  readonly constants: Curated;
+  /** The plan stage 2 is computed against. */
+  readonly plan: RollupRequest["plan"];
+}
+
+export function useConfiguredBase({
+  client,
+  base,
+  initial,
+  constants,
+  plan,
+}: ConfiguredBaseOptions): ConfiguredBase {
+  const [configuration, setConfiguration] = useState<CardConfiguration>(initial);
+  const [dispatches, setDispatches] = useState(0);
+  const sequence = useRef(0);
+
+  const configure = useCallback((next: CardConfiguration) => {
+    setConfiguration(next);
+  }, []);
+
+  useEffect(() => {
+    const issued = sequence.current + 1;
+    sequence.current = issued;
+
+    const rollup: RollupRequest = {
+      plan,
+      sites: { [base]: configuration.site },
+      constants,
+    };
+    const power: PowerRequest = {
+      sources: { [base]: configuration.power },
+      constants,
+    };
+
+    let live = true;
+    void Promise.all([client.rollup(rollup), client.power(power)]).then(() => {
+      /*
+       * The results are the caller's to render; what this hook owns is the
+       * guarantee that they were asked for. A superseded configuration's
+       * reply is dropped rather than counted, so `dispatches` tracks
+       * settled current calls and not every keystroke in flight.
+       */
+      if (!live || sequence.current !== issued) return;
+      setDispatches((count) => count + 1);
+    });
+
+    return () => {
+      live = false;
+    };
+  }, [client, base, configuration, constants, plan]);
+
+  return { configuration, configure, dispatches };
+}

--- a/web/src/styles/card.css
+++ b/web/src/styles/card.css
@@ -133,3 +133,46 @@
   font-size: var(--text-meta);
   color: var(--text-muted);
 }
+
+/* ----------------------------------------------------------------------
+ * Configuration.
+ *
+ * Governing: SPEC-0007 REQ "Site Configuration", REQ "Power Configuration
+ * Supports Mixed Sources"
+ *
+ * Two fieldsets, laid out and nothing more. The controls inside carry
+ * `.control` for the scale step and `.interactive` for hover and focus, both
+ * from base.css — nothing here writes a state.
+ * ------------------------------------------------------------------- */
+
+.card-config {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.card-fieldset {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin: 0;
+  padding: var(--space-2) var(--space-3) var(--space-3);
+  border: var(--border-width) solid var(--border-soft);
+  border-radius: var(--radius-control);
+}
+
+.card-fieldset legend {
+  padding: 0 var(--space-1);
+  color: var(--text-muted);
+}
+
+/* The number entries share a width so the two fieldsets read as one grid. */
+.card-entry {
+  width: 8ch;
+}
+
+.card-batteries {
+  margin: var(--space-1) 0 0;
+}

--- a/web/tests/card/configuration.spec.ts
+++ b/web/tests/card/configuration.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from "@playwright/test";
+
+/*
+ * Governing: SPEC-0007 REQ "Site Configuration", REQ "Power Configuration
+ * Supports Mixed Sources"
+ *
+ * The two configuration requirements, each tested at the point where a
+ * plausible wrong implementation still looks right. A per-row class control
+ * looks correct on a base with one extractor row; an EM-or-solar toggle looks
+ * correct until a base runs both; a solar class picker looks like symmetry
+ * with the EM control rather than like the computation error it is.
+ */
+
+const FIXTURE = "/tests/fixtures/card-config.html";
+const CARD = '[data-base="Verdant Shelf"]';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(FIXTURE, { waitUntil: "load" });
+});
+
+test("one extractor class control governs a card with three extractor rows", async ({
+  page,
+}) => {
+  await expect(page.locator(`${CARD} [data-row="extractor"]`)).toHaveCount(3);
+  await expect(page.locator(`${CARD} [data-testid="extractor-class"]`)).toHaveCount(1);
+  // And no row carries its own.
+  await expect(page.locator(`${CARD} [data-row="extractor"] select`)).toHaveCount(0);
+});
+
+test("fill duration is exposed, not implied", async ({ page }) => {
+  const fill = page.locator(`${CARD} [data-testid="fill-seconds"]`);
+  await expect(fill).toHaveCount(1);
+  await expect(fill).toHaveValue("3600");
+  await expect(page.getByLabel("Fill duration (s)")).toBeVisible();
+});
+
+test("changing the extractor class issues a boundary call", async ({ page }) => {
+  /*
+   * The baseline is not zero: mounting computes the initial configuration,
+   * which is correct and is not a configuration change. What this asserts is
+   * that a change moves the count, which is the requirement — "changing
+   * either MUST recompute through the boundary".
+   */
+  const before = Number(await page.locator("body").getAttribute("data-rollup-calls"));
+  expect(before).toBeGreaterThan(0);
+
+  await page.locator(`${CARD} [data-testid="extractor-class"]`).selectOption("S");
+
+  await expect(page.locator("body")).toHaveAttribute("data-last-extractor-class", "S");
+
+  /*
+   * Both stages, not one. The class resizes extractor counts in stage 2 and
+   * their draw in stage 3, and deciding per-field which to re-run would be
+   * the view reasoning about the domain's dependency graph.
+   */
+  const rollupAfter = Number(
+    await page.locator("body").getAttribute("data-rollup-calls"),
+  );
+  const powerAfter = Number(await page.locator("body").getAttribute("data-power-calls"));
+  expect(rollupAfter).toBeGreaterThan(before);
+  expect(powerAfter).toBeGreaterThan(0);
+});
+
+test("a base runs electromagnetic generators and solar panels together", async ({
+  page,
+}) => {
+  /*
+   * The case the prototype's toggle cannot represent, and the one most
+   * likely to be lost by building from the design alone.
+   */
+  await page.locator(`${CARD} [data-testid="em-generators"]`).fill("4");
+  await page.locator(`${CARD} [data-testid="solar-panels"]`).fill("12");
+
+  await expect(page.locator(`${CARD} [data-testid="em-generators"]`)).toHaveValue("4");
+  await expect(page.locator(`${CARD} [data-testid="solar-panels"]`)).toHaveValue("12");
+  await expect(page.locator("body")).toHaveAttribute("data-last-solar-panels", "12");
+  // Configuring one did not clear the other.
+  await expect(page.locator(`${CARD} [data-testid="em-class"]`)).toHaveCount(1);
+});
+
+test("no class control is offered for solar, anywhere", async ({ page }) => {
+  await page.locator(`${CARD} [data-testid="solar-panels"]`).fill("12");
+
+  const selects = page.locator(`${CARD} select`);
+  // Exactly two class pickers on the whole card: extractor and generator.
+  await expect(selects).toHaveCount(2);
+  await expect(page.locator(`${CARD} [data-testid="extractor-class"]`)).toHaveCount(1);
+  await expect(page.locator(`${CARD} [data-testid="em-class"]`)).toHaveCount(1);
+
+  const labels = await page.locator(`${CARD} label`).allTextContents();
+  expect(labels.filter((text) => /solar/i.test(text) && /class/i.test(text))).toEqual([]);
+});
+
+test("configuring solar surfaces the domain's battery count", async ({ page }) => {
+  await expect(page.locator(`${CARD} [data-testid="batteries"]`)).toHaveCount(0);
+
+  await page.locator(`${CARD} [data-testid="solar-panels"]`).fill("12");
+
+  const batteries = page.locator(`${CARD} [data-testid="batteries"]`);
+  await expect(batteries).toHaveCount(1);
+  /*
+   * 4 is the payload's figure. 12 panels over the fixture's panelsPerBattery
+   * of 3 is also 4, which is exactly why this assertion is worth stating: the
+   * card must be reading the domain's answer, and the two agree here only
+   * because the stub answers consistently. The discipline test is what rules
+   * out the division; this rules out the number being absent.
+   */
+  await expect(batteries).toHaveText("4");
+});
+
+test("every control is reachable and operable by keyboard", async ({ page }) => {
+  for (const testid of [
+    "extractor-class",
+    "fill-seconds",
+    "em-generators",
+    "em-class",
+    "solar-panels",
+  ]) {
+    const control = page.locator(`${CARD} [data-testid="${testid}"]`);
+    await control.focus();
+    await expect(control).toBeFocused();
+    // Focused because it is a real control, not because of a tabindex.
+    await expect(control).not.toHaveAttribute("tabindex", /.*/);
+  }
+});

--- a/web/tests/fixtures/card-config-harness.tsx
+++ b/web/tests/fixtures/card-config-harness.tsx
@@ -1,0 +1,189 @@
+/*
+ * The card with its controls, wired to a boundary client that records calls.
+ *
+ * Governing: SPEC-0007 REQ "Site Configuration", REQ "Power Configuration
+ * Supports Mixed Sources", SPEC-0005 REQ "The View Computes No Domain Values"
+ *
+ * The acceptance criterion is that every configuration change issues a
+ * boundary call, which is a claim about what the card *asks for* rather than
+ * about what it renders. A real WASM module would answer, but it would also
+ * make the assertion depend on the engine agreeing — so the client here is a
+ * stub that records requests and returns a fixed payload. What is under test
+ * is the card's side of the contract.
+ *
+ * The stub returns the same budget every time on purpose: if the card were
+ * adjusting figures itself, the rendered battery count would drift away from
+ * the payload's while the stub kept answering the same thing.
+ */
+
+import { StrictMode, useEffect, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+
+import {
+  asQuantity,
+  EMPTY_PLAN,
+  type BaseBuild,
+  type Curated,
+  type PowerBudget,
+  type PowerRequest,
+  type Quantity,
+  type RollupRequest,
+} from "../../src/boundary";
+import { BasePlannerCard } from "../../src/card/BasePlannerCard";
+import {
+  useConfiguredBase,
+  type RecomputeClient,
+} from "../../src/card/useConfiguredBase";
+
+import "../../src/styles/tokens.css";
+import "../../src/styles/base.css";
+import "../../src/styles/shell.css";
+import "../../src/styles/card.css";
+
+function exact(value: string): Quantity {
+  const quantity = asQuantity(value);
+  if (quantity === null) throw new Error(`fixture quantity is not exact: ${value}`);
+  return quantity;
+}
+
+const base: BaseBuild = {
+  base: "Verdant Shelf",
+  site: { extractorClass: "C", fillSeconds: exact("3600") },
+  farms: [],
+  extractors: [
+    {
+      itemId: "dihydrogen",
+      name: "Di-hydrogen",
+      class: "C",
+      required: exact("1250"),
+      extractorCount: exact("3"),
+      depots: exact("2"),
+      ratePerSecond: exact("1/4"),
+      fillSeconds: exact("3600"),
+      verified: true,
+    },
+    {
+      itemId: "cobalt",
+      name: "Cobalt",
+      class: "C",
+      required: exact("400"),
+      extractorCount: exact("1"),
+      depots: exact("1"),
+      ratePerSecond: exact("1/2"),
+      fillSeconds: exact("3600"),
+      verified: true,
+    },
+    {
+      itemId: "ferrite",
+      name: "Ferrite Dust",
+      class: "C",
+      required: exact("900"),
+      extractorCount: exact("2"),
+      depots: exact("1"),
+      ratePerSecond: exact("1/3"),
+      fillSeconds: exact("3600"),
+      verified: true,
+    },
+  ],
+  ranches: [],
+  kitchen: [],
+  nutrientProcessors: exact("0"),
+  pelletFeeders: exact("0"),
+  noBuild: [],
+  verified: true,
+};
+
+const budget: PowerBudget = {
+  base: "Verdant Shelf",
+  generation: exact("600"),
+  draw: exact("450"),
+  balance: exact("150"),
+  deficit: exact("0"),
+  inDeficit: false,
+  perGenerator: exact("50"),
+  batteries: exact("4"),
+  additionalGenerators: exact("0"),
+  fixUnsized: false,
+  verified: true,
+};
+
+const constants: Curated = {
+  biodomeCropSlots: exact("12"),
+  faunaYieldPerCycle: exact("3"),
+  faunaCycleSeconds: exact("900"),
+  stepsPerProcessor: exact("3"),
+  depotThreshold: exact("1000"),
+  processSeconds: exact("300"),
+  panelsPerBattery: exact("3"),
+};
+
+/*
+ * A client that records rather than computes.
+ *
+ * The hook under test is the one that turns a configuration change into
+ * stage 2 and stage 3 calls, so what a real module would answer is beside
+ * the point — and depending on one would make this suite need a running
+ * WASM build to assert a call was issued. `RecomputeClient` is the narrow
+ * shape the hook actually needs, which is why a stub is three lines.
+ */
+const calls: { rollup: RollupRequest[]; power: PowerRequest[] } = {
+  rollup: [],
+  power: [],
+};
+
+const recorder: RecomputeClient = {
+  rollup: (request) => {
+    calls.rollup.push(request);
+    return Promise.resolve(null);
+  },
+  power: (request) => {
+    calls.power.push(request);
+    return Promise.resolve(null);
+  },
+};
+
+export function Harness(): ReactNode {
+  const { configuration, configure } = useConfiguredBase({
+    client: recorder,
+    base: base.base,
+    initial: { site: base.site, power: { emClass: "C" } },
+    constants,
+    plan: EMPTY_PLAN,
+  });
+
+  /*
+   * Published in an effect, not during render. Writing to the document while
+   * rendering is a side effect in the render body, which React forbids and
+   * eslint's react-hooks/immutability rule catches.
+   *
+   * The counts include the hook's mount-time call. That call is correct — an
+   * initial configuration has to be computed before anything is shown — so
+   * the tests read a baseline and assert it moves, rather than assuming the
+   * first change is the first call.
+   */
+  useEffect(() => {
+    document.body.dataset["rollupCalls"] = String(calls.rollup.length);
+    document.body.dataset["powerCalls"] = String(calls.power.length);
+    document.body.dataset["lastExtractorClass"] = configuration.site.extractorClass;
+    document.body.dataset["lastSolarPanels"] = configuration.power.solarPanels ?? "";
+  }, [configuration]);
+
+  return (
+    <BasePlannerCard
+      base={base}
+      identity={2}
+      configuration={configuration}
+      budget={budget}
+      onConfigure={configure}
+    />
+  );
+}
+
+const root = document.getElementById("root");
+if (!root) throw new Error("card-config.html is missing #root");
+
+createRoot(root).render(
+  <StrictMode>
+    <Harness />
+  </StrictMode>,
+);

--- a/web/tests/fixtures/card-config.html
+++ b/web/tests/fixtures/card-config.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Base planner card configuration fixture</title>
+  </head>
+  <body>
+    <!--
+      Governing: SPEC-0007 REQ "Site Configuration", REQ "Power Configuration
+      Supports Mixed Sources"
+
+      One base with three extractor rows, so "the class control appears once
+      per card regardless of row count" is checkable rather than assumed.
+    -->
+    <div id="root"></div>
+    <script type="module" src="./card-config-harness.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #97
Part of #94

Implements SPEC-0007 REQ "Site Configuration", REQ "Power Configuration Supports Mixed Sources".

## Site: one class control, not one per row

Extractors at a base share a hotspot, so a per-row class would let the view express a configuration the domain cannot model. The fixture gives one base **three extractor rows** because that is the only arrangement where a per-row implementation and a per-site one differ — with one row, both look correct.

Fill duration is exposed rather than implied. Extractor counts are sized to it, and a count shown without the patience it assumes is not interpretable.

## Power: three values, not a mode

`PowerGeneration` already carried `emGenerators`, `emClass` and `solarPanels` as independent optionals from #95, with a governing comment pointing at this requirement. This PR adds the controls that produce it. A base configured with **both** EM generators and solar panels is a test, not a note — it's the case the prototype's `EM | SOLAR` toggle cannot represent and the one most likely to be lost by building from the design alone.

**Solar carries no class control anywhere**, and there is no field to write one into. The domain's solar output is classless and a picker would imply a computation it does not perform. The test asserts the card has exactly two `<select>` elements total, so adding a third fails rather than going unnoticed.

Where solar is configured the card shows the domain's `batteries`, read from the payload. The test notes that 12 panels over the fixture's `panelsPerBattery` of 3 also happens to be 4 — the discipline scan is what rules out the division; the assertion rules out the figure being absent.

## Recompute, not adjust

`useConfiguredBase` is where *"changing either MUST recompute through the boundary"* is true or not. Every change issues **both** stage 2 and stage 3; neither is skipped on the grounds that a change "only affects" one. Deciding per-field which stage to re-run would be the view reasoning about the domain's dependency graph, and getting it wrong surfaces as a stale figure rather than an error.

It depends on a narrow `RecomputeClient` (`rollup` + `power`) rather than the whole `BoundaryClient`, so the suite asserts a call was issued without needing a running WASM module. `BoundaryClient` satisfies it structurally — production passes the real one and nothing adapts.

Two things the tests get right that a first draft got wrong, both caught locally:
- The baseline call count is **not zero**. Mounting computes the initial configuration, which is correct and is not a configuration change, so the test reads a baseline and asserts it moves.
- Publishing state to the DOM happens in a `useEffect`, not the render body — `react-hooks/immutability` flagged the side effect during render.

## Validation

Run against `6e8ba09`:

- `npm run typecheck`, `lint`, `lint:css`, `format:check`, `check:tokens` — all clean
- `npm test` — **247 passed**, including 7 new configuration tests and the existing discipline scan, which now covers `configuration.ts`, `CardControls.tsx` and `useConfiguredBase.ts` and confirms none converts a quantity to a number
- `npm run test:mutation` — every mutation still turns the suite red

No file outside `src/card`, `src/styles/card.css` and `tests/` is touched. Wiring the card into the shell still belongs with the panel, which SPEC-0007 puts out of scope and which has no spec yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsufroW5o7HXQ46hpnZvQa)_