### PR TITLE
feat(web): duration, provenance, and absent data

### DIFF
--- a/web/src/card/BasePlannerCard.tsx
+++ b/web/src/card/BasePlannerCard.tsx
@@ -16,8 +16,10 @@ import { StatusBadge } from "../shell/StatusBadge";
 import { BuildFooter } from "./BuildFooter";
 import { buildItems } from "./build-items";
 import { CardControls } from "./CardControls";
+import { Duration } from "./Duration";
 import type { CardConfiguration } from "./configuration";
 import { PowerBlock } from "./PowerBlock";
+import { BaseProvenance, RowProvenance } from "./Provenance";
 import { PRODUCER_HEADING, presentKinds, type ProducerKind } from "./sections";
 
 /*
@@ -99,7 +101,8 @@ function FarmRowView({ row }: { row: FarmRow }): ReactNode {
           label="Yield/plant"
           value={`${q(row.yieldPerPlant.min)}–${q(row.yieldPerPlant.max)}`}
         />
-        <Figure label="Growth (s)" value={q(row.growthSeconds)} />
+        <Duration label="Growth (s)" seconds={row.growthSeconds} />
+        <RowProvenance verified={row.verified} />
       </span>
     </li>
   );
@@ -116,7 +119,8 @@ function ExtractorRowView({ row }: { row: ExtractorRow }): ReactNode {
         <Figure label="Extractors" value={q(row.extractorCount)} />
         <Figure label="Depots" value={q(row.depots)} />
         <Figure label="Rate/s" value={q(row.ratePerSecond)} />
-        <Figure label="Fill (s)" value={q(row.fillSeconds)} />
+        <Duration label="Fill (s)" seconds={row.fillSeconds} />
+        <RowProvenance verified={row.verified} />
       </span>
     </li>
   );
@@ -129,7 +133,8 @@ function RanchRowView({ row }: { row: RanchRow }): ReactNode {
       <span className="card-row-figures">
         <Figure label="Required" value={q(row.required)} />
         <Figure label="Fauna" value={q(row.fauna)} />
-        <Figure label="Cycle (s)" value={q(row.cycleSeconds)} />
+        <Duration label="Cycle (s)" seconds={row.cycleSeconds} />
+        <RowProvenance verified={row.verified} />
       </span>
     </li>
   );
@@ -143,7 +148,8 @@ function KitchenRowView({ row }: { row: KitchenStep }): ReactNode {
       </span>
       <span className="card-row-figures">
         <Figure label="Required" value={q(row.required)} />
-        <Figure label="Process (s)" value={q(row.processSeconds)} />
+        <Duration label="Process (s)" seconds={row.processSeconds} />
+        <RowProvenance verified={row.verified} />
       </span>
     </li>
   );
@@ -162,6 +168,7 @@ function NoBuildRowView({ row }: { row: NoBuildRow }): ReactNode {
           greyed out is indistinguishable to anyone not seeing the grey.
         */}
         <span className="card-nothing-to-build">Nothing to build</span>
+        <RowProvenance verified={row.verified} />
       </span>
     </li>
   );
@@ -233,6 +240,12 @@ export function BasePlannerCard({
         {identity === undefined ? (
           <StatusBadge status="warning" detail="no identity assigned" />
         ) : null}
+        {/*
+          The base's own provenance, not a summary of the rows'. The payload
+          carries the two separately and the requirement forbids either
+          standing in for the other.
+        */}
+        <BaseProvenance verified={base.verified} />
       </header>
 
       {configuration !== undefined && onConfigure !== undefined ? (

--- a/web/src/card/Duration.tsx
+++ b/web/src/card/Duration.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+
+import { formatQuantity, type Quantity } from "../boundary";
+
+/*
+ * A duration, presented as the estimate it is.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0007 REQ "Duration Display",
+ * SPEC-0005 REQ "The View Computes No Domain Values"
+ *
+ * The domain's rate constants do not state their time unit. The artifact
+ * does not record it, and the engine's arithmetic is consistent under either
+ * reading while its absolute durations are not — so a figure rendered here
+ * as "1800 s" would be a precision claim the underlying data cannot support.
+ * `≈` and the word "est." are the whole of the fix, and they are on every
+ * duration rather than on the ones that felt uncertain.
+ *
+ * No conversion happens here. Turning 1800 into "30 min" is arithmetic the
+ * card is not allowed to do, and where a duration is displayed in a unit
+ * other than the payload's, that conversion is the domain's to make. The
+ * card's discipline scan is what enforces the absence.
+ */
+export function Duration({
+  label,
+  seconds,
+}: {
+  label: string;
+  seconds: Quantity;
+}): ReactNode {
+  return (
+    <span className="card-figure" data-duration={label}>
+      <span className="card-figure-label">{label}</span>
+      <span className="card-figure-value mono">
+        {/*
+          The sign is decorative and "est." is the carrier. Screen readers
+          disagree about how to announce ≈ — some say "almost equal to", some
+          skip it — so the claim is carried by a word that reads the same
+          everywhere, and the symbol only reinforces it visually.
+        */}
+        <span aria-hidden="true">≈</span>
+        {formatQuantity(seconds)}
+      </span>
+      <span className="card-estimate">est.</span>
+    </span>
+  );
+}

--- a/web/src/card/Provenance.tsx
+++ b/web/src/card/Provenance.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react";
+
+import { StatusBadge } from "../shell/StatusBadge";
+
+/*
+ * Provenance markers, at two scales.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0007 REQ "Provenance on
+ * Displayed Figures", SPEC-0005 Accessibility Requirements
+ *
+ * Two components because the requirement names two facts and forbids
+ * substituting one for the other: "a base marked verified says nothing about
+ * a row, and a single marked row does not make the base's own figures
+ * suspect." One shared component taking a scale prop would make the
+ * substitution a one-character edit.
+ *
+ * The row marker is deliberately smaller than the base's, and the reason is
+ * the requirement's own warning rather than taste. Every producer row is
+ * unverified today — no curated constant carries a verified date — so this
+ * marker is on everything, not on the occasional row. A treatment tuned
+ * against two chips in a prototype becomes thirty badges here, and a card
+ * that is legible with two and unreadable with thirty has not met the
+ * requirement. So the row carries a glyph with an accessible name and the
+ * base carries the full badge, once.
+ *
+ * Neither is styled as an error. `status-unverified` is its own token, and
+ * `?` is its own glyph — distinct from `⚠` for a warning and `✕` for a
+ * deficit, which is what "without styling it as an error" asks for and what
+ * a test asserts against both.
+ *
+ * Nothing here computes a flag. The boolean is the domain's answer about
+ * that row's own arithmetic, and re-deriving it would be SPEC-0005's
+ * forbidden arithmetic applied to a boolean.
+ */
+
+/** One row's provenance. Compact, because it will be on every row. */
+export function RowProvenance({ verified }: { verified: boolean }): ReactNode {
+  if (verified) return null;
+  return (
+    <span
+      className="card-unverified status-unverified"
+      data-provenance="row"
+      /*
+       * The glyph is decorative and the name is the carrier: a screen reader
+       * reading "question mark" is noise, and the word is what makes the
+       * distinction survive not seeing the colour.
+       */
+      role="img"
+      aria-label="Unverified"
+      title="Unverified — rests on a constant with no confirmed date"
+    >
+      <span aria-hidden="true">?</span>
+    </span>
+  );
+}
+
+/**
+ * The base's own provenance.
+ *
+ * Reports whether everything contributing to this base's instructions was
+ * confirmed. It is not a summary of the row markers and must not be read as
+ * one — the payload carries it separately for that reason.
+ */
+export function BaseProvenance({ verified }: { verified: boolean }): ReactNode {
+  if (verified) return null;
+  return (
+    <span data-provenance="base">
+      <StatusBadge status="unverified" detail="base figures" />
+    </span>
+  );
+}

--- a/web/src/styles/card.css
+++ b/web/src/styles/card.css
@@ -225,3 +225,34 @@
 .card-row[data-state="pending"] .card-build-state {
   color: var(--warn);
 }
+
+/* ----------------------------------------------------------------------
+ * Provenance and estimated durations.
+ *
+ * Governing: SPEC-0007 REQ "Provenance on Displayed Figures",
+ * REQ "Duration Display", SPEC-0005 Accessibility Requirements
+ *
+ * The row marker is restrained because it is on every row, not because
+ * unverified figures are rare — no curated constant carries a verified date
+ * today, so this is the ordinary state of the card rather than an exception.
+ * A treatment sized for the occasional row would be thirty loud chips here.
+ *
+ * `status-unverified` comes from shell.css and is the same token the rest of
+ * the view uses. It is not an error treatment, and it is not restyled into
+ * one here.
+ * ------------------------------------------------------------------- */
+
+.card-unverified {
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  line-height: 1;
+  padding: 0 var(--space-1);
+  border: var(--border-width) solid currentcolor;
+  border-radius: var(--radius-control);
+  cursor: help;
+}
+
+.card-estimate {
+  font-size: var(--text-meta);
+  color: var(--text-muted);
+}

--- a/web/tests/card/provenance.spec.ts
+++ b/web/tests/card/provenance.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from "@playwright/test";
+
+/*
+ * Governing: SPEC-0007 REQ "Duration Display", REQ "Provenance on Displayed
+ * Figures", REQ "Absent Data Is Absent"
+ *
+ * Three rules that apply across the whole card rather than to one section,
+ * which is why they are one story: implementing them per-section is how one
+ * section ends up disagreeing with another.
+ */
+
+const FIXTURE = "/tests/fixtures/card-provenance.html";
+const ALL = '[data-base="Everything Unverified"]';
+const MIXED = '[data-base="Mixed Provenance"]';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(FIXTURE, { waitUntil: "load" });
+});
+
+test("every duration on the card reads as an estimate", async ({ page }) => {
+  const durations = page.locator(`${ALL} [data-duration]`);
+  // Growth, fill, cycle, process — every kind the card can show.
+  await expect(durations).toHaveCount(4);
+
+  const count = await durations.count();
+  for (let i = 0; i < count; i += 1) {
+    const text = await durations.nth(i).innerText();
+    expect(text).toContain("≈");
+    expect(text).toContain("est.");
+  }
+});
+
+test("no duration is rendered in a unit the payload did not use", async ({ page }) => {
+  /*
+   * The payload's durations are seconds. A card converting to minutes or
+   * hours would be doing the arithmetic REQ "Duration Display" forbids —
+   * the discipline scan rules out the arithmetic itself; this rules out a
+   * converted figure reaching the screen by some other route.
+   */
+  const text = await page.locator(`${ALL} [data-section]`).first().innerText();
+  expect(text).not.toMatch(/\bmin\b|\bminutes\b|\bhours?\b/i);
+});
+
+test("a row marker and the base marker are both surfaced", async ({ page }) => {
+  const card = page.locator(ALL);
+  await expect(card.locator('[data-provenance="row"]').first()).toBeVisible();
+  await expect(card.locator('[data-provenance="base"]')).toHaveCount(1);
+});
+
+test("neither marker substitutes for the other", async ({ page }) => {
+  /*
+   * A verified base carrying an unverified row. The row is marked and the
+   * base is not — a card summarising rows into the base marker would mark
+   * both, and one substituting the base's flag for its rows' would mark
+   * neither.
+   */
+  const card = page.locator(MIXED);
+  await expect(card.locator('[data-provenance="row"]').first()).toBeVisible();
+  await expect(card.locator('[data-provenance="base"]')).toHaveCount(0);
+});
+
+test("the card stays legible with the marker on everything", async ({ page }) => {
+  const card = page.locator(ALL);
+
+  /*
+   * This is the real condition, not an edge case: no curated constant has a
+   * verified date, so every producer row is marked. The requirement says the
+   * treatment "MUST NOT rely on rarity for its restraint".
+   */
+  const rows = await card.locator("[data-row]").count();
+  const markers = await card.locator('[data-provenance="row"]').count();
+  expect(markers).toBe(rows);
+  expect(rows).toBeGreaterThan(4);
+
+  // The card still reads: its name and its figures are not crowded out.
+  await expect(card.locator(".card-name")).toContainText("Everything Unverified");
+  await expect(card.locator('[data-row="farm"]')).toContainText("Plants");
+
+  // And nothing overflows horizontally under that many markers.
+  const overflow = await card.evaluate((el) => el.scrollWidth > el.clientWidth + 1);
+  expect(overflow).toBe(false);
+});
+
+test("the marker is distinct from the warning and error treatments", async ({ page }) => {
+  const marker = page.locator(`${ALL} [data-provenance="row"]`).first();
+  await expect(marker).toHaveClass(/status-unverified/);
+  // Not the warning treatment, and not the error one.
+  await expect(marker).not.toHaveClass(/status-warning/);
+  await expect(marker).not.toHaveClass(/status-danger/);
+
+  const glyph = await marker.innerText();
+  expect(glyph).toContain("?");
+  expect(glyph).not.toContain("⚠");
+  expect(glyph).not.toContain("✕");
+
+  // It is named, so the distinction survives not seeing the colour.
+  await expect(marker).toHaveAttribute("aria-label", "Unverified");
+});
+
+test("no environment or location field renders a placeholder", async ({ page }) => {
+  /*
+   * Planet type, biome, hazards, sentinel level, economy, star class and
+   * portal address have no source in the artifact, the domain, or any
+   * accepted spec. A missing detail is an omitted element — not an empty
+   * one, and not a dash.
+   */
+  const text = await page.locator(ALL).innerText();
+  for (const field of [
+    "planet",
+    "biome",
+    "hazard",
+    "sentinel",
+    "economy",
+    "star class",
+    "portal",
+  ]) {
+    expect(text.toLowerCase()).not.toContain(field);
+  }
+  expect(text).not.toMatch(/—\s*$/m);
+});
+
+test("no control implying persistence exists anywhere on the card", async ({ page }) => {
+  /*
+   * ADR-0008 is accepted, which discharges the requirement's "until a
+   * governing decision" clause — but SPEC-0009 has no implementation reached
+   * from here, so there is still nothing to persist into. The v2 prototype's
+   * checkable build list, storage tracker, notes and screenshot slot all
+   * stay out.
+   */
+  const card = page.locator(ALL);
+  await expect(card.locator('input[type="checkbox"]')).toHaveCount(0);
+  await expect(card.locator("textarea")).toHaveCount(0);
+  await expect(card.locator('input[type="file"]')).toHaveCount(0);
+
+  const names = await card
+    .locator("button, input, select, textarea")
+    .evaluateAll((nodes) =>
+      nodes.map((n) => `${n.getAttribute("aria-label") ?? ""} ${n.textContent ?? ""}`),
+    );
+  for (const name of names) {
+    expect(name.toLowerCase()).not.toMatch(/save|remember|note|screenshot|upload|keep/);
+  }
+});

--- a/web/tests/fixtures/card-provenance-harness.tsx
+++ b/web/tests/fixtures/card-provenance-harness.tsx
@@ -1,0 +1,124 @@
+/*
+ * The card under the provenance condition that actually holds.
+ *
+ * Governing: SPEC-0007 REQ "Provenance on Displayed Figures",
+ * REQ "Duration Display", REQ "Absent Data Is Absent"
+ *
+ * `everything` marks every producer row and the base. That is not an edge
+ * case: none of the curated constants carries a verified date, so this is
+ * what the card renders against today. The requirement says the treatment
+ * "MUST NOT rely on rarity for its restraint", and a fixture with one
+ * marked row could never show whether it does.
+ *
+ * `mixed` is a verified base carrying one unverified row. It exists because
+ * substituting either marker for the other is invisible in every other
+ * arrangement: with both unverified, or both verified, a card that showed
+ * only one of them would look correct.
+ */
+
+import { StrictMode, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { asQuantity, type BaseBuild, type Quantity } from "../../src/boundary";
+import { BasePlannerCard } from "../../src/card/BasePlannerCard";
+
+import "../../src/styles/tokens.css";
+import "../../src/styles/base.css";
+import "../../src/styles/shell.css";
+import "../../src/styles/card.css";
+
+function exact(value: string): Quantity {
+  const quantity = asQuantity(value);
+  if (quantity === null) throw new Error(`fixture quantity is not exact: ${value}`);
+  return quantity;
+}
+
+/** Every producer kind, so every duration the card can show is present. */
+function baseWith(name: string, rowsVerified: boolean, baseVerified: boolean): BaseBuild {
+  return {
+    base: name,
+    site: { extractorClass: "C", fillSeconds: exact("3600") },
+    farms: [
+      {
+        itemId: "starbulb",
+        name: "Star Bulb",
+        required: exact("480"),
+        plants: exact("24"),
+        biodomes: exact("2"),
+        yieldPerPlant: { min: exact("20"), max: exact("30") },
+        growthSeconds: exact("1800"),
+        verified: rowsVerified,
+      },
+    ],
+    extractors: [
+      {
+        itemId: "dihydrogen",
+        name: "Di-hydrogen",
+        class: "C",
+        required: exact("1250"),
+        extractorCount: exact("3"),
+        depots: exact("2"),
+        ratePerSecond: exact("1/4"),
+        fillSeconds: exact("3600"),
+        verified: rowsVerified,
+      },
+    ],
+    ranches: [
+      {
+        itemId: "creaturepellets",
+        name: "Livestock Unit",
+        required: exact("60"),
+        fauna: exact("4"),
+        cycleSeconds: exact("900"),
+        verified: rowsVerified,
+      },
+    ],
+    kitchen: [
+      {
+        itemId: "cakeslice",
+        name: "Cake Slice",
+        recipe: "bake",
+        required: exact("10"),
+        processSeconds: exact("600"),
+        final: true,
+        verified: rowsVerified,
+        inputs: [],
+      },
+    ],
+    nutrientProcessors: exact("1"),
+    pelletFeeders: exact("1"),
+    noBuild: [
+      {
+        itemId: "condensedcarbon",
+        name: "Condensed Carbon",
+        from: "Gas refine byproduct",
+        required: exact("200"),
+        verified: rowsVerified,
+      },
+    ],
+    verified: baseVerified,
+  };
+}
+
+/* The state today: nothing confirmed, anywhere. */
+const everything = baseWith("Everything Unverified", false, false);
+/* A verified base whose row is not. Neither marker may stand in for the other. */
+const mixed = baseWith("Mixed Provenance", false, true);
+
+export function Cards(): ReactNode {
+  return (
+    <>
+      <BasePlannerCard base={everything} identity={1} />
+      <BasePlannerCard base={mixed} identity={2} />
+    </>
+  );
+}
+
+const root = document.getElementById("root");
+if (!root) throw new Error("card-provenance.html is missing #root");
+
+createRoot(root).render(
+  <StrictMode>
+    <Cards />
+  </StrictMode>,
+);

--- a/web/tests/fixtures/card-provenance.html
+++ b/web/tests/fixtures/card-provenance.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Base planner card provenance fixture</title>
+  </head>
+  <body>
+    <!--
+      Governing: SPEC-0007 REQ "Provenance on Displayed Figures",
+      REQ "Duration Display", REQ "Absent Data Is Absent"
+
+      Two bases. `everything` is the real condition today — no curated
+      constant carries a verified date, so every producer row and the base
+      itself are unverified. `mixed` is a verified base with one unverified
+      row, which is the only arrangement where substituting one marker for
+      the other is visible.
+    -->
+    <div id="root"></div>
+    <script type="module" src="./card-provenance-harness.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #99
Part of #94

Implements SPEC-0007 REQ "Duration Display", REQ "Provenance on Displayed Figures", REQ "Absent Data Is Absent".

> **Stacked on #128, which is stacked on #127.** Merge order is #127 → #128 → #130. **Re-base each on `main` as its parent merges.** Review the diff against `feat/98…` to see only this story's changes.

## Durations

Every duration reads as an estimate — `≈` plus the word "est." — on all four kinds the card can show (growth, fill, cycle, process). The marker is on every duration rather than on the ones that felt uncertain, because the reason is structural: the domain's rate constants don't state their time unit, the artifact doesn't record it, and the engine's arithmetic is consistent under either reading while its absolute durations are not.

The `≈` is `aria-hidden` and "est." is the accessible carrier — screen readers disagree about how to announce `≈` (some say "almost equal to", some skip it), so the claim rides on a word that reads the same everywhere.

No conversion happens. The discipline scan rules out the arithmetic; a second test asserts no `min`/`hour` reaches the screen by another route.

## Provenance

**Two components, not one with a scale prop.** The requirement forbids substituting either marker for the other, and a single component taking a prop would make that substitution a one-character edit. The `Mixed Provenance` fixture is what proves it: a *verified base* carrying an *unverified row* marks the row and not the base. With both flags equal — the arrangement every other fixture has — a card showing only one of them looks correct.

**The row marker is restrained because it is on everything.** No curated constant carries a verified date, so every producer row is marked; that's the ordinary state of this card, not an exception. The requirement is explicit that the treatment "MUST NOT rely on rarity for its restraint", so the row carries a compact named glyph and the base carries the full badge once. The `Everything Unverified` fixture renders eight marked rows and the suite asserts the marker count equals the row count, that the card still reads, and that it doesn't overflow horizontally.

**Not an error treatment.** `status-unverified` and its `?` are the view's existing tokens, reused rather than reinvented. The test asserts the marker carries `status-unverified` and *not* `status-warning` or `status-danger`, and that its glyph is `?` and not `⚠` or `✕` — checked against both, as the acceptance criterion asks, rather than described.

## Absent data

No environment or location field renders a placeholder — planet, biome, hazard, sentinel, economy, star class, portal are all asserted absent, along with a trailing-dash check, because a missing detail is an omitted element rather than an empty one.

No control implying persistence exists: no checkbox, no textarea, no file input, and no control whose accessible name matches save/remember/note/screenshot/upload/keep. ADR-0008 being `accepted` discharges the requirement's "until a governing decision" clause, but nothing reached from this card persists anything yet, so the v2 prototype's checkable build list, storage tracker, notes and screenshot slot all stay out. Adding them is a story against SPEC-0009, not a loosening of this one.

## Validation

Run against `1ab722e` (tip of #128):

- `npm run typecheck`, `lint`, `lint:css`, `format:check`, `check:tokens` — all clean
- `npm test` — **265 passed**, including 8 new provenance/duration tests; the discipline scan now also covers `Duration.tsx` and `Provenance.tsx`
- `npm run test:mutation` — every mutation still turns the suite red