### PR TITLE
ci: skip the frontend suite on documentation-only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,9 +141,61 @@ jobs:
         # literal and stylelint does not look.
         run: npm run check:tokens
 
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The diff below needs the base commit present, not just the tip.
+          fetch-depth: 0
+      - id: filter
+        env:
+          # Empty on a push event; the branch below keys off that.
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          # Push to main always runs everything. A push has no single obvious
+          # base to diff against — a force-push or a new branch leaves
+          # github.event.before unusable — and main is the branch whose green
+          # is load-bearing, so it is not the place to economise.
+          if [ -z "${BASE_SHA:-}" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "push event — running everything"
+            exit 0
+          fi
+
+          changed=$(git diff --name-only "$BASE_SHA" HEAD)
+          echo "changed files:"
+          echo "$changed" | sed 's/^/  /'
+
+          # `code` is true when ANY changed file falls outside the documentation
+          # set. The test is deliberately this way round: a path nobody thought
+          # about counts as code and runs the suite. Adding a directory here is
+          # a decision to stop testing changes to it.
+          if printf '%s\n' "$changed" | grep -qvE '^(docs/|[^/]+\.md$|LICENSE$)'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "-> code changed, running the frontend suite"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "-> documentation only, skipping the frontend suite"
+          fi
+
   web-test:
     name: Frontend tests
     runs-on: ubuntu-latest
+    # The frontend suite plus its mutation check is the long pole in CI —
+    # 8-11 minutes against 15-40s for every other job — and a change confined
+    # to docs/ cannot alter its outcome. Gated on `changes` rather than a
+    # workflow-level paths-ignore: a job skipped by `if` still reports a
+    # conclusion, which a required status check accepts, whereas a workflow
+    # that never triggers leaves that check pending and the pull request
+    # unmergeable.
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     defaults:
       run:
         working-directory: web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,18 @@ jobs:
     # that never triggers leaves that check pending and the pull request
     # unmergeable.
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    #
+    # The condition is "not explicitly false" rather than "is true", and it uses
+    # a status-check function so it overrides the default skip-on-needs-failure.
+    # That combination is deliberate: if the gate job fails, its output is empty,
+    # empty is not 'false', and the suite runs.
+    #
+    # Without it a failing gate would SKIP this job, and a skipped required
+    # check counts as passing — so a broken detector would look identical to a
+    # green suite. Failing toward running is the same direction the predicate
+    # itself fails in, and it means the safety of this gate does not depend on
+    # branch protection also requiring the gate job.
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     defaults:
       run:
         working-directory: web


### PR DESCRIPTION
## Summary

Frontend tests is the long pole in CI — 8–11 minutes against 15–40s for every other job, because it runs the 41-mutation check after the suite. #133 spent **11m00s** validating three one-line frontmatter changes under `docs/`.

A `changes` job diffs the PR against its base and sets an output. `web-test` gains `needs: changes` and an `if`.

## Why a job gate and not `paths-ignore`

This is the part worth reviewing. A job skipped by `if` still reports a conclusion, and a required status check accepts that. A workflow that never triggers reports nothing at all — so a required check stays pending and the PR cannot merge.

**If `Frontend tests` is a required check on this repo, a workflow-level `paths-ignore` would have deadlocked every docs-only PR permanently.** I couldn't read the branch-protection settings to confirm one way or the other, so the change is built to be correct under either.

## Two conservative choices

- **Push to `main` always runs everything.** A push has no reliable base to diff against — force-pushes and new branches leave `github.event.before` unusable — and `main`'s green is the load-bearing one.
- **The predicate asks whether anything falls _outside_ the documentation set**, so a path nobody anticipated counts as code and runs the suite. Adding a directory to that set is a deliberate decision to stop testing it.

`.github/` is deliberately **not** in the documentation set: a change to this workflow runs the full suite, so CI cannot switch off its own testing.

Documentation set: `docs/**`, root-level `*.md`, `LICENSE`. Markdown under `web/` is **not** included — it sits beside the code, and being wrong there costs more than the 8 minutes saved.

## Verification

The filter predicate was exercised against 11 cases, including the PRs currently in flight:

| Changed | Result |
|---|---|
| `docs/adrs/ADR-0009-*.md` (#126) | skip |
| `docs/openspec/specs/*/spec.md` (#133) | skip |
| `README.md`, `CLAUDE.md`, `LICENSE` | skip |
| `web/src/card/BasePlannerCard.tsx` | run |
| `web/scripts/mutation-check.sh` | run |
| `internal/rollup/rollup.go` | run |
| docs + code mixed | run |
| `.github/workflows/ci.yml` | run |
| `web/README.md` | run |

All 11 behave as intended. The workflow also parses as YAML.

## What this PR cannot show

It edits `.github/`, so it correctly runs the full suite — the skip path is not exercised here. The skip becomes observable on the first docs-only PR opened after this merges; #133 is the natural candidate if it's rebased.

The `changes` job itself adds one short job (checkout at `fetch-depth: 0`) to every run. On a repo this size that's seconds against 8–11 minutes saved on docs-only PRs.

## Not included

Only `web-test` is gated. `web-build`, `web-lint`, `web-typecheck` and `web-format` also cannot be affected by a docs-only change, but they finish in 15–40s, so gating them trades real risk for little time. Easy to extend later if wanted — they would reuse the same `changes` output.

---
_Generated by [Claude Code](https://claude.ai/code/session_014L2HZzNbE55Ft7eJ84n5ee)_