### PR TITLE
docs(spec): mark SPEC-0005, SPEC-0007 and SPEC-0009 implemented

### DIFF
--- a/docs/openspec/specs/base-planner-card/spec.md
+++ b/docs/openspec/specs/base-planner-card/spec.md
@@ -1,5 +1,5 @@
 ---
-status: approved
+status: implemented
 date: 2026-08-20
 implements: [ADR-0004]
 requires: [SPEC-0001, SPEC-0002, SPEC-0005]

--- a/docs/openspec/specs/durable-store/spec.md
+++ b/docs/openspec/specs/durable-store/spec.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: implemented
 date: 2026-08-28
 implements: [ADR-0008]
 requires: [SPEC-0005]

--- a/docs/openspec/specs/view-foundations/spec.md
+++ b/docs/openspec/specs/view-foundations/spec.md
@@ -1,5 +1,5 @@
 ---
-status: approved
+status: implemented
 date: 2026-08-19
 implements: [ADR-0004]
 requires: [SPEC-0002]


### PR DESCRIPTION
## Summary

Status-only changes to three spec frontmatter blocks.

| Spec | | |
|---|---|---|
| SPEC-0005 view-foundations | `approved` | → `implemented` |
| SPEC-0007 base-planner-card | `approved` | → `implemented` |
| SPEC-0009 durable-store | `draft` | → `implemented` |

Three files, one line each. No other frontmatter key is touched, nothing is reordered, and no body content changes.

## Format handling

All three files are `yaml-frontmatter`, edited in place. The dual-format guard ran first — none of the three carries an inline `- **Status:**` bullet alongside the YAML key, so there was no ambiguous source of truth to refuse.

`nms-base-planner-specs` was re-synced (`qmd update`) so the index reflects the new values.

## Tracker state at the time of the change

Recorded here so the gap is visible rather than discovered later:

- **SPEC-0005** is fully backed — stories #58, #59, #60, #61, #62 and epic #57 are all closed.
- **SPEC-0007** has #95–#99 closed, but its two test stories #100 and #101, and epic #94, are still open.
- **SPEC-0009** has #111–#114 closed, but its test story #115, and epic #110, are still open.

So SPEC-0007 and SPEC-0009 now read `implemented` while the stories that would verify them are unwritten. That was a deliberate call by the repository owner, not an oversight. Closing #100, #101 and #115 would settle it the other way; reverting either spec to `approved` is a one-line change.

---
_Generated by [Claude Code](https://claude.ai/code/session_014L2HZzNbE55Ft7eJ84n5ee)_