### PR TITLE
feat(web): method selection on the node control

### DIFF
--- a/web/scripts/mutation-check.sh
+++ b/web/scripts/mutation-check.sh
@@ -43,7 +43,10 @@ LAYOUT="src/canvas/layout.ts"
 TREE="src/canvas/TreeCanvas.tsx"
 
 MUTABLE="$BASE $TOKENS $TRAP $LIVE $SHELL $BADGE $STORE $MODEL $EDGE $CARD $CANVAS"
-MUTABLE="$MUTABLE $LAYOUT $TREE"
+METHODS="src/canvas/methods.ts"
+CONTROL="src/canvas/NodeControl.tsx"
+
+MUTABLE="$MUTABLE $LAYOUT $TREE $METHODS $CONTROL"
 
 # shellcheck disable=SC2086
 restore() { git checkout -- $MUTABLE 2>/dev/null || true; }
@@ -449,6 +452,46 @@ check "something other than base identity writes to the card border" \
   ".identity {
   border: var(--border-width) solid var(--border);
 }"
+
+# ----------------------------------------------------------------------
+# The node's method control.
+#
+# SPEC-0006 REQ "Method Selection" is two claims that a behavioural test
+# cannot separate on its own: the options come from the payload, and an
+# unavailable one is present-and-inert rather than absent. A canvas that
+# computed legality and happened to agree with the payload passes every
+# rendering assertion, so the first mutation makes it disagree.
+# ----------------------------------------------------------------------
+
+check "the control decides legality instead of reading it" \
+  tests/canvas/method-control.spec.ts "$METHODS" \
+  "    const available = legal.has(method);" \
+  "    const available = true;"
+
+check "an unavailable method is hidden rather than rendered inert" \
+  tests/canvas/method-control.spec.ts "$CONTROL" \
+  "          {options.map((option) => (" \
+  "          {options.filter((shown) => shown.available).map((option) => ("
+
+check "an inert option stops saying why" \
+  tests/canvas/method-control.spec.ts "$CONTROL" \
+  "          .filter((option) => option.reason !== null)" \
+  "          .filter(() => false)"
+
+check "the card stops opening its control" \
+  tests/canvas/method-control.spec.ts "$CARD" \
+  "          onOpen(node.id);" \
+  "          void node.id;"
+
+check "a method change stops recomputing through the boundary" \
+  tests/canvas/method-control.spec.ts "$SHELL" \
+  "      recomputeWith(next);" \
+  "      void next;"
+
+check "the announcement stops naming what changed" \
+  tests/canvas/method-control.spec.ts "$SHELL" \
+  "    const change = pendingChange.current;" \
+  "    const change: string | null = null;"
 
 echo
 if [ "$failures" -gt 0 ]; then

--- a/web/src/canvas/NodeCard.tsx
+++ b/web/src/canvas/NodeCard.tsx
@@ -58,6 +58,15 @@ export interface NodeCardData extends Record<string, unknown> {
   readonly display: string;
   /** The recipe's yield, when it is not 1. Absent otherwise. */
   readonly yieldDisplay: string | null;
+  /**
+   * Open this node's control.
+   *
+   * SPEC-0006 REQ "Method Selection": "Clicking or pressing Enter on a node
+   * MUST open a control". The card is a `<button>`, so Enter and Space
+   * already arrive here as clicks — there is no key handler, which is what
+   * keeps the pointer and keyboard routes from being able to disagree.
+   */
+  readonly onOpen: (nodeId: string) => void;
   /** The application count, exact and unrounded. Absent for a terminal. */
   readonly applicationsDisplay: string | null;
   /**
@@ -113,7 +122,7 @@ function Figure({
 }
 
 export function NodeCard({ data }: NodeProps): ReactNode {
-  const { node, display, yieldDisplay, applicationsDisplay, identity } =
+  const { node, display, yieldDisplay, applicationsDisplay, identity, onOpen } =
     data as unknown as NodeCardData;
 
   /*
@@ -149,6 +158,10 @@ export function NodeCard({ data }: NodeProps): ReactNode {
         type="button"
         className={`node-card interactive selectable ${frame}`}
         data-method={node.method}
+        aria-haspopup="dialog"
+        onClick={() => {
+          onOpen(node.id);
+        }}
         /* Only a leaf can be assigned, so only a leaf carries the attribute.
          * A non-leaf marked "unassigned" would be describing a state it
          * cannot be in. */

--- a/web/src/canvas/NodeControl.tsx
+++ b/web/src/canvas/NodeControl.tsx
@@ -1,0 +1,133 @@
+import type { ReactNode } from "react";
+
+import type { Quantity } from "../boundary";
+import type { CanvasNode } from "./graph-model";
+import { methodOptions } from "./methods";
+
+/*
+ * The node's control: how this item is made.
+ *
+ * Governing: ADR-0004 (React view layer), ADR-0005 (multiple recipes per
+ * output), SPEC-0006 REQ "Method Selection", Accessibility Requirements →
+ * Keyboard Navigation, Focus Management
+ *
+ * Method only. The recipe half of SPEC-0006's control is issue #132 and is
+ * blocked on design rather than on code: the handoff contains no mention of
+ * "recipe", the spec requires an implementation carry the design's answer,
+ * and the segmented control below is drawn for two options against data
+ * that reaches sixty-one. Stretching it here is the thing the spec names.
+ *
+ * The content only. `Popover` owns the dialog, the backdrop, the focus trap
+ * and the return — this renders inside it and never touches focus, which is
+ * what keeps every close route converging on one restore.
+ *
+ * Nothing here decides what is legal. `methodOptions` reads `legalMethods`
+ * off the payload and marks everything else inert; there is no branch on
+ * `terminal`, no check for children, and no item table.
+ */
+
+export interface NodeControlProps {
+  readonly node: CanvasNode;
+  readonly headingId: string;
+  readonly onSelectMethod: (method: string) => void;
+  /** Grouping only — `formatQuantity` never parses. */
+  readonly format: (quantity: Quantity) => string;
+}
+
+export function NodeControl({
+  node,
+  headingId,
+  onSelectMethod,
+  format,
+}: NodeControlProps): ReactNode {
+  const options = methodOptions(node.legalMethods, node.method, node.name);
+
+  return (
+    <div className="node-control">
+      <h3 id={headingId} className="node-control-title">
+        {node.name}
+      </h3>
+
+      {/*
+        The consequence, stated before the change and in the domain's own
+        terms — SPEC-0006 requires it, and the design's example is a route
+        description rather than a confirmation prompt.
+
+        What is stated is the route the payload actually reports: the
+        current method, its yield, and what it consumes per unit. What is
+        NOT stated is what a different method would cost, because the
+        payload carries no figures for a route the planner did not resolve.
+        Inventing them would be the view computing a domain value, which is
+        the rule this whole surface is built under — so the second line
+        names the effect instead, which is true and checkable.
+      */}
+      <p className="node-control-now">
+        <span className="label">Now</span>{" "}
+        <span className="node-control-method">{node.method}</span>
+        {node.recipeYield !== null && (
+          <>
+            {" · "}
+            <span className="numeral">{format(node.recipeYield)}</span> per application
+          </>
+        )}
+      </p>
+
+      {node.inputs.length > 0 && (
+        <ul className="node-control-inputs">
+          {node.inputs.map((input) => (
+            <li key={input.name}>
+              <span className="numeral">{format(input.perUnit)}</span> {input.name} per
+              unit
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <fieldset className="node-control-methods">
+        <legend className="label">Method</legend>
+        <div className="control-row-sm" role="group">
+          {options.map((option) => (
+            <button
+              key={option.method}
+              type="button"
+              className="control control-sm interactive node-method-option"
+              aria-pressed={option.current}
+              /*
+               * `disabled` rather than hidden, and the reason is rendered
+               * below rather than put in a title attribute — a tooltip is
+               * unreachable by keyboard and unreadable by a screen reader
+               * on a disabled control.
+               */
+              disabled={!option.available}
+              aria-describedby={
+                option.reason === null ? undefined : `${headingId}-${option.method}`
+              }
+              onClick={() => {
+                onSelectMethod(option.method);
+              }}
+            >
+              {option.method}
+            </button>
+          ))}
+        </div>
+
+        {options
+          .filter((option) => option.reason !== null)
+          .map((option) => (
+            <p
+              key={option.method}
+              id={`${headingId}-${option.method}`}
+              className="label node-method-reason"
+            >
+              {option.reason}
+            </p>
+          ))}
+      </fieldset>
+
+      <p className="label node-control-effect">
+        Changing the method re-resolves the plan. Every total below this node is
+        recomputed by the planner.
+      </p>
+    </div>
+  );
+}

--- a/web/src/canvas/TreeCanvas.tsx
+++ b/web/src/canvas/TreeCanvas.tsx
@@ -1,14 +1,16 @@
 import { ReactFlow, type Edge, type Node } from "@xyflow/react";
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useId, useMemo, useState, type ReactNode } from "react";
 
 import "@xyflow/react/dist/base.css";
 
 import { formatQuantity, type ResolvedGraph } from "../boundary";
+import { Popover } from "../a11y/Popover";
 import { StatusBadge } from "../shell/StatusBadge";
 import { useViewState } from "../state/useViewState";
 import { toCanvasModel, toLayoutInput, type CanvasModel } from "./graph-model";
 import { layoutGraph, NODE_HEIGHT, NODE_WIDTH, type Placement } from "./layout";
 import { NodeCard } from "./NodeCard";
+import { NodeControl } from "./NodeControl";
 import { TreeEdge } from "./TreeEdge";
 
 /*
@@ -60,9 +62,38 @@ type LayoutState =
 
 const LAYING_OUT: LayoutState = { status: "laying-out" };
 
-export function TreeCanvas({ graph }: { readonly graph: ResolvedGraph }): ReactNode {
+export function TreeCanvas({
+  graph,
+  onSelectMethod,
+}: {
+  readonly graph: ResolvedGraph;
+  /**
+   * A method was chosen for a node.
+   *
+   * The canvas does not hold the override and does not recompute. Both are
+   * the shell's, which owns the crossing — SPEC-0006 requires reassignment
+   * recompute "through the boundary", and a canvas that kept its own copy
+   * of the plan would be the second source of truth SPEC-0005 forbids.
+   */
+  readonly onSelectMethod: (nodeId: string, name: string, method: string) => void;
+}): ReactNode {
   const model = useMemo(() => toCanvasModel(graph), [graph]);
   const [layout, setLayout] = useState<LayoutState>(LAYING_OUT);
+
+  /*
+   * Which node's control is open, by item id rather than by index. A
+   * recompute replaces every node object, and an index would point at a
+   * different node the moment the tree changed shape.
+   */
+  const [openId, setOpenId] = useState<string | null>(null);
+  const controlHeadingId = useId();
+
+  const onOpen = useCallback((nodeId: string) => {
+    setOpenId(nodeId);
+  }, []);
+  const onCloseControl = useCallback(() => {
+    setOpenId(null);
+  }, []);
 
   /*
    * The player's separator, not this file's.
@@ -117,6 +148,7 @@ export function TreeCanvas({ graph }: { readonly graph: ResolvedGraph }): ReactN
         selectable: false,
         data: {
           node,
+          onOpen,
           /*
            * Grouped for display and not otherwise touched. `formatQuantity`
            * inserts separators into the string the module sent; it does not
@@ -153,7 +185,7 @@ export function TreeCanvas({ graph }: { readonly graph: ResolvedGraph }): ReactN
                 }),
         },
       })),
-    [model, layoutOf, preferences.groupSeparator],
+    [model, layoutOf, preferences.groupSeparator, onOpen],
   );
 
   const flowEdges = useMemo<Edge[]>(
@@ -207,6 +239,14 @@ export function TreeCanvas({ graph }: { readonly graph: ResolvedGraph }): ReactN
     );
   }
 
+  /*
+   * `find`, not an index and not a sort. The no-comparator rule this file
+   * is under is about ordering the nodes for render; looking one up by the
+   * id a player just clicked is neither.
+   */
+  const openNode =
+    openId === null ? null : (model.nodes.find((node) => node.id === openId) ?? null);
+
   return (
     <section className="tree-canvas" aria-label="Dependency tree">
       <ReactFlow
@@ -224,6 +264,32 @@ export function TreeCanvas({ graph }: { readonly graph: ResolvedGraph }): ReactN
         fitView
         proOptions={{ hideAttribution: false }}
       />
+
+      {/*
+        The shell's Popover, not a bespoke dialog. Its trap restores focus
+        in the effect cleanup, so Escape, the backdrop and the close control
+        all converge on one restore — SPEC-0006's Focus Management
+        requirement names the return, and a dialog written here would have
+        to reimplement it and would get one of the three routes wrong.
+      */}
+      <Popover
+        open={openNode !== null}
+        onClose={onCloseControl}
+        labelledBy={controlHeadingId}
+      >
+        {openNode !== null && (
+          <NodeControl
+            node={openNode}
+            headingId={controlHeadingId}
+            format={(quantity) =>
+              formatQuantity(quantity, { groupSeparator: preferences.groupSeparator })
+            }
+            onSelectMethod={(method) => {
+              onSelectMethod(openNode.id, openNode.name, method);
+            }}
+          />
+        )}
+      </Popover>
     </section>
   );
 }

--- a/web/src/canvas/graph-model.ts
+++ b/web/src/canvas/graph-model.ts
@@ -45,6 +45,24 @@ export interface CanvasNode {
   readonly applications: Quantity | null;
   readonly terminal: boolean;
   readonly verified: boolean;
+
+  /**
+   * The methods the domain reports as legal for this node.
+   *
+   * Carried verbatim. SPEC-0006 REQ "Method Selection" forbids the canvas
+   * computing which methods are legal, so this is the only thing the
+   * control consults — see canvas/methods.ts.
+   */
+  readonly legalMethods: readonly string[];
+
+  /**
+   * What this node consumes, named, for the control's consequence line.
+   *
+   * Built from the node's own `children` — the same source the edges come
+   * from — so the control states the current route in the domain's terms
+   * without a second crossing.
+   */
+  readonly inputs: readonly { readonly name: string; readonly perUnit: Quantity }[];
 }
 
 export interface CanvasEdge {
@@ -76,6 +94,14 @@ export function toCanvasModel(graph: ResolvedGraph): CanvasModel {
   const nodes: CanvasNode[] = [];
   const edges: CanvasEdge[] = [];
 
+  /*
+   * Names for the control's consequence line. A plain lookup over the same
+   * payload — not a second source, and not an ordering: the iteration below
+   * still walks `graph.nodes` in the payload's order and nothing is sorted.
+   */
+  const nameOf = new Map<string, string>();
+  for (const node of graph.nodes) nameOf.set(node.itemId, node.name);
+
   for (const node of graph.nodes) {
     nodes.push({
       id: node.itemId,
@@ -86,6 +112,11 @@ export function toCanvasModel(graph: ResolvedGraph): CanvasModel {
       applications: node.applications,
       terminal: node.terminal,
       verified: node.verified,
+      legalMethods: node.legalMethods,
+      inputs: node.children.map((child) => ({
+        name: nameOf.get(child.to) ?? child.to,
+        perUnit: child.perUnit,
+      })),
     });
 
     /*

--- a/web/src/canvas/methods.ts
+++ b/web/src/canvas/methods.ts
@@ -1,0 +1,68 @@
+/*
+ * The method options a node offers, and which of them are inert.
+ *
+ * Governing: ADR-0004 (React view layer), ADR-0005 (multiple recipes per
+ * output), SPEC-0006 REQ "Method Selection", SPEC-0005 REQ "The View
+ * Computes No Domain Values"
+ *
+ * "The options offered MUST be the node's `legalMethods` from the payload;
+ * the canvas MUST NOT compute which methods are legal."
+ *
+ * The distinction this file turns on: knowing that the *vocabulary* is
+ * raw / craft / refine is not computing legality. The design fixes that set
+ * ("Methods are craft / refine / raw", and there is deliberately no buy).
+ * Which of them apply to a given item is a domain fact, and the only source
+ * consulted for it is `legalMethods` — there is no table here mapping items
+ * to methods, no terminal-implies-raw shortcut, and no inference from the
+ * presence of children.
+ *
+ * The order is the design's, not the payload's, and that is deliberate: a
+ * segmented control whose buttons move between nodes is a control a player
+ * has to re-read every time. A method the payload reports that this file
+ * has never heard of is still offered — appended in payload order — because
+ * dropping it would be the canvas deciding what is legal by omission.
+ */
+
+/** The design's vocabulary. Not a legality table. */
+export const METHOD_ORDER: readonly string[] = Object.freeze(["raw", "craft", "refine"]);
+
+export interface MethodOption {
+  readonly method: string;
+  /** Reported by the payload as legal for this node. Never inferred. */
+  readonly available: boolean;
+  /** The node's resolved method, per the payload. */
+  readonly current: boolean;
+  /** Why the option is inert. Null when it is selectable. */
+  readonly reason: string | null;
+}
+
+/**
+ * Every method, with the unavailable ones present and inert.
+ *
+ * SPEC-0006: "A method that is not available for the node MUST be rendered
+ * and inert, with the reason stated, rather than hidden. A hidden option
+ * cannot be distinguished from one that does not exist."
+ *
+ * The reason is a statement about the payload rather than an explanation
+ * invented here. The domain does not send a rationale, and a view that
+ * wrote one — "ores cannot be crafted" — would be asserting a domain rule
+ * it does not own and would be wrong the first time the data disagreed.
+ */
+export function methodOptions(
+  legalMethods: readonly string[],
+  current: string,
+  name: string,
+): MethodOption[] {
+  const legal = new Set(legalMethods);
+  const extra = legalMethods.filter((method) => !METHOD_ORDER.includes(method));
+
+  return [...METHOD_ORDER, ...extra].map((method) => {
+    const available = legal.has(method);
+    return {
+      method,
+      available,
+      current: method === current,
+      reason: available ? null : `The planner reports no ${method} route for ${name}.`,
+    };
+  });
+}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1,4 +1,12 @@
-import { lazy, Suspense, useCallback, useId, useState, type ReactNode } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import {
   formatQuantity,
@@ -68,6 +76,24 @@ function failureSummary(outcome: Failure): string {
     ? `contract ${outcome.received}, expected ${outcome.expected}`
     : outcome.code;
 }
+
+/**
+ * Method overrides, carried with the target they were chosen against.
+ *
+ * Plan state, not view state — SPEC-0005 keeps the plan out of `ViewState`
+ * and ADR-0002 puts its permanent home in the URL hash, which is not wired
+ * yet (SPEC-0005 records the decode-on-load path as an open question). Held
+ * here beside the crossing that consumes them, the way the result cache is.
+ */
+interface MethodOverrides {
+  readonly target: string;
+  readonly methods: Readonly<Record<string, string>>;
+}
+
+const NO_OVERRIDES: MethodOverrides = Object.freeze({
+  target: "",
+  methods: Object.freeze({}),
+});
 
 function describeResolution(resolution: Resolution, groupSeparator: string): string {
   switch (resolution.status) {
@@ -222,7 +248,34 @@ function Chrome({
   readonly store: DurableStore;
 }): ReactNode {
   const state = useViewState();
-  const { resolution, resultToken, recompute } = usePlanResolution(client, state);
+
+  /*
+   * Per-node method overrides: plan state, held here rather than in
+   * `ViewState`.
+   *
+   * SPEC-0005 REQ "View State Boundaries" keeps the plan out of view state,
+   * and ADR-0002 puts its permanent home in the URL hash. `encodePlanToHash`
+   * exists and nothing calls it — SPEC-0005 records the decode-on-load path
+   * as an open question — so until that lands these live beside the
+   * crossing that consumes them, the way the result cache does.
+   */
+  const [override, setOverride] = useState<MethodOverrides>(NO_OVERRIDES);
+
+  /*
+   * Overrides belong to the target they were chosen against, so they are
+   * stored with it and *derived* away when it changes rather than cleared
+   * by an effect. An effect calling setState here would be a cascading
+   * render, and the derivation says the same thing more directly: an
+   * override keyed by an item id from the previous tree is not an override
+   * for this one.
+   */
+  const methods =
+    override.target === state.inputs.target ? override.methods : NO_OVERRIDES.methods;
+  const { resolution, resultToken, recompute, recomputeWith } = usePlanResolution(
+    client,
+    state,
+    methods,
+  );
   const stored = useStoredData(store);
 
   /*
@@ -230,8 +283,41 @@ function Chrome({
    * a crossing produces a new answer — not on render, not on a preference
    * change, not on a re-render caused by a parent.
    */
-  useAnnounceOnChange(resultToken, () =>
-    describeResolution(resolution, state.preferences.groupSeparator),
+  /*
+   * What changed, for the announcement.
+   *
+   * SPEC-0006 Accessibility Requirements: a method change "MUST be
+   * announced through an aria-live='polite' region naming what changed and
+   * that totals updated". The existing description says totals updated; it
+   * cannot say what caused it, so the cause is recorded here and consumed
+   * by the next announcement.
+   *
+   * Held in a ref and read at announce time rather than announced on the
+   * click: "totals updated" said before the crossing returns is a claim
+   * about a recompute that has not happened.
+   */
+  const pendingChange = useRef<string | null>(null);
+
+  useAnnounceOnChange(resultToken, () => {
+    const change = pendingChange.current;
+    pendingChange.current = null;
+    const described = describeResolution(resolution, state.preferences.groupSeparator);
+    return change === null ? described : `${change} ${described}`;
+  });
+
+  const onSelectMethod = useCallback(
+    (nodeId: string, name: string, method: string) => {
+      pendingChange.current = `${name} set to ${method}.`;
+      const next = { ...methods, [nodeId]: method };
+      setOverride({ target: state.inputs.target, methods: next });
+      /*
+       * `recomputeWith`, not `recompute`: `setMethods` has not re-rendered
+       * yet, so `recompute` would cross with the previous overrides and
+       * resolve the plan the player just changed away from.
+       */
+      recomputeWith(next);
+    },
+    [methods, recomputeWith, state.inputs.target],
   );
 
   const onRecompute = useCallback(() => {
@@ -283,7 +369,7 @@ function Chrome({
             <Suspense
               fallback={<StatusBadge status="pending" detail="loading the canvas" />}
             >
-              <TreeCanvas graph={resolution.graph} />
+              <TreeCanvas graph={resolution.graph} onSelectMethod={onSelectMethod} />
             </Suspense>
           </section>
         )}

--- a/web/src/state/usePlanResolution.ts
+++ b/web/src/state/usePlanResolution.ts
@@ -34,6 +34,15 @@ export type Resolution =
   /** The inputs are not a plan yet — an empty target, a half-typed quantity. */
   | { readonly status: "unusable"; readonly reason: string };
 
+/**
+ * A stable empty override map.
+ *
+ * A `{}` default in the parameter list would be a new object every render,
+ * which would make the crossing key change every render and reset the
+ * resolution to idle in a loop.
+ */
+const NO_OVERRIDES: Readonly<Record<string, string>> = Object.freeze({});
+
 export interface PlanResolution {
   readonly resolution: Resolution;
   /**
@@ -42,17 +51,42 @@ export interface PlanResolution {
    */
   readonly resultToken: string | null;
   readonly recompute: () => void;
+  /**
+   * Recompute with an override map the caller has just built.
+   *
+   * Separate from `recompute` because the caller that changes a method
+   * holds the next map before React has re-rendered with it. Calling
+   * `recompute` in the same handler would cross with the *previous*
+   * overrides and resolve the plan the player just changed away from.
+   */
+  readonly recomputeWith: (methods: Readonly<Record<string, string>>) => void;
 }
 
 export function usePlanResolution(
   client: BoundaryClient,
   state: ViewState,
+  /**
+   * Per-node method overrides — plan state, not view state.
+   *
+   * SPEC-0005 REQ "View State Boundaries" keeps the plan out of
+   * `ViewState`, and this is why these arrive as an argument rather than
+   * living there. ADR-0002 puts their permanent home in the URL hash;
+   * `encodePlanToHash` exists and nothing calls it yet, which SPEC-0005
+   * records as an open question. Until that path is wired they are held by
+   * the caller that owns the crossing, alongside the result cache.
+   */
+  methods: Readonly<Record<string, string>> = NO_OVERRIDES,
 ): PlanResolution {
   const cache = useRef(new ResultCache<ResolvedGraph>());
   const [resolution, setResolution] = useState<Resolution>({ status: "idle" });
   const [resultToken, setResultToken] = useState<string | null>(null);
 
-  const key = crossingKey(state);
+  /*
+   * The form inputs *and* the overrides. `crossingKey` deliberately covers
+   * only the inputs — a preference change must not discard a good result —
+   * so the override axis is composed on here rather than folded into it.
+   */
+  const key = JSON.stringify([crossingKey(state), methods]);
   const target = state.inputs.target;
   const quantity = state.inputs.quantity;
 
@@ -64,46 +98,49 @@ export function usePlanResolution(
    */
   const latest = useRef(key);
 
-  const run = useCallback(async () => {
-    const validated = validatePlan({ target, quantity });
-    if (!validated.ok) {
-      setResolution({ status: "unusable", reason: validated.reason });
-      setResultToken(null);
-      return;
-    }
+  const run = useCallback(
+    async (overrides: Readonly<Record<string, string>>) => {
+      const validated = validatePlan({ target, quantity, methods: overrides });
+      if (!validated.ok) {
+        setResolution({ status: "unusable", reason: validated.reason });
+        setResultToken(null);
+        return;
+      }
 
-    const requestKey = JSON.stringify([target, quantity]);
-    latest.current = requestKey;
+      const requestKey = JSON.stringify([target, quantity, overrides]);
+      latest.current = requestKey;
 
-    const cached = cache.current.read(requestKey);
-    if (cached) {
-      setResolution({ status: "resolved", graph: cached });
+      const cached = cache.current.read(requestKey);
+      if (cached) {
+        setResolution({ status: "resolved", graph: cached });
+        setResultToken(requestKey);
+        return;
+      }
+
+      setResolution({ status: "pending" });
+
+      const outcome = await client.resolve(validated.plan);
+      if (latest.current !== requestKey) return;
+
+      if (outcome.kind !== "ok") {
+        setResolution({ status: "failed", outcome });
+        setResultToken(null);
+        return;
+      }
+
+      /*
+       * write() returns the frozen value. Using the return rather than the
+       * argument is what stops a component from holding the unfrozen original
+       * and mutating it — which the cache exists to make impossible.
+       */
+      setResolution({
+        status: "resolved",
+        graph: cache.current.write(requestKey, outcome.value),
+      });
       setResultToken(requestKey);
-      return;
-    }
-
-    setResolution({ status: "pending" });
-
-    const outcome = await client.resolve(validated.plan);
-    if (latest.current !== requestKey) return;
-
-    if (outcome.kind !== "ok") {
-      setResolution({ status: "failed", outcome });
-      setResultToken(null);
-      return;
-    }
-
-    /*
-     * write() returns the frozen value. Using the return rather than the
-     * argument is what stops a component from holding the unfrozen original
-     * and mutating it — which the cache exists to make impossible.
-     */
-    setResolution({
-      status: "resolved",
-      graph: cache.current.write(requestKey, outcome.value),
-    });
-    setResultToken(requestKey);
-  }, [client, target, quantity]);
+    },
+    [client, target, quantity],
+  );
 
   /*
    * Not automatic on every keystroke: the target field is typed into a
@@ -113,8 +150,15 @@ export function usePlanResolution(
    * user did.
    */
   const recompute = useCallback(() => {
-    void run();
-  }, [run]);
+    void run(methods);
+  }, [run, methods]);
+
+  const recomputeWith = useCallback(
+    (overrides: Readonly<Record<string, string>>) => {
+      void run(overrides);
+    },
+    [run],
+  );
 
   useEffect(() => {
     /*
@@ -128,5 +172,5 @@ export function usePlanResolution(
     }
   }, [key]);
 
-  return { resolution, resultToken, recompute };
+  return { resolution, resultToken, recompute, recomputeWith };
 }

--- a/web/src/styles/canvas.css
+++ b/web/src/styles/canvas.css
@@ -277,3 +277,73 @@
 .tree-canvas .react-flow__attribution a {
   color: var(--text); /* 9.57 on the --panel backing above */
 }
+
+/*
+ * The node control.
+ *
+ * Governing: SPEC-0006 REQ "Method Selection", SPEC-0005 REQ "Token
+ * Discipline", REQ "Component Styling Discipline"
+ *
+ * Rendered inside the shell's Popover, so the dialog frame, the backdrop
+ * and the close control are already styled by shell.css. What is here is
+ * the control's own content.
+ */
+.node-control {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-inline-size: 18rem;
+}
+
+.node-control-title {
+  margin: 0;
+  color: var(--text-bright);
+  font-size: var(--text-h3);
+}
+
+.node-control-now {
+  margin: 0;
+  color: var(--text);
+}
+
+.node-control-method {
+  color: var(--text-bright);
+  text-transform: uppercase;
+}
+
+.node-control-inputs {
+  margin: 0;
+  padding-inline-start: var(--space-4);
+  color: var(--text-muted);
+  font-size: var(--text-meta);
+}
+
+.node-control-methods {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+/*
+ * An unavailable method is present and inert, never hidden — SPEC-0006:
+ * "A hidden option cannot be distinguished from one that does not exist."
+ * The disabled treatment is a dimmed label and a removed pointer, not a
+ * removed element, and the reason is rendered as text below rather than
+ * hidden in a title attribute a keyboard user cannot reach.
+ */
+.node-method-option:disabled {
+  color: var(--text-dim);
+  cursor: not-allowed;
+}
+
+.node-method-reason {
+  margin: var(--space-1) 0 0;
+  color: var(--text-muted);
+}
+
+.node-control-effect {
+  margin: 0;
+  padding-block-start: var(--space-2);
+  border-block-start: var(--border-width) solid var(--divider);
+  color: var(--text-muted);
+}

--- a/web/tests/canvas/method-control.spec.ts
+++ b/web/tests/canvas/method-control.spec.ts
@@ -1,0 +1,362 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { expect, test, type Page } from "@playwright/test";
+
+import { METHOD_ORDER, methodOptions } from "../../src/canvas/methods";
+import { countCrossings, crossings } from "../helpers/crossings";
+
+/*
+ * Governing: ADR-0004 (React view layer), ADR-0005 (multiple recipes per
+ * output), SPEC-0006 REQ "Method Selection", Accessibility Requirements →
+ * Keyboard Navigation, Focus Management
+ *
+ * Method selection only. The recipe half is #132 and is blocked on design:
+ * the handoff has no answer for a control that must stay usable at
+ * sixty-one options, and SPEC-0006 forbids stretching the segmented control
+ * drawn for two.
+ *
+ * The claim that needs the most care is "the canvas MUST NOT compute which
+ * methods are legal". A behavioural test cannot show it — a canvas that
+ * computed legality and happened to agree with the payload would pass every
+ * assertion below. So the options are compared against the payload's own
+ * `legalMethods`, read out of the captured crossing, and the source is
+ * scanned for the shortcuts a computing implementation would need.
+ */
+
+const CANVAS = { name: "Dependency tree" } as const;
+
+async function resolve(page: Page, target: string): Promise<void> {
+  await page.getByLabel("Target").fill(target);
+  await page.getByRole("button", { name: "Recompute" }).click();
+  await expect(
+    page.getByRole("region", CANVAS).locator(".node-card").first(),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+/** The payload's own methods, per node, from the captured crossing. */
+async function payloadMethods(
+  page: Page,
+): Promise<Record<string, { method: string; legal: string[] }>> {
+  return page.evaluate(() => {
+    const answer = window.__lastResolve;
+    const parsed: unknown = typeof answer === "string" ? JSON.parse(answer) : answer;
+    const nodes =
+      (
+        parsed as {
+          data?: {
+            graph?: {
+              nodes?: { name?: string; method?: string; legalMethods?: string[] }[];
+            };
+          };
+        }
+      ).data?.graph?.nodes ?? [];
+    return Object.fromEntries(
+      nodes.map((node) => [
+        node.name ?? "",
+        { method: node.method ?? "", legal: node.legalMethods ?? [] },
+      ]),
+    );
+  });
+}
+
+/**
+ * A node the domain reports more than one method for, and the method it is
+ * not currently on.
+ *
+ * Derived from the payload rather than named, because which nodes have an
+ * alternative is a property of the shipped artifact. In the Antimatter tree
+ * the terminals carry `raw/refine` while Chromatic Metal is refine-only —
+ * hard-coding the wrong one is how this test first failed.
+ */
+function anAlternative(
+  payload: Record<string, { method: string; legal: string[] }>,
+): { name: string; from: string; to: string } | null {
+  for (const [name, entry] of Object.entries(payload)) {
+    const other = entry.legal.find((method) => method !== entry.method);
+    if (other !== undefined) return { name, from: entry.method, to: other };
+  }
+  return null;
+}
+
+async function openControlFor(page: Page, name: string): Promise<void> {
+  await page
+    .getByRole("region", CANVAS)
+    .locator(".node-card")
+    .filter({ hasText: name })
+    .first()
+    .click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+}
+
+/* ----------------------------------------------------------------------
+ * The option list, as a pure function
+ * ------------------------------------------------------------------- */
+
+test("the options are the payload's, and nothing else decides", () => {
+  const options = methodOptions(["raw"], "raw", "Condensed Carbon");
+
+  expect(options.map((option) => option.method)).toEqual([...METHOD_ORDER]);
+  expect(options.filter((option) => option.available).map((o) => o.method)).toEqual([
+    "raw",
+  ]);
+  expect(options.find((option) => option.current)?.method).toBe("raw");
+});
+
+test("an unavailable method is present and carries a reason", () => {
+  const options = methodOptions(["raw"], "raw", "Condensed Carbon");
+  const refine = options.find((option) => option.method === "refine");
+
+  expect(refine, "refine was dropped from the list").toBeDefined();
+  expect(refine?.available).toBe(false);
+  expect(refine?.reason).toContain("Condensed Carbon");
+  expect(refine?.reason).toContain("refine");
+});
+
+test("a selectable option carries no reason", () => {
+  /*
+   * The companion. A list where every option carried a reason would
+   * satisfy the assertion above and tell the player nothing.
+   */
+  const options = methodOptions(["craft", "refine"], "craft", "Glass");
+  for (const option of options.filter((o) => o.available)) {
+    expect(option.reason, `${option.method} is available and still explained`).toBeNull();
+  }
+});
+
+test("a method the payload reports and this file has never heard of is still offered", () => {
+  /*
+   * Dropping it would be the canvas deciding legality by omission, which is
+   * the failure the requirement is about — just in the opposite direction
+   * from the obvious one.
+   */
+  const options = methodOptions(["raw", "cook"], "cook", "Fried Something");
+  const cook = options.find((option) => option.method === "cook");
+
+  expect(cook?.available).toBe(true);
+  expect(cook?.current).toBe(true);
+  expect(options.map((o) => o.method).slice(0, 3)).toEqual([...METHOD_ORDER]);
+});
+
+test("the order is the design's, so the buttons do not move between nodes", () => {
+  const terminal = methodOptions(["raw"], "raw", "A").map((o) => o.method);
+  const crafted = methodOptions(["craft", "refine"], "craft", "B").map((o) => o.method);
+  expect(terminal).toEqual(crafted);
+});
+
+/* ----------------------------------------------------------------------
+ * Nothing in the canvas computes legality
+ * ------------------------------------------------------------------- */
+
+test("no canvas source decides a method for itself", () => {
+  /*
+   * The acceptance criterion asks for this to be "checkable by grep as
+   * much as by test", and it is the half a behavioural test cannot do.
+   *
+   * `methods.ts` is the only file that builds the option list, and what it
+   * must not do is reach for anything other than its arguments: not the
+   * terminal flag, not the children, not an item identifier.
+   */
+  const directory = path.join(import.meta.dirname, "..", "..", "src", "canvas");
+  const source = readFileSync(path.join(directory, "methods.ts"), "utf8");
+  const code = source.replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, "");
+
+  for (const shortcut of ["terminal", "children", "itemId", "recipe"]) {
+    expect(code.includes(shortcut), `methods.ts consults ${shortcut}`).toBe(false);
+  }
+
+  /*
+   * And no other canvas source builds an option list of its own. Two
+   * places deciding what is offered is two places to drift from the
+   * payload.
+   */
+  const others = readdirSync(directory).filter(
+    (name) => name !== "methods.ts" && (name.endsWith(".ts") || name.endsWith(".tsx")),
+  );
+  expect(others.length).toBeGreaterThan(3);
+  for (const file of others) {
+    const body = readFileSync(path.join(directory, file), "utf8").replace(
+      /\/\*[\s\S]*?\*\/|\/\/[^\n]*/g,
+      "",
+    );
+    expect(body.includes("METHOD_ORDER"), `canvas/${file} builds its own list`).toBe(
+      false,
+    );
+  }
+});
+
+/* ----------------------------------------------------------------------
+ * The control, in the real application
+ * ------------------------------------------------------------------- */
+
+test.describe("in the shell", () => {
+  test.beforeEach(async ({ page }) => {
+    await countCrossings(page);
+    await page.goto("/");
+    await resolve(page, "ANTIMATTER");
+  });
+
+  test("clicking a node opens its control", async ({ page }) => {
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await openControlFor(page, "Antimatter");
+    await expect(page.getByRole("dialog").getByRole("heading")).toHaveText("Antimatter");
+  });
+
+  test("Enter opens the control from the keyboard alone", async ({ page }) => {
+    /*
+     * SPEC-0006: "Clicking or pressing Enter on a node MUST open a
+     * control." Driven with keys rather than by calling a handler — the
+     * card is a button, and this is what shows the keyboard route reaches
+     * the same place the pointer does.
+     */
+    await page.getByRole("region", CANVAS).locator(".node-card").first().focus();
+    await page.keyboard.press("Enter");
+    await expect(page.getByRole("dialog")).toBeVisible();
+  });
+
+  test("the options offered are the payload's legalMethods", async ({ page }) => {
+    const payload = await payloadMethods(page);
+    const name = "Antimatter";
+    const expected = payload[name];
+    expect(expected, "the payload was not captured").toBeDefined();
+
+    await openControlFor(page, name);
+
+    const enabled = await page
+      .getByRole("dialog")
+      .locator(".node-method-option:not([disabled])")
+      .evaluateAll((nodes) => nodes.map((node) => node.textContent ?? ""));
+
+    expect([...enabled].sort()).toEqual([...(expected?.legal ?? [])].sort());
+  });
+
+  test("an unavailable method is rendered, inert, and says why", async ({ page }) => {
+    const payload = await payloadMethods(page);
+    /* A terminal: the domain reports raw and nothing else. */
+    const terminal = Object.entries(payload).find(
+      ([, entry]) => entry.legal.length === 1 && entry.legal[0] === "raw",
+    );
+    expect(terminal, "no single-method node in this tree").toBeDefined();
+    const name = terminal?.[0] ?? "";
+
+    await openControlFor(page, name);
+    const dialog = page.getByRole("dialog");
+
+    const refine = dialog.locator(".node-method-option").filter({ hasText: "refine" });
+    await expect(refine, "the unavailable option was hidden").toHaveCount(1);
+    await expect(refine).toBeDisabled();
+
+    /* The reason is text on the page, not a title attribute. */
+    await expect(dialog).toContainText(`no refine route for ${name}`);
+  });
+
+  test("the control states the current route before anything changes", async ({
+    page,
+  }) => {
+    /* Chromatic Metal: refine, with real inputs and a recipe yield. */
+    await openControlFor(page, "Chromatic Metal");
+    const dialog = page.getByRole("dialog");
+
+    await expect(dialog).toContainText("Now");
+    await expect(dialog.locator(".node-control-method")).toHaveText("refine");
+    /* Its inputs, from the payload's own children. */
+    await expect(dialog.locator(".node-control-inputs li").first()).toBeVisible();
+    await expect(dialog).toContainText("recomputed by the planner");
+  });
+
+  test("choosing a method recomputes through the boundary, once", async ({ page }) => {
+    const swap = anAlternative(await payloadMethods(page));
+    expect(swap, "no node in this tree offers an alternative method").not.toBeNull();
+    if (swap === null) return;
+
+    const before = (await crossings(page)).resolve;
+    expect(before).toBe(1);
+
+    await openControlFor(page, swap.name);
+    await page
+      .getByRole("dialog")
+      .locator(".node-method-option:not([disabled])")
+      .filter({ hasText: swap.to })
+      .click();
+
+    await expect
+      .poll(async () => (await crossings(page)).resolve, { timeout: 20_000 })
+      .toBe(before + 1);
+
+    /*
+     * And no other stage was reached. A canvas that adjusted a figure
+     * itself would show no second crossing at all; one that reached for
+     * rollup would be doing stage 2's work.
+     */
+    const after = await crossings(page);
+    expect(after.rollup + after.power).toBe(0);
+  });
+
+  test("the change is announced, naming what changed and that totals updated", async ({
+    page,
+  }) => {
+    const swap = anAlternative(await payloadMethods(page));
+    expect(swap, "no node in this tree offers an alternative method").not.toBeNull();
+    if (swap === null) return;
+
+    await openControlFor(page, swap.name);
+    await page
+      .getByRole("dialog")
+      .locator(".node-method-option:not([disabled])")
+      .filter({ hasText: swap.to })
+      .click();
+
+    const live = page.locator('[aria-live="polite"]');
+    await expect(live).toContainText(`${swap.name} set to ${swap.to}`, {
+      timeout: 20_000,
+    });
+    await expect(live).toContainText("Totals updated");
+  });
+
+  test("Escape closes the control and returns focus to the node", async ({ page }) => {
+    const card = page
+      .getByRole("region", CANVAS)
+      .locator(".node-card")
+      .filter({ hasText: "Antimatter" })
+      .first();
+
+    await card.click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await expect(card).toBeFocused();
+  });
+
+  test("the close control returns focus too, not only Escape", async ({ page }) => {
+    /*
+     * The route an Escape-only implementation gets wrong. #82's trap
+     * restores in the effect cleanup so all routes converge; this is what
+     * notices if that stops being true.
+     */
+    const card = page
+      .getByRole("region", CANVAS)
+      .locator(".node-card")
+      .filter({ hasText: "Antimatter" })
+      .first();
+
+    await card.click();
+    await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
+
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await expect(card).toBeFocused();
+  });
+
+  test("focus stays inside the control while it is open", async ({ page }) => {
+    await openControlFor(page, "Chromatic Metal");
+    const dialog = page.getByRole("dialog");
+
+    for (let i = 0; i < 8; i += 1) {
+      await page.keyboard.press("Tab");
+      await expect(
+        dialog.locator(":focus"),
+        `focus left on tab ${String(i)}`,
+      ).toHaveCount(1);
+    }
+  });
+});

--- a/web/tests/fixtures/node-card-harness.tsx
+++ b/web/tests/fixtures/node-card-harness.tsx
@@ -217,6 +217,14 @@ function toNode(spec: Spec, index: number): Node {
     applications: spec.applications === null ? null : exact(spec.applications),
     terminal: spec.terminal,
     verified: spec.verified,
+    /*
+     * The fixture exercises the card, not the method control. Every node
+     * here reports its own resolved method as the only legal one, which is
+     * the shape a terminal really has and keeps the control out of the way
+     * of the card's own assertions.
+     */
+    legalMethods: [spec.method],
+    inputs: [],
   };
 
   /* `identity` is spread rather than assigned, because the project builds
@@ -225,6 +233,14 @@ function toNode(spec: Spec, index: number): Node {
   const data: NodeCardData = {
     ...(spec.identity === undefined ? {} : { identity: spec.identity }),
     node,
+    /*
+     * The card fixture asserts the card. Opening the control is the
+     * canvas's job, exercised against the real application in
+     * tests/canvas/method-control.spec.ts.
+     */
+    onOpen: () => {
+      /* this fixture mounts no control */
+    },
     display: formatQuantity(node.total, { groupSeparator: "," }),
     yieldDisplay:
       node.recipeYield === null || node.recipeYield === "1"


### PR DESCRIPTION
Closes #87
Part of #84

Implements SPEC-0006 REQ "Method Selection".

> **Scoped to Method Selection.** The Recipe Selection half moved to #132, which is blocked on design rather than on code. `docs/design/tree-canvas/handoff.md` contains **no mention of "recipe"** — verified, not assumed — and SPEC-0006 requires an implementation carry the design's answer rather than stretch the segmented control past the two options it was drawn for. design.md's own Migration Plan already sequences them apart: step 4 (method) is buildable, step 5 (recipe) *"is blocked on design rather than on code"*.
>
> The real data backs that up: **Chromatic Metal carries 25 legal recipes** and Ionised Cobalt 5, measured from the shipped artifact during this work.

## The rule that needed care

*"The options offered MUST be the node's `legalMethods` from the payload; the canvas MUST NOT compute which methods are legal."*

Knowing the vocabulary is raw / craft / refine is the design's fact — it fixes that set and deliberately excludes buy. Which of them apply to a given item is the domain's. `methods.ts` reads only `legalMethods` for that: no terminal-implies-raw shortcut, no inference from the presence of children, no item table.

That distinction is not testable by rendering. **A canvas that computed legality and happened to agree with the payload passes every rendering assertion**, so it is checked two more ways:

- the rendered options are compared against `legalMethods` read out of the captured crossing, not against a fixture
- `methods.ts` is scanned for the shortcuts a computing implementation would need (`terminal`, `children`, `itemId`, `recipe`), and every other canvas source is scanned to confirm none builds a second option list

A method the payload reports and `methods.ts` has never heard of is **still offered**, appended in payload order. Dropping it would be the canvas deciding legality by omission — the same failure from the other direction, and the case a whitelist quietly gets wrong.

## Inert, not hidden

*"A hidden option cannot be distinguished from one that does not exist."* Unavailable methods render `disabled`, and the reason is **text on the page** rather than a `title` attribute — a tooltip is unreachable by keyboard and unread by a screen reader on a disabled control.

The reason states what the payload says (*"The planner reports no refine route for Silver."*) rather than inventing a domain rule the view does not own and would get wrong the first time the data disagreed.

## The consequence line

SPEC-0006 requires the control state the consequence before the change, in the domain's terms. It names the route the payload **actually reports**: current method, recipe yield, and what the node consumes per unit, from its own `children`.

It deliberately does **not** price the alternative. The payload carries no figures for a route the planner did not resolve, so any number there would be the view computing a domain value — the rule this whole surface is built under. The second line names the effect instead, which is true and checkable.

## Where overrides live

Plan state, held beside the crossing rather than in `ViewState` — SPEC-0005 keeps the plan out of view state, and ADR-0002 puts its permanent home in the URL hash. `encodePlanToHash` exists and **nothing calls it**; SPEC-0005 records the decode-on-load path as an open question. Until that lands they sit next to the result cache, and the comment says so.

They are stored **with the target they were chosen against** and derived away when it changes, rather than cleared by an effect. An override keyed by an item id from the previous tree is not an override for this one, and the effect version was a cascading render the linter correctly rejected.

`recomputeWith` rather than `recompute`: `setState` has not re-rendered when the handler runs, so `recompute` would cross with the *previous* overrides and resolve the plan the player just changed away from.

## A test that was wrong first

The change tests originally drove Chromatic Metal from refine to craft. Chromatic Metal is **refine-only** — the terminals are the nodes carrying `raw/refine`. The tests now derive the node and target method from the payload, so they follow the artifact instead of a guess about it.

## Verification

**294 tests pass** (up from 278), 16 new. lint, lint:css, typecheck, format:check, check:tokens, build all clean. **47/47 mutations red**, six new:

| Mutation | Catches |
|---|---|
| the control decides legality instead of reading it | payload-sourced options |
| an unavailable method is hidden rather than rendered inert | present-and-inert |
| an inert option stops saying why | the stated reason |
| the card stops opening its control | click / Enter route |
| a method change stops recomputing through the boundary | recompute, not in-place adjustment |
| the announcement stops naming what changed | the live-region requirement |

Both focus-return routes are tested separately — Escape and the close control — because an Escape-only implementation leaves the other green.

No protected paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)