### PR TITLE
feat(web): the node card — identity, yield, and provenance

### DIFF
--- a/web/scripts/check-tokens.sh
+++ b/web/scripts/check-tokens.sh
@@ -40,6 +40,29 @@ from pathlib import Path
 # file is the one place any of them is allowed.
 PATTERN = re.compile(r"#[0-9a-fA-F]{3,8}\b|\brgba?\(|\bhsla?\(|\boklch\(")
 
+# The other way a colour stops resolving through a token: reaching for a
+# token that is not a colour. `color: var(--text-body)` looks exactly like
+# discipline and is `color: 15px`, which the browser drops on the floor —
+# the element silently inherits and nobody sees a failure. Six of these were
+# live in canvas.css, including one inside a WCAG fix.
+#
+# The type scale is a closed set, so this names it rather than guessing at
+# what is or is not a colour. A token added to that scale belongs here too.
+SIZE_TOKENS = (
+    "text-label",
+    "text-meta",
+    "text-body",
+    "text-emphasis",
+    "text-h3",
+    "text-h2",
+    "text-display",
+    "display-floor",
+)
+COLOUR_PROPERTIES = r"color|background-color|border-color|outline-color|fill|stroke|caret-color|text-decoration-color|column-rule-color"
+MISUSE = re.compile(
+    rf"\b(?:{COLOUR_PROPERTIES})\s*:\s*var\(\s*--(?:{'|'.join(SIZE_TOKENS)})\b"
+)
+
 BLOCK = re.compile(r"/\*.*?\*/", re.S)
 LINE = re.compile(r"^\s*(//|\*)")
 
@@ -61,6 +84,14 @@ def findings(source: str) -> list[tuple[int, str]]:
         (number, line.strip())
         for number, line in enumerate(strip_comments(source).split("\n"), start=1)
         if PATTERN.search(line)
+    ]
+
+
+def misuses(source: str) -> list[tuple[int, str]]:
+    return [
+        (number, line.strip())
+        for number, line in enumerate(strip_comments(source).split("\n"), start=1)
+        if MISUSE.search(line)
     ]
 
 
@@ -89,17 +120,36 @@ CASES: list[tuple[str, str, bool]] = [
     ("a literal after a comment closes", "  /* note */ color: #ff0000;", True),
 ]
 
+# The size-token-in-a-colour-slot check gets its own controls, including the
+# near-misses: a size token in a size slot is correct, and a colour token in
+# a colour slot is the whole point.
+MISUSE_CASES: list[tuple[str, str, bool]] = [
+    ("a size token as a colour", "  color: var(--text-body);", True),
+    ("a size token as a background", "  background-color: var(--text-meta);", True),
+    ("a size token as a border colour", "  border-color: var(--text-label);", True),
+    ("a size token as an SVG fill", "  fill: var(--text-emphasis);", True),
+    ("a size token in a size slot", "  font-size: var(--text-body);", False),
+    ("a colour token in a colour slot", "  color: var(--text);", False),
+    ("a colour token whose name starts the same", "  color: var(--text-bright);", False),
+    ("a muted colour token", "  color: var(--text-muted);", False),
+    ("a size token named in a comment", "/* color: var(--text-body) was wrong */", False),
+]
+
 broken = [
     f"  {name}: expected {'a finding' if want else 'no finding'}"
     for name, source, want in CASES
     if bool(findings(source)) != want
+] + [
+    f"  {name}: expected {'a finding' if want else 'no finding'}"
+    for name, source, want in MISUSE_CASES
+    if bool(misuses(source)) != want
 ]
 
 if broken:
-    print("The colour-literal check cannot see what it is for:")
+    print("The colour checks cannot see what they are for:")
     print("\n".join(broken))
     print()
-    print("Fix the pattern or the comment stripping before trusting a clean run.")
+    print("Fix the patterns or the comment stripping before trusting a clean run.")
     sys.exit(1)
 
 # ----------------------------------------------------------------------
@@ -108,17 +158,23 @@ if broken:
 TOKEN_FILE = Path("src/styles/tokens.css")
 
 offenders: list[str] = []
+misused: list[str] = []
 scanned = 0
 for path in sorted(Path("src").rglob("*")):
     if path.suffix not in {".ts", ".tsx", ".css"} or path == TOKEN_FILE:
         continue
     scanned += 1
-    for number, text in findings(path.read_text()):
+    source = path.read_text()
+    for number, text in findings(source):
         offenders.append(f"{path}:{number}:{text}")
+    for number, text in misuses(source):
+        misused.append(f"{path}:{number}:{text}")
 
 if scanned == 0:
     print("No source files were scanned — the check found nothing to look at.")
     sys.exit(1)
+
+failed = False
 
 if offenders:
     print("Colour literals found outside src/styles/tokens.css:")
@@ -126,7 +182,22 @@ if offenders:
     print()
     print("Add the value to the token file with its design provenance, or")
     print("reference an existing custom property.")
+    failed = True
+
+if misused:
+    if offenders:
+        print()
+    print("Type-scale tokens used as colours (the browser drops these):")
+    print("\n".join(misused))
+    print()
+    print("These look like token discipline and are not — `color: var(--text-body)`")
+    print("is `color: 15px`, which is invalid, so the element silently inherits.")
+    print("Use a colour token: --text, --text-bright, --text-muted, or a state token.")
+    failed = True
+
+if failed:
     sys.exit(1)
 
-print(f"No colour literals outside the token file ({scanned} files, {len(CASES)} self-checks).")
+checks = len(CASES) + len(MISUSE_CASES)
+print(f"No colour literals and no type-scale tokens in colour slots ({scanned} files, {checks} self-checks).")
 PY

--- a/web/scripts/mutation-check.sh
+++ b/web/scripts/mutation-check.sh
@@ -327,10 +327,16 @@ check "edge styling stops distinguishing a refine step" \
 
 # The other half of "no fact lives only in an edge": if the card stops
 # naming the method, the edge's stroke becomes the sole carrier of it.
+#
+# The same breakage as "the method badge loses its word" below, named
+# against a different suite on purpose. That one asks whether the badge
+# still carries a word; this one asks whether the fact an edge's stroke
+# conveys is still text somewhere. Two requirements, one way to break both,
+# and a mutation that only named one of the suites would let the other rot.
 check "the node card stops naming its method" \
   tests/canvas/edges.spec.ts "$CARD" \
-  '<span className="node-method">{node.method}</span>' \
-  '<span className="node-method" />'
+  "      <span>{method}</span>" \
+  "      <span />"
 
 # ----------------------------------------------------------------------
 # The three findings from the review of #124.

--- a/web/scripts/mutation-check.sh
+++ b/web/scripts/mutation-check.sh
@@ -374,6 +374,76 @@ check "a failed layout becomes indistinguishable from an empty one" \
     return new Map();
   }"
 
+# ----------------------------------------------------------------------
+# The node card: identity, yield and provenance.
+#
+# Three of these break a rule that had no way to fail before this story —
+# the card could not be hovered at all, so "hover is a filter" was kept by
+# nobody; and the artifact marks nothing unverified, so the provenance
+# treatment was unreachable from the application.
+# ----------------------------------------------------------------------
+
+check "the method badge loses its glyph" \
+  tests/canvas/node-card.spec.ts "$CARD" \
+  '  raw: "▽",
+  craft: "⚒",
+  refine: "◇",' \
+  '  raw: "",
+  craft: "",
+  refine: "",'
+
+# The other half: the glyph alone is a colour-and-shape carrier with no word.
+check "the method badge loses its word" \
+  tests/canvas/node-card.spec.ts "$CARD" \
+  "      <span>{method}</span>" \
+  "      <span />"
+
+check "a fractional application count is rounded up to a whole operation" \
+  tests/canvas/node-card.spec.ts "$TREE" \
+  "          applicationsDisplay:
+            node.applications === null
+              ? null" \
+  "          applicationsDisplay:
+            node.applications === null
+              ? null
+              : node.applications.includes(\"/\")
+                ? String(Math.ceil(Number(node.applications.split(\"/\")[0]) / Number(node.applications.split(\"/\")[1])))"
+
+check "the recipe yield stops reaching the card" \
+  tests/canvas/node-card.spec.ts "$TREE" \
+  "          yieldDisplay:
+            node.recipeYield === null || node.recipeYield === \"1\"" \
+  "          yieldDisplay:
+            true || node.recipeYield === null || node.recipeYield === \"1\""
+
+# SPEC-0006: the unassigned state must not rest on the border alone.
+check "an unassigned leaf is left with only its dashed border" \
+  tests/canvas/node-card.spec.ts "$CARD" \
+  "        {node.terminal && identity === undefined && (" \
+  "        {false && node.terminal && identity === undefined && ("
+
+# SPEC-0006: the marker "MUST NOT be styled as an error state".
+check "provenance takes the treatment reserved for something to fix" \
+  tests/canvas/node-card.spec.ts "$CANVAS" \
+  "  border: var(--border-width) dashed var(--text-muted); /* 4.72, non-text needs 3.0 */" \
+  "  border: var(--border-width) solid var(--danger);"
+
+# The card was unreachable by pointer until this story; nothing noticed.
+check "the pane goes back to swallowing the pointer" \
+  tests/canvas/node-card.spec.ts "$CANVAS" \
+  "  pointer-events: auto;" \
+  "  pointer-events: none;"
+
+# The border is base identity's and nothing else may write to it.
+check "something other than base identity writes to the card border" \
+  tests/canvas/node-card.spec.ts "$BASE" \
+  ".identity {
+  border: var(--border-width-identity) solid var(--border);
+}" \
+  ".identity {
+  border: var(--border-width) solid var(--border);
+}"
+
 echo
 if [ "$failures" -gt 0 ]; then
   echo "$failures mutation(s) did not turn the suite red. Those rules are unwatched."

--- a/web/src/canvas/NodeCard.tsx
+++ b/web/src/canvas/NodeCard.tsx
@@ -1,45 +1,133 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
+import type { IdentitySlot } from "../card/BasePlannerCard";
+import { StatusBadge } from "../shell/StatusBadge";
 import type { CanvasNode } from "./graph-model";
 
 /*
- * Handles are anchor points the edge renderer needs in the DOM; nothing
- * needs to see them. Hidden here rather than in canvas.css because the
- * override would have to name React Flow's own `react-flow__handle` class,
- * and reaching into a third-party selector to undo its styling is how a
- * stylesheet acquires a dependency on someone else's internals.
- */
-const ANCHOR = Object.freeze({ opacity: 0, border: 0 });
-
-/*
- * One node, as a card.
+ * What a node says about itself.
  *
- * Governing: ADR-0004 (React view layer), SPEC-0006 REQ "Graph Rendering
- * From the Boundary Payload", Accessibility Requirements → Keyboard
- * Navigation, SPEC-0005 REQ "The View Computes No Domain Values"
- *
- * Deliberately minimal. This story renders the graph — identity, yield and
- * provenance are the node-card story's, and the method and recipe controls
- * are their own. What is here is what an edge needs to connect to and what
- * the layout needs to place.
+ * Governing: ADR-0004 (React view layer), SPEC-0006 REQ "Node Card",
+ * REQ "Yield and Application Display", REQ "Provenance Display",
+ * SPEC-0005 REQ "The View Computes No Domain Values", Accessibility
+ * Requirements
  *
  * A `<button>`, so the node is one tab stop. React Flow is mounted with
  * `nodesFocusable={false}` for the same reason: its own wrapper would take
  * a tab stop of its own and every node would cost two.
  *
- * The total is printed as it arrived. `formatQuantity` groups digits and
- * does not parse — SPEC-0005 keeps quantities as exact strings end to end,
- * and this is the last point before a screen.
+ * Every quantity is printed as it arrived. `formatQuantity` groups digits
+ * and does not parse — SPEC-0005 keeps quantities as exact strings end to
+ * end, and this is the last point before a screen.
+ *
+ * The border carries base identity and nothing else. That is the whole
+ * reason SPEC-0005's interaction primitives are shaped the way they are —
+ * hover a filter, focus an outboard outline, selection an overlay ring —
+ * and they are inherited from base.css here rather than restated. A card
+ * that is assigned, hovered, focused and selected at once shows all four,
+ * because only one of them is written with a border.
  */
+
+/** The handles are anchor points for the edge renderer, not controls. */
+const ANCHOR: CSSProperties = { opacity: 0, pointerEvents: "none" };
+
+/*
+ * Method as a glyph and a word, from the design handoff's own set.
+ *
+ * SPEC-0006: "its resolved method as a badge carrying both a glyph and a
+ * text label". The word is the accessible carrier and the glyph is the
+ * visual one, the same division StatusBadge makes — so the glyph is hidden
+ * from assistive technology, which would otherwise read "white down-pointing
+ * triangle".
+ *
+ * A method the payload sends that is not in this table still renders, with
+ * its word and no glyph. The domain's methods are raw, craft and refine
+ * today; a fourth arriving should show up as an unfamiliar badge rather
+ * than as a card that throws.
+ */
+const METHOD_GLYPH: Readonly<Record<string, string>> = Object.freeze({
+  raw: "▽",
+  craft: "⚒",
+  refine: "◇",
+});
 
 export interface NodeCardData extends Record<string, unknown> {
   readonly node: CanvasNode;
+  /** The total, grouped for display. */
   readonly display: string;
+  /** The recipe's yield, when it is not 1. Absent otherwise. */
+  readonly yieldDisplay: string | null;
+  /** The application count, exact and unrounded. Absent for a terminal. */
+  readonly applicationsDisplay: string | null;
+  /**
+   * Which base owns this leaf.
+   *
+   * A prop rather than a payload field because assignment is plan state
+   * that reaches the view through an entry point SPEC-0006 REQ "Leaf
+   * Assignment to Bases" leaves for a later story. Until then every leaf
+   * renders unassigned, which is the truth: nothing has assigned one.
+   *
+   * The type is the base card's, imported rather than restated. There is
+   * one categorical palette and one meaning for slot 4; a second copy of
+   * the type is a second place for the two to disagree.
+   */
+  readonly identity?: IdentitySlot;
+}
+
+function MethodBadge({ method }: { readonly method: string }): ReactNode {
+  const glyph = METHOD_GLYPH[method];
+  return (
+    <span className="node-method label">
+      {glyph !== undefined && (
+        <span aria-hidden="true" className="node-method-glyph">
+          {glyph}
+        </span>
+      )}
+      <span>{method}</span>
+    </span>
+  );
+}
+
+/*
+ * A figure the total alone does not carry.
+ *
+ * SPEC-0006: a total of 300 through a recipe yielding 50 is a different
+ * build instruction from a total of 300 through a recipe yielding 1, and
+ * the card as drawn shows only the total. The label is text, not a glyph,
+ * because there is no established symbol for either of these.
+ */
+function Figure({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: string;
+}): ReactNode {
+  return (
+    <span className="node-figure">
+      <span className="node-figure-label label">{label}</span>{" "}
+      <span className="numeral node-figure-value">{value}</span>
+    </span>
+  );
 }
 
 export function NodeCard({ data }: NodeProps): ReactNode {
-  const { node, display } = data as unknown as NodeCardData;
+  const { node, display, yieldDisplay, applicationsDisplay, identity } =
+    data as unknown as NodeCardData;
+
+  /*
+   * Three border states and no fourth. A leaf carries the 3px identity
+   * frame — its base's colour when assigned, dashed neutral when not — and
+   * a non-leaf carries the 1px neutral border. `.identity` and its slot
+   * classes are base.css's, so the frame this card draws is the same frame
+   * the base planner card draws.
+   */
+  const frame = !node.terminal
+    ? "node-card-plain"
+    : identity === undefined
+      ? "identity identity-unassigned"
+      : `identity identity-${String(identity)}`;
 
   return (
     <>
@@ -57,10 +145,71 @@ export function NodeCard({ data }: NodeProps): ReactNode {
         isConnectable={false}
       />
 
-      <button type="button" className="node-card interactive" data-method={node.method}>
+      <button
+        type="button"
+        className={`node-card interactive selectable ${frame}`}
+        data-method={node.method}
+        /* Only a leaf can be assigned, so only a leaf carries the attribute.
+         * A non-leaf marked "unassigned" would be describing a state it
+         * cannot be in. */
+        data-identity={
+          !node.terminal
+            ? undefined
+            : identity === undefined
+              ? "unassigned"
+              : String(identity)
+        }
+      >
         <span className="node-name">{node.name}</span>
         <span className="numeral node-total">{display}</span>
-        <span className="node-method">{node.method}</span>
+
+        <span className="node-facts">
+          <MethodBadge method={node.method} />
+          {yieldDisplay !== null && <Figure label="yield" value={yieldDisplay} />}
+          {applicationsDisplay !== null && (
+            <Figure label="apps" value={applicationsDisplay} />
+          )}
+        </span>
+
+        {/*
+          The unassigned state, with a second carrier.
+
+          SPEC-0006: "it shows a dashed border and a warning dot, and the
+          state is legible without colour perception". The dashed frame is
+          one non-colour carrier and the dot's own label is the other — the
+          dot's colour is reinforcement, not the fact.
+        */}
+        {node.terminal && identity === undefined && (
+          <span className="node-unassigned">
+            <span aria-hidden="true" className="node-warning-dot" />
+            <span className="label">Unassigned</span>
+          </span>
+        )}
+
+        {/*
+          Provenance, and deliberately not an alarm.
+
+          SPEC-0006 REQ "Provenance Display" requires the marker state that
+          the data is community-sourced and not verified in-game, and
+          requires it not be styled as an error. SPEC-0001 propagates the
+          flag to every ancestor, so the normal case is a connected span up
+          to the target rather than an isolated chip — which is why this is
+          a muted dashed chip and not the warning or deficit treatment.
+
+          StatusBadge's `unverified` member is reused rather than restyled:
+          its glyph and its word are the same ones the figure list uses for
+          the same fact, and its colour is `--text-muted`, which is neither
+          `--warn` nor `--danger`. The full sentence rides on the badge's
+          own detail slot so the marker states it rather than implying it.
+        */}
+        {!node.verified && (
+          <span className="node-provenance">
+            <StatusBadge
+              status="unverified"
+              detail="community data, not verified in-game"
+            />
+          </span>
+        )}
       </button>
 
       <Handle

--- a/web/src/canvas/TreeCanvas.tsx
+++ b/web/src/canvas/TreeCanvas.tsx
@@ -126,6 +126,31 @@ export function TreeCanvas({ graph }: { readonly graph: ResolvedGraph }): ReactN
           display: formatQuantity(node.total, {
             groupSeparator: preferences.groupSeparator,
           }),
+          /*
+           * SPEC-0006: a yield "other than 1" must be visible. A yield of
+           * exactly 1 is the absence of the fact, not a fact worth a line
+           * on every card — the domain sends reduced rationals, so the
+           * comparison is against the one string that can mean it.
+           */
+          yieldDisplay:
+            node.recipeYield === null || node.recipeYield === "1"
+              ? null
+              : formatQuantity(node.recipeYield, {
+                  groupSeparator: preferences.groupSeparator,
+                }),
+          /*
+           * Exact and unrounded. `formatQuantity` keeps the `a/b` form for
+           * a non-integral quantity and never produces a decimal, which is
+           * what SPEC-0005's display rule requires of a rational with no
+           * terminating decimal — and `5/6` is one the shipped artifact
+           * really produces.
+           */
+          applicationsDisplay:
+            node.applications === null
+              ? null
+              : formatQuantity(node.applications, {
+                  groupSeparator: preferences.groupSeparator,
+                }),
         },
       })),
     [model, layoutOf, preferences.groupSeparator],

--- a/web/src/canvas/graph-model.ts
+++ b/web/src/canvas/graph-model.ts
@@ -34,6 +34,15 @@ export interface CanvasNode {
   readonly name: string;
   readonly total: Quantity;
   readonly method: string;
+  /** The resolved recipe's yield per application. Absent for a terminal. */
+  readonly recipeYield: Quantity | null;
+  /**
+   * How many applications of the recipe the total needs — exact, and not a
+   * whole number of crafting operations. SPEC-0006 forbids rounding it and
+   * SPEC-0001 confines rounding to enumerated physical boundaries, which
+   * this is not one of.
+   */
+  readonly applications: Quantity | null;
   readonly terminal: boolean;
   readonly verified: boolean;
 }
@@ -73,6 +82,8 @@ export function toCanvasModel(graph: ResolvedGraph): CanvasModel {
       name: node.name,
       total: node.total,
       method: node.method,
+      recipeYield: node.yield,
+      applications: node.applications,
       terminal: node.terminal,
       verified: node.verified,
     });

--- a/web/src/canvas/layout.ts
+++ b/web/src/canvas/layout.ts
@@ -45,9 +45,17 @@ export interface Placement {
   readonly y: number;
 }
 
-/** The card's fixed footprint, in CSS pixels. Not derived from anything. */
+/**
+ * The card's fixed footprint, in CSS pixels. Not derived from anything.
+ *
+ * Taller than the name-and-total card it started as, because SPEC-0006 puts
+ * a method badge, a yield, an application count, an unassigned marker and a
+ * provenance chip on it. Still a constant: sizing a card by its total is
+ * named in the spec as a violation, and a fixed size is what makes "changing
+ * quantity does not move the graph" true by construction.
+ */
 export const NODE_WIDTH = 210;
-export const NODE_HEIGHT = 96;
+export const NODE_HEIGHT = 148;
 
 /*
  * Left to right, layered.

--- a/web/src/styles/canvas.css
+++ b/web/src/styles/canvas.css
@@ -24,52 +24,170 @@
 /*
  * The card.
  *
- * A 1px neutral border, which is what SPEC-0006 REQ "Node Card" gives a
- * non-leaf. Base identity owns the border and there is no assignment yet —
- * the leaf treatment arrives with the story that adds it, and taking the
- * border for anything else now would have to be undone then.
+ * The background is `--panel`, and the choice is load-bearing rather than
+ * cosmetic. SPEC-0006 gives an assigned leaf a 3px border in its base's
+ * colour token, so that border is the sole carrier of base identity and
+ * owes SC 1.4.11's 3:1 against the colours either side of it. tokens.css
+ * states the palette was measured against three frame surfaces — #1d2021,
+ * #282828 and #32302f — and `--panel-raised` is not one of them. Recomputed
+ * against it, purple lands at 2.76:1 and fails; on `--panel` it is 3.12 and
+ * the whole palette clears. Same reasoning tokens.css already applies to
+ * `--text-muted` on `--input-bg`: a surface the design never measured is
+ * out of range, not a value to extrapolate.
+ *
+ * The move pays twice. `--text-muted` is 4.72 on `--panel` against 4.17 on
+ * `--panel-raised`, so the provenance chip the design drew in that token is
+ * above AA here and would have been below it there.
+ *
+ * Every colour figure below is against `--panel` unless stated.
  */
 .node-card {
   display: flex;
+
+  /*
+   * The card is a hit target, which it was not.
+   *
+   * React Flow turns pointer events off across the node layer when nodes
+   * are neither draggable, selectable nor connectable — all three of which
+   * this canvas sets false, for reasons that have nothing to do with
+   * pointing at a card. The result was that `elementsFromPoint` over a node
+   * returned the pane: `:hover` never matched, and a `<button>` could not
+   * be clicked.
+   *
+   * SPEC-0006 REQ "Node Card" requires hover be expressed as a brightness
+   * filter on the card, and its scenario has a leaf hovered, focused and
+   * selected at once — none of which is reachable while the pane is
+   * swallowing the pointer. Overriding it here rather than by making nodes
+   * draggable: the requirement is about pointing at a card, not about
+   * rewiring a crafting tree by dragging one.
+   */
+  pointer-events: auto;
   box-sizing: border-box;
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;
   padding: var(--space-2) var(--space-3);
-  border: var(--border-width) solid var(--border);
   border-radius: var(--radius-control);
-  background-color: var(--panel-raised);
+  background-color: var(--panel);
   block-size: 100%;
-  color: var(--text-body);
+  color: var(--text); /* 9.57 */
   font-family: var(--font-body);
+  font-size: var(--text-meta);
   gap: var(--space-1);
   inline-size: 100%;
   text-align: start;
 }
 
+/*
+ * A non-leaf's 1px neutral border.
+ *
+ * On its own class rather than on `.node-card`, because `.identity` in
+ * base.css is also a single-class selector and canvas.css is loaded after
+ * it — a `border` shorthand on `.node-card` would win the cascade and
+ * quietly flatten every identity frame to 1px. The three border states are
+ * mutually exclusive and none of them is a default.
+ */
+.node-card-plain {
+  border: var(--border-width) solid var(--border);
+}
+
 .node-name {
-  color: var(--text-bright);
+  color: var(--text-bright); /* 11.57 */
   font-size: var(--text-body);
   line-height: 1.2;
 }
 
 .node-total {
-  color: var(--text-emphasis);
-  font-size: var(--text-h);
+  color: var(--text-bright);
+  font-size: var(--text-emphasis);
+  line-height: 1.1;
+}
+
+/* Method, yield and applications on one line. */
+.node-facts {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
 }
 
 /*
- * The method, as a word.
+ * The method badge: a glyph and a word.
  *
- * SPEC-0006 REQ "Edge Rendering" requires every fact an edge's appearance
- * conveys also be available as text on the node it connects to. The edge's
- * stroke treatment says "refine"; this is where that same fact is text.
+ * SPEC-0006 REQ "Node Card" requires both, and REQ "Edge Rendering"
+ * requires every fact an edge's appearance conveys also be available as
+ * text on the node it connects to. The edge's stroke treatment says
+ * "refine"; this is where that same fact is a word.
+ *
+ * `--text` on `--input-bg` is 7.45. The design draws this chip on that
+ * surface and the text token is the one thing changed: `--text-muted`
+ * would be 3.68 there, which tokens.css names as out of range outright.
  */
 .node-method {
-  color: var(--text-meta);
-  font-size: var(--text-label);
-  letter-spacing: var(--label-tracking);
-  text-transform: uppercase;
+  display: inline-flex;
+  gap: var(--space-1);
+  align-items: baseline;
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-control);
+  background-color: var(--input-bg);
+  color: var(--text); /* 7.45 on --input-bg */
+}
+
+.node-method-glyph {
+  font-family: var(--font-mono);
+}
+
+/* Yield and applications. Muted, because the total is the headline. */
+.node-figure-label {
+  color: var(--text-muted); /* 4.72 */
+}
+
+.node-figure-value {
+  color: var(--text);
+}
+
+/*
+ * Unassigned: the dashed frame, a dot, and the word.
+ *
+ * SPEC-0006 requires "a dashed border and a warning dot, and the state is
+ * legible without colour perception". The dashed frame is one non-colour
+ * carrier, the word is another, and the dot is the reinforcement the
+ * requirement names — not the fact itself, which is why it is aria-hidden
+ * in the component.
+ */
+.node-unassigned {
+  display: inline-flex;
+  gap: var(--space-1);
+  align-items: center;
+  color: var(--text-muted);
+}
+
+.node-warning-dot {
+  display: inline-block;
+  border-radius: 50%;
+  background-color: var(--warn); /* 5.29, non-text needs 3.0 */
+  block-size: 0.5em;
+  inline-size: 0.5em;
+}
+
+/*
+ * Provenance, styled as neither warning nor deficit.
+ *
+ * SPEC-0006 REQ "Provenance Display": legible without alarm, and not the
+ * treatment reserved for something the player must resolve. The chip is a
+ * dashed 1px hairline in `--text-muted` with `StatusBadge`'s own muted
+ * colour inside it — the dashed edge is what the design drew to say
+ * "provisional" without spending a status colour on it.
+ *
+ * SPEC-0001 propagates the flag to every ancestor, so this appears on a
+ * connected span up to the target rather than on isolated nodes. That is
+ * the reason it has no fill and no status colour: thirty-six of these must
+ * still read as a tree.
+ */
+.node-provenance {
+  padding: 0 var(--space-1);
+  border: var(--border-width) dashed var(--text-muted); /* 4.72, non-text needs 3.0 */
+  border-radius: var(--radius-control);
 }
 
 /*
@@ -102,7 +220,7 @@
 }
 
 .edge-label[data-method="refine"] {
-  color: var(--text-body);
+  color: var(--text); /* 9.57 on --panel */
 }
 
 /*
@@ -124,7 +242,7 @@
   border: var(--border-width) solid var(--border);
   border-radius: var(--radius-panel);
   background-color: var(--panel);
-  color: var(--text-body);
+  color: var(--text); /* 9.57 */
 }
 
 /*
@@ -157,5 +275,5 @@
 
 /* stylelint-disable-next-line selector-class-pattern */
 .tree-canvas .react-flow__attribution a {
-  color: var(--text-body);
+  color: var(--text); /* 9.57 on the --panel backing above */
 }

--- a/web/tests/canvas/edges.spec.ts
+++ b/web/tests/canvas/edges.spec.ts
@@ -173,16 +173,18 @@ test("disregarding edge styling entirely loses no fact", async ({ page }) => {
   const canvas = page.getByRole("region", CANVAS);
 
   const expected = await payloadEdges(page);
-  const methodsOnCards = await canvas
-    .locator(".react-flow__node")
-    .evaluateAll((nodes) =>
-      Object.fromEntries(
-        nodes.map((node) => [
-          node.getAttribute("data-id") ?? "",
-          node.querySelector(".node-method")?.textContent ?? "",
-        ]),
-      ),
-    );
+  const methodsOnCards = await canvas.locator(".react-flow__node").evaluateAll((nodes) =>
+    Object.fromEntries(
+      nodes.map((node) => [
+        node.getAttribute("data-id") ?? "",
+        /* The word, not the glyph beside it. The glyph is aria-hidden,
+         * so this is also what a screen reader is left with — and the
+         * requirement is that the fact survive as text. */
+        node.querySelector(".node-method span:not([aria-hidden])")?.textContent?.trim() ??
+          "",
+      ]),
+    ),
+  );
 
   for (const edge of expected) {
     const target = edge.id.split("->")[1] ?? "";

--- a/web/tests/canvas/node-card.spec.ts
+++ b/web/tests/canvas/node-card.spec.ts
@@ -1,0 +1,451 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+/*
+ * What a node says about itself.
+ *
+ * Governing: SPEC-0006 REQ "Node Card", REQ "Yield and Application Display",
+ * REQ "Provenance Display", Accessibility Requirements
+ *
+ * Split across two drivers, because the requirements are.
+ *
+ * The application is where the real payload is, and it is the only place
+ * `5/6` arrives from the engine rather than from a fixture author. But it
+ * resolves 36 nodes with 0 unverified and cannot assign a leaf to a base
+ * until a later story wires the entry point, so the provenance marker and
+ * five of the six identity slots are unreachable there. Those run against
+ * the fixture, which mounts the same component through the same ReactFlow.
+ *
+ * Each half is checked for the thing that would make it vacuous: the
+ * application half asserts the real payload actually carried the figures,
+ * and the fixture half asserts the fixture actually rendered the states.
+ */
+
+const CANVAS = { name: "Dependency tree" } as const;
+const FIXTURE = "/tests/fixtures/node-card.html";
+
+async function resolve(page: Page, target: string): Promise<void> {
+  await page.getByLabel("Target").fill(target);
+  await page.getByRole("button", { name: "Recompute" }).click();
+  await expect(
+    page.getByRole("region", CANVAS).locator(".node-card").first(),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+function card(page: Page, name: string): Locator {
+  return page
+    .getByRole("region", CANVAS)
+    .locator(".node-card")
+    .filter({ has: page.locator(".node-name", { hasText: new RegExp(`^${name}$`) }) });
+}
+
+/* ----------------------------------------------------------------------
+ * Against the real application.
+ * ------------------------------------------------------------------- */
+
+test.describe("the real payload", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("the method is a glyph and a word, not a colour", async ({ page }) => {
+    await resolve(page, "ANTIMATTER");
+
+    const badges = page.getByRole("region", CANVAS).locator(".node-method");
+    await expect(badges.first()).toBeVisible();
+
+    /*
+     * SPEC-0006: the badge carries "both a glyph and a text label". The
+     * glyph is aria-hidden — a screen reader announcing "white down-pointing
+     * triangle raw" is worse than "raw" — so the word is what the
+     * accessible name must contain, and the glyph is what must be on screen.
+     */
+    for (const badge of await badges.all()) {
+      /* What is left after the aria-hidden glyph is removed — which is what
+       * a screen reader is left with too. */
+      const word = (await badge.locator("span:not([aria-hidden])").innerText()).trim();
+      expect(word, "a method badge rendered without its word").toMatch(
+        /^(raw|craft|refine)$/i,
+      );
+      await expect(badge.locator(".node-method-glyph")).toHaveCount(1);
+    }
+
+    /* All three methods are on this tree, so the table is exercised, and
+     * all three glyphs are distinct — one glyph reused for every method
+     * would satisfy the per-badge assertion above. */
+    const words = await badges.evaluateAll((nodes) =>
+      nodes.map((node) =>
+        (node.querySelector("span:not([aria-hidden])")?.textContent ?? "")
+          .trim()
+          .toLowerCase(),
+      ),
+    );
+    expect(new Set(words)).toEqual(new Set(["raw", "craft", "refine"]));
+
+    const glyphs = await badges.evaluateAll((nodes) =>
+      nodes.map((node) => node.querySelector(".node-method-glyph")?.textContent ?? ""),
+    );
+    expect(new Set(glyphs).size).toBe(3);
+  });
+
+  test("a fractional application count reaches the screen unrounded", async ({
+    page,
+  }) => {
+    /*
+     * The acceptance criterion: "A fractional application count reaches the
+     * screen unrounded. This is the first surface at which a non-integer
+     * domain figure is displayed."
+     *
+     * Chromatic Metal, in the Antimatter tree, needs 5/6 of a refine
+     * application. Rounding it up to 1 would be the violation SPEC-0006
+     * names, and it is exactly what a naive `Math.ceil` on "operations"
+     * would produce.
+     */
+    await resolve(page, "ANTIMATTER");
+
+    const chromatic = card(page, "Chromatic Metal");
+    await expect(chromatic).toHaveCount(1);
+
+    const apps = chromatic.locator(".node-figure").filter({ hasText: "apps" });
+    await expect(apps).toContainText("5/6");
+    await expect(apps).not.toContainText("1 ");
+
+    /* And the yield, which the total alone does not carry. */
+    const yields = chromatic.locator(".node-figure").filter({ hasText: "yield" });
+    await expect(yields).toContainText("30");
+  });
+
+  test("a yield of exactly one is not printed as if it were a fact", async ({ page }) => {
+    /*
+     * SPEC-0006 requires a yield "other than 1" be visible. The negative
+     * half matters as much: Antimatter crafts one per application, and a
+     * card that printed "yield 1" on every crafted node would satisfy the
+     * requirement's letter while making the figure meaningless.
+     */
+    await resolve(page, "ANTIMATTER");
+
+    const antimatter = card(page, "Antimatter");
+    await expect(antimatter).toHaveCount(1);
+    await expect(
+      antimatter.locator(".node-figure").filter({ hasText: "yield" }),
+    ).toHaveCount(0);
+    /* But it does carry its application count, so this is not just an
+     * absent figures row. */
+    await expect(
+      antimatter.locator(".node-figure").filter({ hasText: "apps" }),
+    ).toHaveCount(1);
+  });
+
+  test("a terminal has no yield or application count, because the payload sends none", async ({
+    page,
+  }) => {
+    await resolve(page, "ANTIMATTER");
+
+    const silver = card(page, "Silver");
+    await expect(silver).toHaveCount(1);
+    await expect(silver.locator(".node-figure")).toHaveCount(0);
+    /* It is still a card with a name, a total and a method. */
+    await expect(silver.locator(".node-total")).not.toBeEmpty();
+    await expect(silver.locator(".node-method")).toContainText("raw");
+  });
+
+  test("every leaf is unassigned, and says so in more than its border", async ({
+    page,
+  }) => {
+    /*
+     * Nothing can assign a leaf until SPEC-0006 REQ "Leaf Assignment to
+     * Bases" is wired, so every terminal here is unassigned — which is the
+     * truth rather than a placeholder. The assertion worth making is that
+     * the state is carried by something other than the dashed border.
+     */
+    await resolve(page, "ANTIMATTER");
+
+    const unassigned = page
+      .getByRole("region", CANVAS)
+      .locator('.node-card[data-identity="unassigned"]');
+    await expect(unassigned).toHaveCount(4); /* four terminals in this tree */
+
+    for (const leaf of await unassigned.all()) {
+      await expect(leaf).toHaveClass(/identity-unassigned/);
+      await expect(leaf.locator(".node-unassigned")).toContainText(/unassigned/i);
+      await expect(leaf.locator(".node-warning-dot")).toHaveCount(1);
+    }
+
+    /* A non-leaf gets the 1px neutral border and none of that. */
+    const antimatter = card(page, "Antimatter");
+    await expect(antimatter).toHaveClass(/node-card-plain/);
+    await expect(antimatter.locator(".node-unassigned")).toHaveCount(0);
+  });
+
+  test("a card can actually be pointed at", async ({ page }) => {
+    /*
+     * React Flow turns pointer events off across the node layer when nodes
+     * are neither draggable, selectable nor connectable — which this canvas
+     * sets, for reasons unrelated to pointing at a card. The effect was that
+     * `elementsFromPoint` over a node returned the pane, `:hover` never
+     * matched, and the card — a `<button>` — could not be clicked.
+     *
+     * Nothing looked wrong. SPEC-0006 REQ "Node Card" requires hover be a
+     * brightness filter, and a filter that can never apply is a rule kept by
+     * nobody. The method control in a later story would have been the first
+     * thing to notice, by not opening.
+     */
+    await resolve(page, "ANTIMATTER");
+
+    const first = page.getByRole("region", CANVAS).locator(".node-card").first();
+    const before = await first.evaluate((el) => getComputedStyle(el).filter);
+    expect(before, "the card was already filtered before any hover").toBe("none");
+
+    /* No `force`: the point is that the pointer reaches it unaided. */
+    await first.hover({ timeout: 5_000 });
+
+    expect(await first.evaluate((el) => el.matches(":hover"))).toBe(true);
+    expect(
+      await first.evaluate((el) => getComputedStyle(el).filter),
+      "hover is not expressed as a filter on the card",
+    ).not.toBe("none");
+
+    /* And the card is the topmost thing at its own centre. */
+    const topmost = await first.evaluate((el) => {
+      const box = el.getBoundingClientRect();
+      const hit = document.elementFromPoint(
+        box.x + box.width / 2,
+        box.y + box.height / 2,
+      );
+      return hit === el || el.contains(hit);
+    });
+    expect(topmost, "something is painted over the card").toBe(true);
+  });
+
+  test("nothing in the real artifact is unverified, which is why the fixture exists", async ({
+    page,
+  }) => {
+    /*
+     * Not a requirement — a guard on the split. design.md records that the
+     * normalizer never emits `"verified": false`, so the provenance tests
+     * below run against a fixture. If that ever changes, this goes red and
+     * the split should be revisited rather than silently kept.
+     */
+    await resolve(page, "ULTRAPROD2");
+    await expect(
+      page.getByRole("region", CANVAS).locator(".node-provenance"),
+    ).toHaveCount(0);
+    await expect(page.getByRole("region", CANVAS).locator(".node-card")).toHaveCount(36);
+  });
+});
+
+/* ----------------------------------------------------------------------
+ * Against the fixture, for the states the artifact cannot produce.
+ * ------------------------------------------------------------------- */
+
+test.describe("the states the artifact cannot reach", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(FIXTURE, { waitUntil: "load" });
+    await expect(page.locator(".node-card").first()).toBeVisible({ timeout: 20_000 });
+  });
+
+  test("each base slot puts its own colour on the border", async ({ page }) => {
+    /*
+     * Asserted on the rendered result, not the class list — the acceptance
+     * criterion says so, and a class-list assertion passes against a
+     * stylesheet that has stopped defining the slot.
+     */
+    const slots = await page
+      .locator('.node-card[data-identity]:not([data-identity="unassigned"])')
+      .evaluateAll((cards) =>
+        cards.map((el) => {
+          const cs = getComputedStyle(el);
+          return {
+            slot: (el as HTMLElement).dataset["identity"] ?? "",
+            color: cs.borderTopColor,
+            width: cs.borderTopWidth,
+            style: cs.borderTopStyle,
+          };
+        }),
+      );
+
+    expect(slots.length, "the fixture rendered no assigned leaves").toBe(6);
+    for (const slot of slots) {
+      expect(slot.width, `slot ${slot.slot} is not a 3px frame`).toBe("3px");
+      expect(slot.style).toBe("solid");
+    }
+    /* Six slots, six distinct colours — a palette that collapsed to one
+     * colour would satisfy every per-slot assertion above. */
+    expect(new Set(slots.map((s) => s.color)).size).toBe(6);
+  });
+
+  test("base identity survives hover, focus and selection at once", async ({ page }) => {
+    /*
+     * The scenario SPEC-0006 names, and the reason the interaction
+     * primitives are shaped the way they are: "WHEN a leaf node is assigned
+     * to a base and is simultaneously hovered, focused and selected THEN its
+     * border still shows the base's colour, and hover, focus and selection
+     * are shown by filter, outline and overlay ring respectively."
+     */
+    const leaf = page.locator('.node-card[data-identity="6"]');
+    await expect(leaf).toHaveCount(1);
+
+    const before = await leaf.evaluate((el) => getComputedStyle(el).borderTopColor);
+
+    await leaf.hover();
+    await leaf.evaluate((el) => {
+      (el as HTMLElement).focus();
+      el.setAttribute("data-selected", "true");
+    });
+
+    const after = await leaf.evaluate((el) => {
+      const cs = getComputedStyle(el);
+      const ring = getComputedStyle(el, "::after");
+      return {
+        border: cs.borderTopColor,
+        width: cs.borderTopWidth,
+        filter: cs.filter,
+        outlineWidth: cs.outlineWidth,
+        outlineStyle: cs.outlineStyle,
+        ringWidth: ring.borderTopWidth,
+        ringContent: ring.content,
+      };
+    });
+
+    expect(after.border, "the border stopped carrying base identity").toBe(before);
+    expect(after.width).toBe("3px");
+    expect(after.filter, "hover is not a filter").not.toBe("none");
+    expect(after.outlineStyle, "focus is not an outline").not.toBe("none");
+    expect(after.ringContent, "selection is not an overlay ring").not.toBe("none");
+    expect(after.ringWidth).not.toBe("0px");
+  });
+
+  test("the unassigned state survives colour being removed entirely", async ({
+    page,
+  }) => {
+    /*
+     * The acceptance criterion is worded as a removal, so this removes it:
+     * every colour on the page is forced to one value, and the state must
+     * still be readable. The dashed border and the word both survive that;
+     * the warning dot does not, which is why it is the reinforcement and
+     * not the carrier.
+     */
+    const unassigned = page.locator('.node-card[data-identity="unassigned"]');
+    /* Two of them: one verified, one not. Provenance and assignment are
+     * separate facts and the fixture keeps them separable. */
+    await expect(unassigned).toHaveCount(2);
+    const leaf = unassigned.filter({
+      has: page.locator(".node-name", { hasText: /^Silver$/ }),
+    });
+    await expect(leaf).toHaveCount(1);
+
+    await page.addStyleTag({
+      content: `*, *::before, *::after {
+        color: rgb(128, 128, 128) !important;
+        border-color: rgb(128, 128, 128) !important;
+        background-color: rgb(0, 0, 0) !important;
+        fill: rgb(128, 128, 128) !important;
+      }`,
+    });
+
+    const state = await leaf.evaluate((el) => ({
+      style: getComputedStyle(el).borderTopStyle,
+      width: getComputedStyle(el).borderTopWidth,
+      text: (el.textContent ?? "").toLowerCase(),
+    }));
+
+    expect(state.style, "the dashed frame was the only carrier").toBe("dashed");
+    expect(state.width).toBe("3px");
+    expect(state.text).toContain("unassigned");
+  });
+
+  test("the provenance marker states what it means, on every node in the span", async ({
+    page,
+  }) => {
+    /*
+     * SPEC-0006: the marker must state "that the data is community-sourced
+     * and not verified in-game". A chip reading only "unverified" leaves
+     * the player to guess whether they did something wrong.
+     *
+     * Three nodes, because SPEC-0001 propagates the flag to every ancestor
+     * and design.md is explicit that the real shape is a spine rather than
+     * a pair.
+     */
+    const marked = page.locator(".node-provenance");
+    await expect(marked).toHaveCount(3);
+
+    for (const chip of await marked.all()) {
+      await expect(chip).toContainText(/not verified in-game/i);
+      await expect(chip).toContainText(/community data/i);
+    }
+  });
+
+  test("provenance is not the treatment reserved for something to fix", async ({
+    page,
+  }) => {
+    /*
+     * "WHEN a node carries the provenance marker THEN it is not styled with
+     * the error or warning treatment reserved for conditions the player must
+     * resolve." Checked against both rather than asserted, per the
+     * acceptance criterion — the comparison is to the tokens those
+     * treatments actually use, read off the document rather than restated
+     * here, so a token whose value changes cannot make this pass by drift.
+     */
+    const tokens = await page.evaluate(() => {
+      const cs = getComputedStyle(document.documentElement);
+      const resolve = (name: string): string => {
+        const probe = document.createElement("span");
+        probe.style.color = cs.getPropertyValue(name).trim();
+        document.body.append(probe);
+        const value = getComputedStyle(probe).color;
+        probe.remove();
+        return value;
+      };
+      return { warn: resolve("--warn"), danger: resolve("--danger") };
+    });
+
+    const chip = page.locator(".node-provenance").first();
+    const painted = await chip.evaluate((el) => {
+      const cs = getComputedStyle(el);
+      const badge = el.querySelector(".status-badge");
+      return {
+        border: cs.borderTopColor,
+        borderStyle: cs.borderTopStyle,
+        text: badge === null ? "" : getComputedStyle(badge).color,
+      };
+    });
+
+    expect(painted.text).not.toBe(tokens.warn);
+    expect(painted.text).not.toBe(tokens.danger);
+    expect(painted.border).not.toBe(tokens.warn);
+    expect(painted.border).not.toBe(tokens.danger);
+    /* And it is the dashed hairline the design drew, not a fill. */
+    expect(painted.borderStyle).toBe("dashed");
+
+    /* The control: the unassigned dot IS the warning token, so "not warn"
+     * above is a distinction this page can actually draw. */
+    const dot = await page
+      .locator(".node-warning-dot")
+      .first()
+      .evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(dot, "nothing on this page uses --warn, so the check proves nothing").toBe(
+      tokens.warn,
+    );
+  });
+
+  test("a tree with an unverified span still passes a WCAG 2.1 AA audit", async ({
+    page,
+  }) => {
+    /*
+     * The acceptance criterion asks that "a tree with a long unverified span
+     * stays readable". Legibility is not entirely mechanical, but contrast
+     * is, and the fixture is the only place the marker, all six identity
+     * frames and the fractional figure appear at once.
+     */
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .analyze();
+
+    expect(
+      results.violations.map(
+        (violation) =>
+          `${violation.id}: ${violation.nodes.map((node) => node.target.join(" ")).join("; ")}`,
+      ),
+    ).toEqual([]);
+  });
+});

--- a/web/tests/fixtures/node-card-harness.tsx
+++ b/web/tests/fixtures/node-card-harness.tsx
@@ -1,0 +1,284 @@
+/*
+ * The node card in the states the shipped artifact cannot produce.
+ *
+ * Governing: SPEC-0006 REQ "Node Card", REQ "Yield and Application Display",
+ * REQ "Provenance Display"
+ *
+ * Two of this story's three requirements describe states the real data will
+ * not reach. design.md says so outright about the third: "The generated
+ * artifact marks nothing unverified — resolving ULTRAPROD2 against
+ * data/tier1.json returns 36 nodes, 0 of them unverified — because the
+ * normalizer never emits `"verified": false`." Confirmed by resolving both
+ * targets and counting: zero, twice. Base assignment is the same story from
+ * the other end — SPEC-0006 REQ "Leaf Assignment to Bases" leaves the entry
+ * point for a later story, so nothing can assign a leaf yet.
+ *
+ * A suite that only drove the application would therefore assert that the
+ * marker is absent and that every leaf is unassigned, and pass forever
+ * against a card that could not draw either one.
+ *
+ * So the fixture mounts the real `NodeCard` through a real `ReactFlow`,
+ * exactly as `TreeCanvas` does — same node type, same props, same handles —
+ * and hands it the states the artifact will not. What it does not do is
+ * re-implement the card: a fixture that drew its own markup would test the
+ * fixture.
+ *
+ * The unverified nodes are a connected span rather than a scattering,
+ * because SPEC-0001 propagates the flag to every ancestor and design.md is
+ * explicit that "the design tuned 'subtle, honest, non-alarming' against two
+ * instances in a prototype; propagation means the real count is a spine, not
+ * a pair."
+ */
+
+import { ReactFlow, type Node } from "@xyflow/react";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import "@xyflow/react/dist/base.css";
+
+import { asQuantity, formatQuantity, type Quantity } from "../../src/boundary";
+import type { IdentitySlot } from "../../src/card/BasePlannerCard";
+import type { CanvasNode } from "../../src/canvas/graph-model";
+import { NODE_HEIGHT, NODE_WIDTH } from "../../src/canvas/layout";
+import { NodeCard, type NodeCardData } from "../../src/canvas/NodeCard";
+
+import "../../src/styles/tokens.css";
+import "../../src/styles/base.css";
+import "../../src/styles/shell.css";
+import "../../src/styles/canvas.css";
+
+/** Exact strings in, exact strings out. A bad literal fails the fixture loudly. */
+function exact(value: string): Quantity {
+  const quantity = asQuantity(value);
+  if (quantity === null) throw new Error(`fixture quantity is not exact: ${value}`);
+  return quantity;
+}
+
+interface Spec {
+  readonly id: string;
+  readonly name: string;
+  readonly total: string;
+  readonly method: string;
+  readonly recipeYield: string | null;
+  readonly applications: string | null;
+  readonly terminal: boolean;
+  readonly verified: boolean;
+  readonly identity?: IdentitySlot;
+}
+
+/*
+ * Six leaves across all six identity slots, an unassigned leaf, a non-leaf,
+ * a fractional application count, a yield of exactly 1 (which must NOT
+ * show), and a three-node unverified span.
+ *
+ * The slot-6 leaf is deliberate: purple is the palette's contrast floor and
+ * the reason the card sits on `--panel` rather than `--panel-raised`.
+ */
+const SPECS: readonly Spec[] = [
+  {
+    id: "SLOT1",
+    name: "Ferrite Dust",
+    total: "1200",
+    method: "raw",
+    recipeYield: null,
+    applications: null,
+    terminal: true,
+    verified: true,
+    identity: 1,
+  },
+  {
+    id: "SLOT2",
+    name: "Carbon",
+    total: "800",
+    method: "raw",
+    recipeYield: null,
+    applications: null,
+    terminal: true,
+    verified: true,
+    identity: 2,
+  },
+  {
+    id: "SLOT3",
+    name: "Sodium",
+    total: "640",
+    method: "raw",
+    recipeYield: null,
+    applications: null,
+    terminal: true,
+    verified: true,
+    identity: 3,
+  },
+  {
+    id: "SLOT4",
+    name: "Oxygen",
+    total: "500",
+    method: "raw",
+    recipeYield: null,
+    applications: null,
+    terminal: true,
+    verified: true,
+    identity: 4,
+  },
+  {
+    id: "SLOT5",
+    name: "Paraffinium",
+    total: "450",
+    method: "raw",
+    recipeYield: null,
+    applications: null,
+    terminal: true,
+    verified: true,
+    identity: 5,
+  },
+  {
+    id: "SLOT6",
+    name: "Dioxite",
+    total: "300",
+    method: "raw",
+    recipeYield: null,
+    applications: null,
+    terminal: true,
+    verified: true,
+    identity: 6,
+  },
+  {
+    id: "UNASSIGNED",
+    name: "Silver",
+    total: "918273",
+    method: "raw",
+    recipeYield: null,
+    applications: null,
+    terminal: true,
+    verified: true,
+  },
+  {
+    /* A yield of exactly 1 is the absence of the fact, not a line on the card. */
+    id: "UNIT_YIELD",
+    name: "Antimatter",
+    total: "1",
+    method: "craft",
+    recipeYield: "1",
+    applications: "1",
+    terminal: false,
+    verified: true,
+  },
+  {
+    /* The real shape: Chromatic Metal in the Antimatter tree yields 30 per
+     * application and needs 5/6 of one. Neither figure is derivable from
+     * the total, and 5/6 is what must not become 1. */
+    id: "FRACTIONAL",
+    name: "Chromatic Metal",
+    total: "25",
+    method: "refine",
+    recipeYield: "30",
+    applications: "5/6",
+    terminal: false,
+    verified: true,
+  },
+  {
+    id: "UNVERIFIED_LEAF",
+    name: "Frost Crystal",
+    total: "200",
+    method: "raw",
+    recipeYield: null,
+    applications: null,
+    terminal: true,
+    verified: false,
+  },
+  {
+    id: "UNVERIFIED_MID",
+    name: "Glass",
+    total: "40",
+    method: "refine",
+    recipeYield: "5",
+    applications: "8",
+    terminal: false,
+    verified: false,
+  },
+  {
+    id: "UNVERIFIED_TARGET",
+    name: "Living Glass",
+    total: "5",
+    method: "craft",
+    recipeYield: "1",
+    applications: "5",
+    terminal: false,
+    verified: false,
+  },
+];
+
+function toNode(spec: Spec, index: number): Node {
+  const node: CanvasNode = {
+    id: spec.id,
+    name: spec.name,
+    total: exact(spec.total),
+    method: spec.method,
+    recipeYield: spec.recipeYield === null ? null : exact(spec.recipeYield),
+    applications: spec.applications === null ? null : exact(spec.applications),
+    terminal: spec.terminal,
+    verified: spec.verified,
+  };
+
+  /* `identity` is spread rather than assigned, because the project builds
+   * with exactOptionalPropertyTypes: an absent slot is an absent property,
+   * not a property holding undefined. */
+  const data: NodeCardData = {
+    ...(spec.identity === undefined ? {} : { identity: spec.identity }),
+    node,
+    display: formatQuantity(node.total, { groupSeparator: "," }),
+    yieldDisplay:
+      node.recipeYield === null || node.recipeYield === "1"
+        ? null
+        : formatQuantity(node.recipeYield, { groupSeparator: "," }),
+    applicationsDisplay:
+      node.applications === null
+        ? null
+        : formatQuantity(node.applications, { groupSeparator: "," }),
+  };
+
+  return {
+    id: spec.id,
+    type: "card",
+    /* Laid out by hand: elkjs is not what this fixture is about, and a
+     * fixed grid keeps every card on screen for the audit. */
+    position: {
+      x: (index % 4) * (NODE_WIDTH + 40),
+      y: Math.floor(index / 4) * (NODE_HEIGHT + 40),
+    },
+    width: NODE_WIDTH,
+    height: NODE_HEIGHT,
+    draggable: false,
+    selectable: false,
+    data,
+  };
+}
+
+const NODE_TYPES = { card: NodeCard };
+
+function Harness(): React.ReactNode {
+  return (
+    <section className="tree-canvas" aria-label="Dependency tree">
+      <ReactFlow
+        nodes={SPECS.map(toNode)}
+        edges={[]}
+        nodeTypes={NODE_TYPES}
+        nodesFocusable={false}
+        nodesConnectable={false}
+        nodesDraggable={false}
+        edgesFocusable={false}
+        elementsSelectable={false}
+        fitView
+        proOptions={{ hideAttribution: false }}
+      />
+    </section>
+  );
+}
+
+const root = document.getElementById("root");
+if (!root) throw new Error("fixture root is missing");
+
+createRoot(root).render(
+  <StrictMode>
+    <Harness />
+  </StrictMode>,
+);

--- a/web/tests/fixtures/node-card.html
+++ b/web/tests/fixtures/node-card.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Node card fixture</title>
+  </head>
+  <body>
+    <!--
+      Governing: SPEC-0006 REQ "Node Card", REQ "Yield and Application
+      Display", REQ "Provenance Display"
+
+      The node card in the states the shipped artifact will not produce: a
+      leaf in each of the six base slots, an unassigned leaf, a yield of
+      exactly 1 that must not be shown, a fractional application count, and
+      a three-node unverified span rather than an isolated chip.
+
+      The real application covers the rest. What it cannot cover is any of
+      the above — it resolves 36 nodes with 0 unverified, and nothing can
+      assign a leaf until the assignment story lands.
+    -->
+    <div id="root"></div>
+    <script type="module" src="./node-card-harness.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #86
Part of #84

Implements SPEC-0006 REQ "Node Card", REQ "Yield and Application Display", REQ "Provenance Display".

The card carries its method as a glyph and a word, the recipe's yield where it is not 1, the application count exactly as the domain reports it, the base identity frame, the unassigned marker, and the provenance chip. The interaction primitives are base.css's, inherited rather than rebuilt — which is what makes the border available for identity in the first place.

## Three things had to be fixed before any of it could be true

**A node card could not be pointed at.** React Flow turns pointer events off across the node layer when nodes are neither draggable, selectable nor connectable — all three of which this canvas sets, for reasons that have nothing to do with pointing at a card. Probed:

```
hover: BLOCKED — TimeoutError
stack at centre: ["div.react-flow__pane.draggable", "div.react-flow__renderer", ...]
:hover matched: false      filter: none
```

The card — a `<button>` — was not in its own hit stack. SPEC-0006 requires hover be a brightness filter and its scenario has a leaf hovered, focused and selected *at once*; none of it was reachable. Nothing looked wrong, and #87's method control would have been the first thing to notice, by not opening. After: `filter: brightness(1.12)`, and the card is topmost at its own centre.

**Six colour declarations named a type-scale token.** `color: var(--text-body)` is `color: 15px` — invalid, dropped, element silently inherits. Confirmed in the browser rather than by reading:

```
.node-card   color=rgb(235,219,178)  ← --text, inherited from body
.node-total  color=rgb(235,219,178)  font-size=13.3333px  ← the button's UA default
tokens       --text-body=15px  --text-emphasis=17px  --text-h=(undefined)
```

Every colour on the card was inherited rather than set — including one inside #124's WCAG fix for React Flow's attribution, where the `background-color` half was doing all the work alone. `--text-h`, used for the total's font-size, does not exist at all, so the emphasis figure rendered *smaller* than the name.

`scripts/check-tokens.sh` now rejects a type-scale token in any colour property, with its own controls including the near-misses — a size token in a size slot, a colour token whose name starts the same. Run against main's `canvas.css` it reports all six, with line numbers.

**The card moved from `--panel-raised` to `--panel`.** An assigned leaf's 3px border is the sole carrier of base identity, so it owes SC 1.4.11's 3:1 against the colours either side of it. tokens.css records the palette as measured against three frame surfaces — #1d2021 / #282828 / #32302f — and `--panel-raised` is not one of them:

| token | on `--panel-raised` | on `--panel` |
|---|---|---|
| `--base-6` (purple, the floor) | **2.76** ✗ | 3.12 ✓ |
| `--base-3` (copper) | 3.18 | 3.60 |
| `--text-muted` | **4.17** ✗ | 4.72 ✓ |

Same reasoning tokens.css already applies to `--text-muted` on `--input-bg`: a surface the design never measured is out of range, not a value to extrapolate from. The move pays twice — the provenance chip the design drew in `--text-muted` is above AA on `--panel` and would have been below it on `--panel-raised`.

## Two requirements the artifact cannot exercise

Resolving ANTIMATTER and ULTRAPROD2 returns **0 unverified nodes both times**, exactly as design.md records, and nothing can assign a leaf until #88 wires the entry point. A suite driving only the application would assert the marker is absent and every leaf unassigned, and pass forever against a card that could draw neither.

So those run against `tests/fixtures/node-card.html`, which mounts the **real** `NodeCard` through a **real** `ReactFlow` — same node type, same props, same handles — with all six identity slots, an unassigned leaf, a yield of exactly 1 that must *not* show, and a **three-node unverified span** rather than the isolated pair the design tuned against. The application half carries a guard that goes red if the artifact ever starts marking nodes unverified, so the split gets revisited rather than silently kept.

`5/6` is real, though. Chromatic Metal in the Antimatter tree yields 30 per application and needs 5/6 of one, and it reaches the screen unrounded — the first non-integer domain figure on any surface.

## Departures from the handoff, both under its own convention note

- The unverified chip's text is `StatusBadge`'s muted colour on `--panel` (4.72) rather than on `--panel-raised` (4.17). Same token, legible surface.
- The method badge's text is `--text` on `--input-bg` (7.45) rather than `--text-muted` (3.68), which tokens.css names as out of range outright.

## Verification

**253 tests pass**, 13 new. **41 mutations, all red**, 8 new:

| Mutation | Test that goes red |
|---|---|
| the method badge loses its glyph | node-card |
| the method badge loses its word | node-card *and* edges |
| a fractional application count is rounded up | node-card |
| the recipe yield stops reaching the card | node-card |
| an unassigned leaf is left with only its dashed border | node-card |
| provenance takes the treatment reserved for something to fix | node-card |
| the pane goes back to swallowing the pointer | node-card |
| something other than base identity writes to the card border | node-card |

typecheck, lint, lint:css, format:check, check:tokens, build all clean. No protected paths touched.

## Worth flagging

Issue #86's note says `5/6` is "a real value the shipped artifact produces for Antimatter's **Silver**". It is Chromatic Metal — Silver is one of its inputs. The substance holds; the node is different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)