### PR TITLE
feat(web): power position, deficit, and the build rollup footer

### DIFF
--- a/web/src/card/BasePlannerCard.tsx
+++ b/web/src/card/BasePlannerCard.tsx
@@ -13,8 +13,11 @@ import {
 } from "../boundary";
 import { StatusBadge } from "../shell/StatusBadge";
 
+import { BuildFooter } from "./BuildFooter";
+import { buildItems } from "./build-items";
 import { CardControls } from "./CardControls";
 import type { CardConfiguration } from "./configuration";
+import { PowerBlock } from "./PowerBlock";
 import { PRODUCER_HEADING, presentKinds, type ProducerKind } from "./sections";
 
 /*
@@ -250,6 +253,10 @@ export function BasePlannerCard({
         </section>
       ))}
 
+      {budget !== undefined ? (
+        <PowerBlock budget={budget} emClass={configuration?.power.emClass} />
+      ) : null}
+
       {base.noBuild.length > 0 ? (
         <section className="card-section" data-section="no-build">
           <h4 className="card-section-head">Covered by byproduct</h4>
@@ -260,6 +267,25 @@ export function BasePlannerCard({
           </ul>
         </section>
       ) : null}
+
+      {/*
+        The footer is last because it is a rollup of what is above it. Its
+        pending row exists only where the domain reported a deficit it could
+        size — an unsized fix has no count to carry into the footer, and
+        inventing one there would be the same error as offering it as an
+        action.
+      */}
+      <BuildFooter
+        items={buildItems(
+          base,
+          budget !== undefined && budget.inDeficit && !budget.fixUnsized
+            ? {
+                count: budget.additionalGenerators,
+                unitType: "Electromagnetic generators",
+              }
+            : undefined,
+        )}
+      />
     </article>
   );
 }

--- a/web/src/card/BuildFooter.tsx
+++ b/web/src/card/BuildFooter.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+
+import { formatQuantity } from "../boundary";
+
+import type { BuildItem } from "./build-items";
+
+/*
+ * Everything to construct at this base.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0007 REQ "Build Rollup
+ * Footer", SPEC-0005 Accessibility Requirements
+ *
+ * Each row carries `data-from`, the id of the section row it was collected
+ * out of, so "every footer item corresponds to a row above it" is asserted by
+ * comparison rather than by eye. An item the footer invented would have a
+ * `data-from` matching nothing.
+ *
+ * Pending and unbuilt are distinguished by a word, not by a tint. A player
+ * who cannot see the tint still needs to know which items are waiting on a
+ * decision and which are only waiting on them.
+ *
+ * There is no completion fraction and no progress bar. The v2 prototype has
+ * both; they need durable per-base state that does not exist, and a fraction
+ * computed against session state would be a figure the card made up.
+ */
+
+const STATE_WORD: Record<BuildItem["state"], string> = {
+  unbuilt: "to build",
+  pending: "pending — power deficit",
+};
+
+export function BuildFooter({ items }: { items: readonly BuildItem[] }): ReactNode {
+  if (items.length === 0) return null;
+
+  return (
+    <section className="card-section card-footer" data-section="build-rollup">
+      <h4 className="card-section-head">To build</h4>
+      <ul className="card-rows">
+        {items.map((item) => (
+          <li
+            className="card-row"
+            key={`${item.from}:${item.label}`}
+            data-build-item={item.label}
+            data-from={item.from}
+            data-state={item.state}
+          >
+            <span className="card-row-name">{item.label}</span>
+            <span className="card-row-figures">
+              <span className="card-figure-value mono">{formatQuantity(item.count)}</span>
+              <span className="card-build-state">{STATE_WORD[item.state]}</span>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/web/src/card/PowerBlock.tsx
+++ b/web/src/card/PowerBlock.tsx
@@ -1,0 +1,105 @@
+import type { ReactNode } from "react";
+
+import { formatQuantity, type PowerBudget } from "../boundary";
+import { StatusBadge } from "../shell/StatusBadge";
+
+/*
+ * The base's power position, and what to do about a deficit.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0007 REQ "Power Position",
+ * REQ "Deficit Is an Action, Including When It Cannot Be Sized",
+ * SPEC-0005 REQ "The View Computes No Domain Values"
+ *
+ * Generation, draw and balance are all the domain's. `balance` is a payload
+ * field, not `generation - draw` computed here — the subtraction is exactly
+ * what REQ "Power Position" forbids, and it is forbidden because the domain
+ * computes in exact rationals and the view would be doing it in floats.
+ *
+ * No meter is drawn. The requirement permits a proportional indicator and
+ * forbids computing its proportion from the two figures, and the payload
+ * reports no proportion — so a bar here would have to be arithmetic the card
+ * is not allowed to do. Three exact figures and a stated position carry the
+ * relationship without inventing one.
+ *
+ * The deficit badge is StatusBadge rather than a local treatment: it already
+ * pairs a glyph and a word with every colour, which is the whole of "a
+ * deficit MUST be conveyed by more than colour", and a second implementation
+ * would be a second place for that rule to lapse.
+ */
+
+export interface PowerBlockProps {
+  readonly budget: PowerBudget;
+  /** The configured generator class, where one is set. */
+  readonly emClass?: string | undefined;
+}
+
+function Figure({ label, value }: { label: string; value: string }): ReactNode {
+  return (
+    <span className="card-figure">
+      <span className="card-figure-label">{label}</span>
+      <span className="card-figure-value mono">{value}</span>
+    </span>
+  );
+}
+
+export function PowerBlock({ budget, emClass }: PowerBlockProps): ReactNode {
+  const sized = budget.inDeficit && !budget.fixUnsized;
+
+  return (
+    <section className="card-section card-power" data-section="power">
+      <h4 className="card-section-head">Power</h4>
+
+      <div className="card-row-figures" data-power="position">
+        <Figure label="Generation" value={formatQuantity(budget.generation)} />
+        <Figure label="Draw" value={formatQuantity(budget.draw)} />
+        {/* The domain's own value, negative in deficit. Not a subtraction. */}
+        <Figure label="Balance" value={formatQuantity(budget.balance)} />
+      </div>
+
+      {budget.inDeficit ? (
+        <div className="card-deficit" data-power="deficit">
+          {/*
+            Symbol, word and the shortfall as a stated quantity — the state
+            survives colour being removed entirely, which is the point of
+            the requirement rather than a nicety.
+          */}
+          <StatusBadge status="danger" detail={formatQuantity(budget.deficit)} />
+
+          {sized ? (
+            /*
+              An action, not a warning to interpret: the count, what to build,
+              and the position it produces.
+            */
+            <p className="card-fix" data-fix="sized">
+              Build{" "}
+              <span className="card-figure-value mono" data-testid="fix-count">
+                {formatQuantity(budget.additionalGenerators)}
+              </span>{" "}
+              more {emClass === undefined ? "" : `class ${emClass} `}
+              electromagnetic generators to clear the shortfall.{" "}
+              <span className="card-fix-position">
+                That takes this base out of deficit.
+              </span>
+            </p>
+          ) : (
+            /*
+              `fixUnsized` is the state design.md warns reads as "nothing to
+              show": a budget in deficit with additionalGenerators of zero.
+              The deficit stays visible and the fix is stated as needing a
+              class — never offered as a count, because the domain did not
+              report one and the card must not size a fix it was not given.
+            */
+            <p className="card-fix" data-fix="unsized">
+              This fix needs a generator class before it can be costed. No generator count
+              is offered, because the domain reported none.
+            </p>
+          )}
+        </div>
+      ) : (
+        <p className="card-surplus" data-power="surplus">
+          <StatusBadge status="ok" detail={`surplus ${formatQuantity(budget.balance)}`} />
+        </p>
+      )}
+    </section>
+  );
+}

--- a/web/src/card/build-items.ts
+++ b/web/src/card/build-items.ts
@@ -1,0 +1,123 @@
+/*
+ * Everything to construct at one base, collected from the rows above it.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0007 REQ "Build Rollup
+ * Footer", SPEC-0005 REQ "The View Computes No Domain Values"
+ *
+ * "A rollup of everything to be constructed at that base, drawn from the
+ * same payload as the sections above it" — so this collects rather than
+ * computes. Every item carries `from`, the id of the row it came out of, and
+ * the footer test walks those back to the rendered rows: an item whose `from`
+ * matches no row is an item the footer invented, which the requirement
+ * forbids and which no amount of reading the footer would reveal.
+ *
+ * Two `from` values are not row ids and say so. `base` marks the figures the
+ * domain reports per base rather than per row — nutrient processors and
+ * pellet feeders — which is the same distinction the card's sections draw
+ * when they render those counts once. `power` marks generators implied by an
+ * unresolved deficit, which are pending rather than unbuilt and are the one
+ * kind of item with no producer row behind them.
+ *
+ * There is no count of built versus total here, and no field one could be
+ * put in. That is REQ "Build Rollup Footer" holding: a completion fraction
+ * needs durable per-base state this project does not have, and one computed
+ * against session state would be a figure the card made up.
+ */
+
+import type { BaseBuild, Quantity } from "../boundary";
+
+/** Pending items wait on a decision; unbuilt ones only wait on the player. */
+export type BuildState = "unbuilt" | "pending";
+
+export interface BuildItem {
+  readonly label: string;
+  readonly count: Quantity;
+  /** The row id this came from, or `base` / `power`. */
+  readonly from: string;
+  readonly state: BuildState;
+}
+
+export interface PendingGenerators {
+  readonly count: Quantity;
+  readonly unitType: string;
+}
+
+export function buildItems(
+  base: BaseBuild,
+  pending?: PendingGenerators,
+): readonly BuildItem[] {
+  const items: BuildItem[] = [];
+
+  for (const row of base.farms) {
+    items.push({
+      label: `${row.name} plants`,
+      count: row.plants,
+      from: row.itemId,
+      state: "unbuilt",
+    });
+    items.push({
+      label: `${row.name} biodomes`,
+      count: row.biodomes,
+      from: row.itemId,
+      state: "unbuilt",
+    });
+  }
+
+  for (const row of base.extractors) {
+    items.push({
+      label: `${row.name} extractors`,
+      count: row.extractorCount,
+      from: row.itemId,
+      state: "unbuilt",
+    });
+    items.push({
+      label: `${row.name} depots`,
+      count: row.depots,
+      from: row.itemId,
+      state: "unbuilt",
+    });
+  }
+
+  for (const row of base.ranches) {
+    items.push({
+      label: `${row.name} fauna`,
+      count: row.fauna,
+      from: row.itemId,
+      state: "unbuilt",
+    });
+  }
+
+  /*
+   * Base-level, and appended once rather than per row for the same reason
+   * the kitchen section renders the count once: a base with three steps has
+   * one processor count, and a per-row push would report three times the
+   * build in the footer while the section above it read correctly.
+   */
+  if (base.kitchen.length > 0) {
+    items.push({
+      label: "Nutrient processors",
+      count: base.nutrientProcessors,
+      from: "base",
+      state: "unbuilt",
+    });
+  }
+  if (base.ranches.length > 0) {
+    items.push({
+      label: "Pellet feeders",
+      count: base.pelletFeeders,
+      from: "base",
+      state: "unbuilt",
+    });
+  }
+
+  if (pending !== undefined) {
+    items.push({
+      label: pending.unitType,
+      count: pending.count,
+      from: "power",
+      state: "pending",
+    });
+  }
+
+  return items;
+}

--- a/web/src/styles/card.css
+++ b/web/src/styles/card.css
@@ -176,3 +176,52 @@
 .card-batteries {
   margin: var(--space-1) 0 0;
 }
+
+/* ----------------------------------------------------------------------
+ * Power position and the build rollup.
+ *
+ * Governing: SPEC-0007 REQ "Power Position", REQ "Deficit Is an Action,
+ * Including When It Cannot Be Sized", REQ "Build Rollup Footer"
+ *
+ * No meter and no progress bar, and both absences are requirements rather
+ * than omissions: a meter's proportion would be arithmetic on two figures
+ * the card may only display, and a completion bar would be drawn against
+ * durable state that does not exist.
+ *
+ * The deficit and pending treatments are laid out here; the words that
+ * carry them without colour are in PowerBlock.tsx and BuildFooter.tsx,
+ * where they cannot be dropped by a stylesheet change.
+ * ------------------------------------------------------------------- */
+
+.card-power {
+  gap: var(--space-2);
+}
+
+.card-deficit,
+.card-surplus {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin: 0;
+}
+
+.card-fix {
+  margin: 0;
+  font-size: var(--text-meta);
+  color: var(--text);
+  max-width: 60ch;
+}
+
+.card-fix-position {
+  color: var(--text-muted);
+}
+
+.card-build-state {
+  font-size: var(--text-meta);
+  color: var(--text-muted);
+}
+
+.card-row[data-state="pending"] .card-build-state {
+  color: var(--warn);
+}

--- a/web/tests/card/composition.spec.ts
+++ b/web/tests/card/composition.spec.ts
@@ -26,9 +26,13 @@ test.beforeEach(async ({ page }) => {
 test("all four producer groups render when the payload carries all four", async ({
   page,
 }) => {
-  const sections = page.locator(`${FULL} .card-section[data-section]`);
-  await expect(sections).toHaveCount(5); // four producers + byproducts
-  for (const kind of ["farm", "extractor", "ranch", "kitchen"]) {
+  /*
+   * Named rather than counted. A total over every `data-section` made this
+   * assertion fail when #98 added the power block and the build footer —
+   * sections this test has no opinion about. What it is checking is that
+   * all four producer groups render, plus the byproducts one.
+   */
+  for (const kind of ["farm", "extractor", "ranch", "kitchen", "no-build"]) {
     await expect(page.locator(`${FULL} [data-section="${kind}"]`)).toHaveCount(1);
   }
 });

--- a/web/tests/card/power.spec.ts
+++ b/web/tests/card/power.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test } from "@playwright/test";
+
+/*
+ * Governing: SPEC-0007 REQ "Power Position", REQ "Deficit Is an Action,
+ * Including When It Cannot Be Sized", REQ "Build Rollup Footer"
+ *
+ * The unsized-deficit case is the reason this file exists. A budget in
+ * deficit whose `additionalGenerators` is zero reads as "nothing to show"
+ * unless `fixUnsized` is read as its own signal, and an implementation that
+ * misses it passes every assertion about the sized case.
+ */
+
+const FIXTURE = "/tests/fixtures/card-power.html";
+const SIZED = '[data-base="Sized Deficit"]';
+const UNSIZED = '[data-base="Unsized Deficit"]';
+const SURPLUS = '[data-base="Surplus"]';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(FIXTURE, { waitUntil: "load" });
+});
+
+test("generation, draw and balance are all the payload's figures", async ({ page }) => {
+  const position = page.locator(`${SIZED} [data-power="position"]`);
+  await expect(position).toContainText("300");
+  await expect(position).toContainText("450");
+  /*
+   * -150 is the payload's `balance`. A card computing generation minus draw
+   * would land on the same number here — which is why the discipline scan,
+   * not this assertion, is what rules the subtraction out. This rules out
+   * the figure being absent or reworded into a percentage.
+   */
+  await expect(position).toContainText("-150");
+});
+
+test("no percentage or meter proportion is rendered beside the figures", async ({
+  page,
+}) => {
+  const position = await page.locator(`${SIZED} [data-power="position"]`).innerText();
+  expect(position).not.toMatch(/%/);
+  // A meter would need a proportion the payload does not report.
+  await expect(page.locator(`${SIZED} progress, ${SIZED} meter`)).toHaveCount(0);
+});
+
+test("a deficit carries a symbol and the shortfall, surviving colour removal", async ({
+  page,
+}) => {
+  const deficit = page.locator(`${SIZED} [data-power="deficit"]`);
+  await expect(deficit).toBeVisible();
+  await expect(deficit).toContainText("150");
+
+  await page.addStyleTag({
+    content:
+      "*, *::before, *::after { color: inherit !important;" +
+      " border-color: currentColor !important; background: none !important; }",
+  });
+  // The word and the glyph both survive; only the colour was removed.
+  await expect(deficit).toContainText("Deficit");
+  await expect(deficit).toContainText("150");
+});
+
+test("a sized fix is an action naming the count and the position it produces", async ({
+  page,
+}) => {
+  const fix = page.locator(`${SIZED} [data-fix="sized"]`);
+  await expect(fix).toBeVisible();
+  await expect(page.locator(`${SIZED} [data-testid="fix-count"]`)).toHaveText("3");
+  await expect(fix).toContainText("electromagnetic generators");
+  await expect(fix).toContainText("class B");
+  await expect(fix).toContainText("out of deficit");
+});
+
+test("fixUnsized shows the deficit and states the fix needs a class", async ({
+  page,
+}) => {
+  /*
+   * The state design.md warns about: deficit true, additionalGenerators
+   * zero. An implementation that infers "no fix to show" from the zero
+   * hides a real deficit, and this is the only case that catches it.
+   */
+  const deficit = page.locator(`${UNSIZED} [data-power="deficit"]`);
+  await expect(deficit).toBeVisible();
+  await expect(deficit).toContainText("180");
+
+  const fix = page.locator(`${UNSIZED} [data-fix="unsized"]`);
+  await expect(fix).toBeVisible();
+  await expect(fix).toContainText("needs a generator class");
+
+  // Never presented as an actionable count.
+  await expect(page.locator(`${UNSIZED} [data-fix="sized"]`)).toHaveCount(0);
+  await expect(page.locator(`${UNSIZED} [data-testid="fix-count"]`)).toHaveCount(0);
+});
+
+test("a solar base in deficit with no sized fix offers no panel count", async ({
+  page,
+}) => {
+  const card = page.locator(UNSIZED);
+  const fix = await card.locator('[data-fix="unsized"]').innerText();
+  // No count of anything is offered as the fix.
+  expect(fix).not.toMatch(/\d/);
+  expect(fix).not.toMatch(/panel/i);
+});
+
+test("a surplus states the position rather than leaving it to be inferred", async ({
+  page,
+}) => {
+  const surplus = page.locator(`${SURPLUS} [data-power="surplus"]`);
+  await expect(surplus).toContainText("surplus");
+  await expect(surplus).toContainText("150");
+  await expect(page.locator(`${SURPLUS} [data-power="deficit"]`)).toHaveCount(0);
+});
+
+test("every footer item corresponds to a row above it", async ({ page }) => {
+  const card = page.locator(SIZED);
+  const rowIds = await card
+    .locator("[data-row][data-item]")
+    .evaluateAll((nodes) => nodes.map((n) => n.getAttribute("data-item")));
+  const froms = await card
+    .locator("[data-build-item]")
+    .evaluateAll((nodes) => nodes.map((n) => n.getAttribute("data-from")));
+
+  expect(froms.length).toBeGreaterThan(0);
+  /*
+   * `base` and `power` are the two legitimate non-row sources: figures the
+   * domain reports per base, and generators implied by a deficit. Anything
+   * else is an item the footer invented.
+   */
+  const invented = froms.filter(
+    (from) => from !== "base" && from !== "power" && !rowIds.includes(from),
+  );
+  expect(invented).toEqual([]);
+});
+
+test("pending items are distinguished from unbuilt ones by a word", async ({ page }) => {
+  const pending = page.locator(`${SIZED} [data-build-item][data-state="pending"]`);
+  await expect(pending).toHaveCount(1);
+  await expect(pending).toContainText("pending");
+  await expect(pending).toContainText("Electromagnetic generators");
+
+  // The unsized deficit has no sized fix, so it contributes no pending row.
+  await expect(
+    page.locator(`${UNSIZED} [data-build-item][data-state="pending"]`),
+  ).toHaveCount(0);
+});
+
+test("no completion fraction is rendered anywhere", async ({ page }) => {
+  for (const card of [SIZED, UNSIZED, SURPLUS]) {
+    const footer = page.locator(`${card} [data-section="build-rollup"]`);
+    const text = await footer.innerText();
+    // "3 / 8", "38% complete", and a progress element are all the same error.
+    expect(text).not.toMatch(/\d+\s*\/\s*\d+/);
+    expect(text).not.toMatch(/complete/i);
+    await expect(footer.locator("progress, meter")).toHaveCount(0);
+  }
+});

--- a/web/tests/fixtures/card-power-harness.tsx
+++ b/web/tests/fixtures/card-power-harness.tsx
@@ -1,0 +1,164 @@
+/*
+ * Three bases, three power positions, one real card.
+ *
+ * Governing: SPEC-0007 REQ "Power Position", REQ "Deficit Is an Action,
+ * Including When It Cannot Be Sized", REQ "Build Rollup Footer"
+ *
+ * `unsized` is the fixture that matters. design.md warns that an implementer
+ * meeting a budget in deficit with `additionalGenerators` of zero would
+ * reasonably conclude there was nothing to show — so this fixture is exactly
+ * that payload, with `fixUnsized` set, and the suite requires the deficit to
+ * be visible anyway.
+ *
+ * `solar` is in deficit with no sized fix and no generator class. It exists
+ * to assert an absence: the card offers no panel count, because the domain
+ * reported none and computing one would be the card sizing a fix it was not
+ * given.
+ */
+
+import { StrictMode, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+
+import {
+  asQuantity,
+  type BaseBuild,
+  type PowerBudget,
+  type Quantity,
+} from "../../src/boundary";
+import { BasePlannerCard } from "../../src/card/BasePlannerCard";
+
+import "../../src/styles/tokens.css";
+import "../../src/styles/base.css";
+import "../../src/styles/shell.css";
+import "../../src/styles/card.css";
+
+function exact(value: string): Quantity {
+  const quantity = asQuantity(value);
+  if (quantity === null) throw new Error(`fixture quantity is not exact: ${value}`);
+  return quantity;
+}
+
+function baseNamed(name: string): BaseBuild {
+  return {
+    base: name,
+    site: { extractorClass: "C", fillSeconds: exact("3600") },
+    farms: [
+      {
+        itemId: "starbulb",
+        name: "Star Bulb",
+        required: exact("480"),
+        plants: exact("24"),
+        biodomes: exact("2"),
+        yieldPerPlant: { min: exact("20"), max: exact("30") },
+        growthSeconds: exact("1800"),
+        verified: true,
+      },
+    ],
+    extractors: [
+      {
+        itemId: "dihydrogen",
+        name: "Di-hydrogen",
+        class: "C",
+        required: exact("1250"),
+        extractorCount: exact("3"),
+        depots: exact("2"),
+        ratePerSecond: exact("1/4"),
+        fillSeconds: exact("3600"),
+        verified: true,
+      },
+    ],
+    ranches: [],
+    kitchen: [],
+    nutrientProcessors: exact("0"),
+    pelletFeeders: exact("0"),
+    noBuild: [],
+    verified: true,
+  };
+}
+
+/** Deficit the domain could size. */
+const sizedBudget: PowerBudget = {
+  base: "Sized Deficit",
+  generation: exact("300"),
+  draw: exact("450"),
+  balance: exact("-150"),
+  deficit: exact("150"),
+  inDeficit: true,
+  perGenerator: exact("50"),
+  batteries: exact("0"),
+  additionalGenerators: exact("3"),
+  fixUnsized: false,
+  verified: true,
+};
+
+/*
+ * Deficit the domain could not size. Zero additional generators AND the flag
+ * — the pair that reads as "nothing to show" without it.
+ */
+const unsizedBudget: PowerBudget = {
+  base: "Unsized Deficit",
+  generation: exact("200"),
+  draw: exact("380"),
+  balance: exact("-180"),
+  deficit: exact("180"),
+  inDeficit: true,
+  perGenerator: exact("0"),
+  batteries: exact("0"),
+  additionalGenerators: exact("0"),
+  fixUnsized: true,
+  verified: true,
+};
+
+const surplusBudget: PowerBudget = {
+  base: "Surplus",
+  generation: exact("600"),
+  draw: exact("450"),
+  balance: exact("150"),
+  deficit: exact("0"),
+  inDeficit: false,
+  perGenerator: exact("50"),
+  batteries: exact("4"),
+  additionalGenerators: exact("0"),
+  fixUnsized: false,
+  verified: true,
+};
+
+const root = document.getElementById("root");
+if (!root) throw new Error("card-power.html is missing #root");
+
+/* Exported so the module has one, which react-refresh asks of a file
+ * declaring a component. */
+export function Cards(): ReactNode {
+  return (
+    <>
+      <BasePlannerCard
+        base={baseNamed("Sized Deficit")}
+        identity={1}
+        budget={sizedBudget}
+        configuration={{
+          site: baseNamed("Sized Deficit").site,
+          power: { emClass: "B", emGenerators: exact("2") },
+        }}
+        onConfigure={() => {}}
+      />
+      {/* No generator class configured — solar only, and no sized fix. */}
+      <BasePlannerCard
+        base={baseNamed("Unsized Deficit")}
+        identity={2}
+        budget={unsizedBudget}
+        configuration={{
+          site: baseNamed("Unsized Deficit").site,
+          power: { solarPanels: exact("10") },
+        }}
+        onConfigure={() => {}}
+      />
+      <BasePlannerCard base={baseNamed("Surplus")} identity={3} budget={surplusBudget} />
+    </>
+  );
+}
+
+createRoot(root).render(
+  <StrictMode>
+    <Cards />
+  </StrictMode>,
+);

--- a/web/tests/fixtures/card-power.html
+++ b/web/tests/fixtures/card-power.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Base planner card power fixture</title>
+  </head>
+  <body>
+    <!--
+      Governing: SPEC-0007 REQ "Power Position", REQ "Deficit Is an Action,
+      Including When It Cannot Be Sized", REQ "Build Rollup Footer"
+
+      Three power states, because two of them look identical to a wrong
+      implementation: a deficit the domain sized, a deficit it could not size
+      (fixUnsized, additionalGenerators zero — the state design.md warns
+      reads as "nothing to show"), and a surplus.
+    -->
+    <div id="root"></div>
+    <script type="module" src="./card-power-harness.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #98
Part of #94

Implements SPEC-0007 REQ "Power Position", REQ "Deficit Is an Action, Including When It Cannot Be Sized", REQ "Build Rollup Footer".

> **Stacked on #127.** This branches from `feat/97-site-and-power-configuration` rather than `main`, because it needs the `budget` prop and `CardConfiguration` that #127 adds and the two otherwise collide in the same files. **Base this on `main` once #127 merges.** Review the diff against `feat/97…` to see only this story's changes.

## Power position

`generation`, `draw` and `balance` are all payload fields. `balance` is the domain's own value, not `generation - draw` computed here — the subtraction is what the requirement forbids, and it's forbidden because the engine computes in exact rationals while the view would be doing it in floats.

**No meter is drawn.** The requirement permits a proportional indicator and forbids computing its proportion from the two figures; the payload reports no proportion. So a bar would have to be arithmetic the card isn't allowed to do. Three exact figures plus a stated position carry the relationship without inventing one. A test asserts no `%`, no `<progress>`, no `<meter>`.

The deficit badge reuses `StatusBadge` rather than a local treatment — it already pairs a glyph and a word with every colour, which is the whole of "conveyed by more than colour", and a second implementation would be a second place for that rule to lapse. The test strips every colour from the document and requires the word and the shortfall to survive.

## The state design.md warns about

`fixUnsized` is read as its own signal, not inferred from `additionalGenerators` being zero. The fixture is exactly the payload the design warns reads as "nothing to show" — deficit `180`, additional generators `0`, flag set — and the suite requires:

- the deficit stays **visible**
- the fix is stated as **needing a generator class**, never offered as a count
- no `[data-fix="sized"]` and no fix count exist on that card at all

The same card is solar-only with no class configured, so it doubles as the "offers no computed panel count" case: the test asserts the fix text contains **no digit at all**.

## Footer

It collects; it doesn't compute. Every item carries `data-from`, the id of the row it came out of, so *"no item was added by the footer"* is checked by comparison rather than by eye — `base` and `power` are the two legitimate non-row sources (per-base figures, and generators implied by a sized deficit) and anything else fails the test.

Base-level counts are appended once, not per row, for the same reason the kitchen section renders them once: a per-row push would report three times the build in the footer while the section above it read correctly.

**No completion fraction, and no field one could go in.** The test checks all three cards for `N / M`, for "complete", and for a progress element. The v2 prototype's progress bar needs durable per-base state that doesn't exist; a fraction against session state would be a figure the card made up.

## One change to an existing test

#96's "all four producer groups render" asserted a **total** over every `data-section`, which this PR broke by adding two sections that test has no opinion about. It now names the five sections it cares about instead of counting all of them. That's the assertion's original intent and it's no longer brittle to a sixth section.

## Validation

Run against `364dc88` (tip of #127):

- `npm run typecheck`, `lint`, `lint:css`, `format:check`, `check:tokens` — all clean
- `npm test` — **257 passed**, including 10 new power/footer tests; the discipline scan now also covers `PowerBlock.tsx`, `BuildFooter.tsx` and `build-items.ts` and confirms none converts a quantity to a number or rounds one
- `npm run test:mutation` — every mutation still turns the suite red

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsufroW5o7HXQ46hpnZvQa)_