### PR TITLE
feat(web): leaf assignment to bases

### DIFF
--- a/web/scripts/mutation-check.sh
+++ b/web/scripts/mutation-check.sh
@@ -46,7 +46,10 @@ MUTABLE="$BASE $TOKENS $TRAP $LIVE $SHELL $BADGE $STORE $MODEL $EDGE $CARD $CANV
 METHODS="src/canvas/methods.ts"
 CONTROL="src/canvas/NodeControl.tsx"
 
-MUTABLE="$MUTABLE $LAYOUT $TREE $METHODS $CONTROL"
+ASSIGN="src/canvas/useLeafAssignment.ts"
+BASES="src/canvas/bases.ts"
+
+MUTABLE="$MUTABLE $LAYOUT $TREE $METHODS $CONTROL $ASSIGN $BASES"
 
 # shellcheck disable=SC2086
 restore() { git checkout -- $MUTABLE 2>/dev/null || true; }
@@ -492,6 +495,40 @@ check "the announcement stops naming what changed" \
   tests/canvas/method-control.spec.ts "$SHELL" \
   "    const change = pendingChange.current;" \
   "    const change: string | null = null;"
+
+# ----------------------------------------------------------------------
+# Leaf assignment.
+#
+# The first mutation is the bug this story actually shipped and a test
+# caught: skipping the dispatch when the map goes empty suppresses the
+# *clear*, which is a real change — a leaf no longer gathered at a base
+# changes that base's totals exactly as reassigning it does.
+# ----------------------------------------------------------------------
+
+check "clearing an assignment stops recomputing" \
+  tests/canvas/assignment.spec.ts "$ASSIGN" \
+  "    if (constants === null) return;" \
+  "    if (constants === null || Object.keys(next).length === 0) return;"
+
+check "the rollup goes out without the assignment on it" \
+  tests/canvas/assignment.spec.ts "$ASSIGN" \
+  "    const request: RollupRequest = { plan, assignments: next, constants };" \
+  "    const request: RollupRequest = { plan, assignments: {}, constants };"
+
+check "a non-leaf is offered a base it cannot be gathered at" \
+  tests/canvas/assignment.spec.ts "$CONTROL" \
+  "      {node.terminal && (" \
+  "      {(node.terminal || true) && ("
+
+check "an assigned leaf stops taking its base colour" \
+  tests/canvas/assignment.spec.ts "$BASES" \
+  "  return BASES.find((base) => base.id === id)?.slot;" \
+  "  return undefined;"
+
+check "the assignment announcement stops naming the base" \
+  tests/canvas/assignment.spec.ts "$SHELL" \
+  "      const label = BASES.find((base) => base.id === baseId)?.label;" \
+  "      const label: string | undefined = undefined;"
 
 echo
 if [ "$failures" -gt 0 ]; then

--- a/web/src/canvas/NodeControl.tsx
+++ b/web/src/canvas/NodeControl.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import type { Quantity } from "../boundary";
+import { BASES } from "./bases";
 import type { CanvasNode } from "./graph-model";
 import { methodOptions } from "./methods";
 
@@ -30,6 +31,14 @@ export interface NodeControlProps {
   readonly node: CanvasNode;
   readonly headingId: string;
   readonly onSelectMethod: (method: string) => void;
+  /**
+   * Assign this leaf to a base, or clear it with null.
+   *
+   * Only a leaf can be assigned, so the control only renders for one.
+   */
+  readonly onAssign: (baseId: string | null) => void;
+  /** The base this leaf is currently assigned to, if any. */
+  readonly assignedTo: string | null;
   /** Grouping only — `formatQuantity` never parses. */
   readonly format: (quantity: Quantity) => string;
 }
@@ -38,6 +47,8 @@ export function NodeControl({
   node,
   headingId,
   onSelectMethod,
+  onAssign,
+  assignedTo,
   format,
 }: NodeControlProps): ReactNode {
   const options = methodOptions(node.legalMethods, node.method, node.name);
@@ -124,9 +135,44 @@ export function NodeControl({
           ))}
       </fieldset>
 
+      {/*
+        Only a leaf is assignable. A non-leaf is produced by the steps below
+        it rather than gathered at a base, and offering the control on one
+        would be describing a state it cannot be in — the same reason the
+        card only carries `data-identity` on a leaf.
+
+        A `<select>` because the design asks for one and because it is
+        operable by keyboard without anything added: SPEC-0006 requires the
+        assignment "be changed and committed without a pointing device", and
+        a bespoke listbox would have to re-earn that.
+      */}
+      {node.terminal && (
+        <p className="node-control-base">
+          <label className="label" htmlFor={`${headingId}-base`}>
+            Gathered at
+          </label>{" "}
+          <select
+            id={`${headingId}-base`}
+            className="control control-sm interactive node-base-select"
+            value={assignedTo ?? ""}
+            onChange={(event) => {
+              onAssign(event.target.value === "" ? null : event.target.value);
+            }}
+          >
+            <option value="">Unassigned</option>
+            {BASES.map((base) => (
+              <option key={base.id} value={base.id}>
+                {base.label}
+              </option>
+            ))}
+          </select>
+        </p>
+      )}
+
       <p className="label node-control-effect">
-        Changing the method re-resolves the plan. Every total below this node is
-        recomputed by the planner.
+        {node.terminal
+          ? "Changing the method or the base recomputes through the planner. No figure is adjusted here."
+          : "Changing the method re-resolves the plan. Every total below this node is recomputed by the planner."}
       </p>
     </div>
   );

--- a/web/src/canvas/TreeCanvas.tsx
+++ b/web/src/canvas/TreeCanvas.tsx
@@ -9,6 +9,7 @@ import { StatusBadge } from "../shell/StatusBadge";
 import { useViewState } from "../state/useViewState";
 import { toCanvasModel, toLayoutInput, type CanvasModel } from "./graph-model";
 import { layoutGraph, NODE_HEIGHT, NODE_WIDTH, type Placement } from "./layout";
+import { slotFor } from "./bases";
 import { NodeCard } from "./NodeCard";
 import { NodeControl } from "./NodeControl";
 import { TreeEdge } from "./TreeEdge";
@@ -65,6 +66,8 @@ const LAYING_OUT: LayoutState = { status: "laying-out" };
 export function TreeCanvas({
   graph,
   onSelectMethod,
+  assignments,
+  onAssign,
 }: {
   readonly graph: ResolvedGraph;
   /**
@@ -76,6 +79,9 @@ export function TreeCanvas({
    * of the plan would be the second source of truth SPEC-0005 forbids.
    */
   readonly onSelectMethod: (nodeId: string, name: string, method: string) => void;
+  /** Item id to base id. The canvas renders it; it does not own it. */
+  readonly assignments: Readonly<Record<string, string>>;
+  readonly onAssign: (nodeId: string, name: string, baseId: string | null) => void;
 }): ReactNode {
   const model = useMemo(() => toCanvasModel(graph), [graph]);
   const [layout, setLayout] = useState<LayoutState>(LAYING_OUT);
@@ -150,6 +156,16 @@ export function TreeCanvas({
           node,
           onOpen,
           /*
+           * SPEC-0006 REQ "Node Card": an assigned leaf carries its base's
+           * colour on the border, an unassigned one a dashed neutral frame
+           * and a warning dot. The slot is looked up from the assignments
+           * the shell holds — the card does not know what a base is.
+           */
+          ...(() => {
+            const slot = slotFor(assignments, node.id);
+            return slot === undefined ? {} : { identity: slot };
+          })(),
+          /*
            * Grouped for display and not otherwise touched. `formatQuantity`
            * inserts separators into the string the module sent; it does not
            * parse it, and SPEC-0005 forbids the view doing arithmetic on a
@@ -185,7 +201,7 @@ export function TreeCanvas({
                 }),
         },
       })),
-    [model, layoutOf, preferences.groupSeparator, onOpen],
+    [model, layoutOf, preferences.groupSeparator, onOpen, assignments],
   );
 
   const flowEdges = useMemo<Edge[]>(
@@ -284,8 +300,12 @@ export function TreeCanvas({
             format={(quantity) =>
               formatQuantity(quantity, { groupSeparator: preferences.groupSeparator })
             }
+            assignedTo={assignments[openNode.id] ?? null}
             onSelectMethod={(method) => {
               onSelectMethod(openNode.id, openNode.name, method);
+            }}
+            onAssign={(baseId) => {
+              onAssign(openNode.id, openNode.name, baseId);
             }}
           />
         )}

--- a/web/src/canvas/bases.ts
+++ b/web/src/canvas/bases.ts
@@ -1,0 +1,50 @@
+/*
+ * The bases a leaf can be assigned to.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0006 REQ "Leaf Assignment to
+ * Bases", REQ "Node Card"
+ *
+ * The six identity slots are the design's: `base.css` defines a colour
+ * token for each, and SPEC-0006 REQ "Node Card" requires an assigned leaf
+ * carry "a 3px border in that base's colour token". So the *set* is not
+ * invented here.
+ *
+ * The names are placeholders and are the one thing here that is not
+ * settled. A base's real name comes from the bases map, which has no spec
+ * and no surface yet — the design handoff expects one ("base identity has
+ * the name in the popover/base panel"). Until it exists a slot needs
+ * something a player can say out loud, and "Base 3" is that without
+ * pretending to be a name someone chose.
+ *
+ * The identifier is what crosses the boundary. `RollupRequest.assignments`
+ * maps an item id to a base id, and the domain takes the id as an opaque
+ * string — so the slot number is carried through rather than translated,
+ * and a real registry can replace the label without touching what the
+ * domain receives.
+ */
+
+import type { IdentitySlot } from "../card/BasePlannerCard";
+
+export interface Base {
+  readonly slot: IdentitySlot;
+  /** What crosses the boundary. Opaque to the domain. */
+  readonly id: string;
+  /** Placeholder until the bases map exists. */
+  readonly label: string;
+}
+
+export const BASES: readonly Base[] = Object.freeze(
+  ([1, 2, 3, 4, 5, 6] as const).map((slot) =>
+    Object.freeze({ slot, id: `base-${String(slot)}`, label: `Base ${String(slot)}` }),
+  ),
+);
+
+/** The slot a leaf is showing, or undefined when it is unassigned. */
+export function slotFor(
+  assignments: Readonly<Record<string, string>>,
+  itemId: string,
+): IdentitySlot | undefined {
+  const id = assignments[itemId];
+  if (id === undefined) return undefined;
+  return BASES.find((base) => base.id === id)?.slot;
+}

--- a/web/src/canvas/useLeafAssignment.ts
+++ b/web/src/canvas/useLeafAssignment.ts
@@ -1,0 +1,120 @@
+import { useCallback, useRef, useState } from "react";
+
+import type { Curated, Plan, RollupRequest } from "../boundary";
+
+/*
+ * Assignment in, recomputation out.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0006 REQ "Leaf Assignment to
+ * Bases", SPEC-0005 REQ "The View Computes No Domain Values", REQ "Boundary
+ * Client"
+ *
+ * "Reassigning a leaf MUST cause the affected figures to be recomputed
+ * through the boundary; the canvas MUST NOT adjust any base's totals
+ * itself." This hook is where that is true or not — it holds the
+ * assignments and every change to them issues stage 2, rather than editing
+ * a figure a previous call returned.
+ *
+ * It goes through `client.rollup()` and adds no boundary method of its own,
+ * which #88 requires and #95 is the reason for: two stories adding methods
+ * to one client is the drift a foundation story exists to prevent. It also
+ * does not reach past the boundary for the domain's rollup types, which
+ * SPEC-0006 names as the tempting workaround and closes.
+ *
+ * `constants` is nullable, and that is the honest shape rather than a
+ * convenience. `RollupRequest` requires curated constants; the application
+ * has no source for them — they exist only in test fixtures, and the base
+ * planner card is not mounted either — so today the shell passes null and
+ * this hook holds assignments without dispatching. A fixture supplies real
+ * constants and proves the dispatch. One code path, with the missing half
+ * stated rather than hidden behind a stub.
+ *
+ * Out-of-order replies are dropped by sequence number, the way
+ * usePlanResolution and useConfiguredBase both do it: two assignments in
+ * flight settle in whatever order the module finishes them, and without
+ * this the figures land from whichever call happened to be slower.
+ */
+
+interface AssignmentClient {
+  readonly rollup: (request: RollupRequest) => Promise<unknown>;
+}
+
+export interface LeafAssignmentOptions {
+  readonly client: AssignmentClient;
+  readonly plan: Plan;
+  /** Null until the application has a curated-constants source. */
+  readonly constants: Curated | null;
+}
+
+export interface LeafAssignment {
+  readonly assignments: Readonly<Record<string, string>>;
+  /** Assign a leaf to a base, or pass null to clear it. */
+  readonly assign: (itemId: string, baseId: string | null) => void;
+  /** Settled stage-2 round trips this hook has dispatched. */
+  readonly dispatches: number;
+}
+
+export function useLeafAssignment({
+  client,
+  plan,
+  constants,
+}: LeafAssignmentOptions): LeafAssignment {
+  const [assignments, setAssignments] = useState<Readonly<Record<string, string>>>({});
+  const [dispatches, setDispatches] = useState(0);
+  const sequence = useRef(0);
+
+  /*
+   * The current map, readable synchronously.
+   *
+   * The dispatch happens in the handler rather than in an effect on
+   * `assignments`, for two reasons. An effect cannot tell the first render
+   * from a real change without a flag, and StrictMode double-invokes both
+   * the effect and the flag — which is how a mount ends up issuing a rollup
+   * for an empty map. And an effect that skipped the empty map to avoid
+   * that would skip the *clear* as well, which is a real change: a leaf no
+   * longer gathered at a base changes that base's totals exactly as
+   * reassigning it does. The first version had that bug and a test found it.
+   */
+  const current = useRef<Readonly<Record<string, string>>>({});
+
+  const assign = useCallback(
+    (itemId: string, baseId: string | null) => {
+      const previous = current.current;
+
+      /*
+       * Rebuilt without the key rather than set to undefined. An assignments
+       * map carrying `{ COBALT: undefined }` serialises to a field the domain
+       * has to interpret, and "assigned to nothing" is not in the contract.
+       */
+      const next: Readonly<Record<string, string>> =
+        baseId === null
+          ? Object.fromEntries(Object.entries(previous).filter(([key]) => key !== itemId))
+          : { ...previous, [itemId]: baseId };
+
+      if (baseId === null && !(itemId in previous)) return;
+      if (baseId !== null && previous[itemId] === baseId) return;
+
+      current.current = next;
+      setAssignments(next);
+
+      if (constants === null) return;
+
+      const issued = sequence.current + 1;
+      sequence.current = issued;
+
+      const request: RollupRequest = { plan, assignments: next, constants };
+      void client.rollup(request).then(() => {
+        /*
+         * What this hook owns is that the recompute was asked for. A
+         * superseded assignment's reply is dropped rather than counted, the
+         * way usePlanResolution and useConfiguredBase both do it.
+         */
+        if (sequence.current !== issued) return;
+        setDispatches((count) => count + 1);
+      });
+    },
+    [client, plan, constants],
+  );
+
+  return { assignments, assign, dispatches };
+}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -3,24 +3,29 @@ import {
   Suspense,
   useCallback,
   useId,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
 } from "react";
 
 import {
+  EMPTY_PLAN,
   formatQuantity,
   isQuantity,
+  validatePlan,
   type BoundaryClient,
   type Failure,
 } from "../boundary";
 import { LiveRegionProvider } from "../a11y/LiveRegion";
-import { useAnnounceOnChange } from "../a11y/useLiveRegion";
+import { useAnnounceOnChange, useLiveRegion } from "../a11y/useLiveRegion";
 import { Popover } from "../a11y/Popover";
 import { ViewStateProvider } from "../state/ViewStateProvider";
 import { useViewDispatch, useViewState } from "../state/useViewState";
 import { usePlanResolution, type Resolution } from "../state/usePlanResolution";
 import { useStoredData } from "../state/useStoredData";
+import { BASES } from "../canvas/bases";
+import { useLeafAssignment } from "../canvas/useLeafAssignment";
 import { DurableStore } from "../store";
 import { StatusBadge } from "./StatusBadge";
 
@@ -297,6 +302,31 @@ function Chrome({
    * about a recompute that has not happened.
    */
   const pendingChange = useRef<string | null>(null);
+  const { announce } = useLiveRegion();
+
+  /*
+   * The plan the assignment hook sends with its rollup. Built through
+   * `validatePlan` rather than assembled by hand — SPEC-0005 makes it the
+   * single gate, and a second construction path is a second thing to drift.
+   */
+  const plan = useMemo(() => {
+    const validated = validatePlan({
+      target: state.inputs.target,
+      quantity: state.inputs.quantity,
+      methods,
+    });
+    return validated.ok ? validated.plan : EMPTY_PLAN;
+  }, [state.inputs.target, state.inputs.quantity, methods]);
+
+  /*
+   * `constants: null` is not a stub. `RollupRequest` requires curated
+   * constants and the application has no source for them — they exist only
+   * in test fixtures, and the base planner card that would own them is not
+   * mounted either. So assignments are held and rendered here, and the
+   * stage-2 dispatch this hook performs is exercised where constants exist.
+   * Stated rather than hidden: see the PR for #88.
+   */
+  const { assignments, assign } = useLeafAssignment({ client, plan, constants: null });
 
   useAnnounceOnChange(resultToken, () => {
     const change = pendingChange.current;
@@ -304,6 +334,27 @@ function Chrome({
     const described = describeResolution(resolution, state.preferences.groupSeparator);
     return change === null ? described : `${change} ${described}`;
   });
+
+  const onAssign = useCallback(
+    (nodeId: string, name: string, baseId: string | null) => {
+      assign(nodeId, baseId);
+
+      /*
+       * Announced directly rather than through the recompute's description.
+       * SPEC-0006 requires an assignment change be announced naming what
+       * changed; it also expects "totals updated", and saying so here would
+       * be false while no recompute is dispatched. What is true is the
+       * assignment, so that is what is said.
+       */
+      const label = BASES.find((base) => base.id === baseId)?.label;
+      announce(
+        label === undefined
+          ? `${name} is no longer assigned to a base.`
+          : `${name} assigned to ${label}.`,
+      );
+    },
+    [assign, announce],
+  );
 
   const onSelectMethod = useCallback(
     (nodeId: string, name: string, method: string) => {
@@ -369,7 +420,12 @@ function Chrome({
             <Suspense
               fallback={<StatusBadge status="pending" detail="loading the canvas" />}
             >
-              <TreeCanvas graph={resolution.graph} onSelectMethod={onSelectMethod} />
+              <TreeCanvas
+                graph={resolution.graph}
+                onSelectMethod={onSelectMethod}
+                assignments={assignments}
+                onAssign={onAssign}
+              />
             </Suspense>
           </section>
         )}

--- a/web/src/styles/canvas.css
+++ b/web/src/styles/canvas.css
@@ -347,3 +347,25 @@
   border-block-start: var(--border-width) solid var(--divider);
   color: var(--text-muted);
 }
+
+/*
+ * The base assignment control.
+ *
+ * Governing: SPEC-0006 REQ "Leaf Assignment to Bases"
+ *
+ * A native select, which the design asks for and which is keyboard
+ * operable without anything added — the requirement is that the assignment
+ * "be changed and committed without a pointing device", and a bespoke
+ * listbox would have to re-earn that.
+ */
+.node-control-base {
+  display: flex;
+  align-items: center;
+  margin: 0;
+  gap: var(--space-2);
+}
+
+.node-base-select {
+  background-color: var(--input-bg);
+  color: var(--text);
+}

--- a/web/tests/canvas/assignment.spec.ts
+++ b/web/tests/canvas/assignment.spec.ts
@@ -1,0 +1,326 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { expect, test, type Page } from "@playwright/test";
+
+import { BASES, slotFor } from "../../src/canvas/bases";
+import { countCrossings, crossings } from "../helpers/crossings";
+
+/*
+ * Governing: ADR-0004 (React view layer), SPEC-0006 REQ "Leaf Assignment to
+ * Bases", REQ "Node Card", Accessibility Requirements → Keyboard Navigation
+ *
+ * Three claims, checked where each is actually observable:
+ *
+ *   - the assignment is operable with the keyboard alone — the application
+ *   - a change recomputes through the boundary — the fixture, because
+ *     `RollupRequest` needs curated constants the application has no source
+ *     for, and a shell that cannot dispatch cannot demonstrate a dispatch
+ *   - the canvas adjusts no figure itself — the source, since a canvas that
+ *     recomputed *and* adjusted would pass both of the above
+ *
+ * The URL-hash round trip is #135. `Plan` carries no assignments,
+ * `RollupRequest` carries them beside it, and SPEC-0002 encodes neither —
+ * so there is nothing here asserting a link survives them.
+ */
+
+const CANVAS = { name: "Dependency tree" } as const;
+
+/*
+ * `exact: true` throughout the fixture, because "reassign cobalt" contains
+ * "assign cobalt" and getByRole matches an accessible name by substring.
+ * Without it the locator resolves to two buttons and fails strict mode,
+ * which is how these three tests failed first time round.
+ */
+const FIXTURE = "/tests/fixtures/assignment.html";
+
+async function resolve(page: Page, target: string): Promise<void> {
+  await page.getByLabel("Target").fill(target);
+  await page.getByRole("button", { name: "Recompute" }).click();
+  await expect(
+    page.getByRole("region", CANVAS).locator(".node-card").first(),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+/** A leaf, by the payload's own terminal flag. */
+async function aLeafName(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const answer = window.__lastResolve;
+    const parsed: unknown = typeof answer === "string" ? JSON.parse(answer) : answer;
+    const nodes =
+      (
+        parsed as {
+          data?: { graph?: { nodes?: { name?: string; terminal?: boolean }[] } };
+        }
+      ).data?.graph?.nodes ?? [];
+    return nodes.find((node) => node.terminal === true)?.name ?? "";
+  });
+}
+
+/* ----------------------------------------------------------------------
+ * The slot mapping
+ * ------------------------------------------------------------------- */
+
+test("a base id maps to the slot whose colour the card draws", () => {
+  const second = BASES[1];
+  expect(second).toBeDefined();
+  expect(slotFor({ COBALT: second?.id ?? "" }, "COBALT")).toBe(second?.slot);
+});
+
+test("an unassigned leaf has no slot, and neither does an unknown base", () => {
+  /*
+   * The second half matters: a base id from a link or an older session that
+   * no longer maps to a slot must read as unassigned rather than as slot
+   * undefined-coloured, which is how a leaf ends up with no border at all.
+   */
+  expect(slotFor({}, "COBALT")).toBeUndefined();
+  expect(slotFor({ COBALT: "base-99" }, "COBALT")).toBeUndefined();
+});
+
+test("every base has a distinct id and a distinct slot", () => {
+  expect(new Set(BASES.map((base) => base.id)).size).toBe(BASES.length);
+  expect(new Set(BASES.map((base) => base.slot)).size).toBe(BASES.length);
+  expect(BASES.length).toBe(6);
+});
+
+/* ----------------------------------------------------------------------
+ * The canvas adjusts nothing itself
+ * ------------------------------------------------------------------- */
+
+test("no canvas source adds a boundary method or does its own arithmetic", () => {
+  /*
+   * "The canvas MUST NOT adjust any base's totals itself", and #88: "The
+   * assignment call goes through #95's `rollup` client method. This story
+   * adds no boundary method of its own."
+   *
+   * A behavioural test cannot separate "recomputed" from "recomputed and
+   * then adjusted" — both render a changed figure.
+   */
+  const directory = path.join(import.meta.dirname, "..", "..", "src", "canvas");
+  const files = readdirSync(directory).filter(
+    (name) => name.endsWith(".ts") || name.endsWith(".tsx"),
+  );
+  expect(files.length).toBeGreaterThan(5);
+
+  for (const file of files) {
+    const code = readFileSync(path.join(directory, file), "utf8").replace(
+      /\/\*[\s\S]*?\*\/|\/\/[^\n]*/g,
+      "",
+    );
+    expect(
+      /\bNumber\s*\(|\bparseInt\s*\(|\bparseFloat\s*\(|\.\s*toFixed\s*\(/.test(code),
+      `canvas/${file} converts a quantity to a number`,
+    ).toBe(false);
+    /* The domain's own types are past the boundary; SPEC-0006 names the reach. */
+    expect(code.includes("internal/"), `canvas/${file} reaches past the boundary`).toBe(
+      false,
+    );
+  }
+});
+
+/* ----------------------------------------------------------------------
+ * The dispatch, where constants exist
+ * ------------------------------------------------------------------- */
+
+test.describe("with curated constants", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(FIXTURE, { waitUntil: "load" });
+    await expect(page.locator("body")).toHaveAttribute("data-ready", "true");
+  });
+
+  test("assigning a leaf issues a rollup carrying the assignment", async ({ page }) => {
+    await page.getByRole("button", { name: "assign cobalt", exact: true }).click();
+
+    await expect
+      .poll(async () => page.evaluate(() => window.__assignment.requests().length), {
+        timeout: 10_000,
+      })
+      .toBeGreaterThan(0);
+
+    const request = await page.evaluate(() => window.__assignment.requests().at(-1));
+    expect(request?.assignments).toEqual({ COBALT: "base-2" });
+    /* The plan travels with it, unchanged. */
+    expect(request?.plan.target).toBe("ANTIMATTER");
+  });
+
+  test("reassigning issues another rollup with the new base", async ({ page }) => {
+    await page.getByRole("button", { name: "assign cobalt", exact: true }).click();
+    await expect
+      .poll(async () => page.evaluate(() => window.__assignment.dispatches()), {
+        timeout: 10_000,
+      })
+      .toBe(1);
+
+    await page.getByRole("button", { name: "reassign cobalt", exact: true }).click();
+    await expect
+      .poll(async () => page.evaluate(() => window.__assignment.dispatches()), {
+        timeout: 10_000,
+      })
+      .toBe(2);
+
+    const request = await page.evaluate(() => window.__assignment.requests().at(-1));
+    expect(request?.assignments).toEqual({ COBALT: "base-5" });
+  });
+
+  test("clearing an assignment removes the key rather than blanking it", async ({
+    page,
+  }) => {
+    /*
+     * `{ COBALT: undefined }` serialises to a field the domain has to
+     * interpret, and "assigned to nothing" is not in the boundary contract.
+     */
+    await page.getByRole("button", { name: "assign cobalt", exact: true }).click();
+    await expect
+      .poll(async () => page.evaluate(() => window.__assignment.dispatches()), {
+        timeout: 10_000,
+      })
+      .toBe(1);
+
+    await page.getByRole("button", { name: "clear cobalt", exact: true }).click();
+    await expect(page.locator("[data-assigned]")).toHaveAttribute("data-assigned", "");
+
+    const keys = await page.evaluate(() => {
+      const last = window.__assignment.requests().at(-1);
+      return Object.keys(last?.assignments ?? {});
+    });
+    expect(keys).not.toContain("COBALT");
+  });
+});
+
+/* ----------------------------------------------------------------------
+ * The control, in the real application
+ * ------------------------------------------------------------------- */
+
+test.describe("in the shell", () => {
+  test.beforeEach(async ({ page }) => {
+    await countCrossings(page);
+    await page.goto("/");
+    await resolve(page, "ANTIMATTER");
+  });
+
+  test("a leaf offers a base, and a non-leaf does not", async ({ page }) => {
+    const leaf = await aLeafName(page);
+    expect(leaf, "no terminal in this tree").not.toBe("");
+
+    await page
+      .getByRole("region", CANVAS)
+      .locator(".node-card")
+      .filter({ hasText: leaf })
+      .first()
+      .click();
+    await expect(page.getByRole("dialog").getByLabel("Gathered at")).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    /*
+     * A non-leaf is produced by the steps below it rather than gathered, so
+     * offering the control would describe a state it cannot be in.
+     */
+    await page
+      .getByRole("region", CANVAS)
+      .locator(".node-card")
+      .filter({ hasText: "Antimatter" })
+      .first()
+      .click();
+    await expect(page.getByRole("dialog").getByLabel("Gathered at")).toHaveCount(0);
+  });
+
+  test("a leaf is assigned with the keyboard alone", async ({ page }) => {
+    /*
+     * SPEC-0006: "the base assignment can be changed and committed without
+     * a pointing device". Driven with keys from the card onward — not by
+     * calling a handler, and not by clicking the select open.
+     */
+    const leaf = await aLeafName(page);
+    await page
+      .getByRole("region", CANVAS)
+      .locator(".node-card")
+      .filter({ hasText: leaf })
+      .first()
+      .focus();
+    await page.keyboard.press("Enter");
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    const select = page.getByRole("dialog").getByLabel("Gathered at");
+    await select.focus();
+    await expect(select).toBeFocused();
+    await select.selectOption("base-3");
+
+    await expect(select).toHaveValue("base-3");
+  });
+
+  test("an assigned leaf takes its base's colour on the border", async ({ page }) => {
+    const leaf = await aLeafName(page);
+    const card = page
+      .getByRole("region", CANVAS)
+      .locator(".node-card")
+      .filter({ hasText: leaf })
+      .first();
+
+    const before = await card.evaluate((el) => getComputedStyle(el).borderTopColor);
+    await expect(card).toHaveAttribute("data-identity", "unassigned");
+
+    await card.click();
+    await page.getByRole("dialog").getByLabel("Gathered at").selectOption("base-3");
+    await page.keyboard.press("Escape");
+
+    await expect(card).toHaveAttribute("data-identity", "3");
+    const after = await card.evaluate((el) => getComputedStyle(el).borderTopColor);
+    expect(after, "the border did not take the base's colour").not.toBe(before);
+  });
+
+  test("the assignment is announced, naming the leaf and the base", async ({ page }) => {
+    const leaf = await aLeafName(page);
+    await page
+      .getByRole("region", CANVAS)
+      .locator(".node-card")
+      .filter({ hasText: leaf })
+      .first()
+      .click();
+    await page.getByRole("dialog").getByLabel("Gathered at").selectOption("base-3");
+
+    const live = page.locator('[aria-live="polite"]');
+    await expect(live).toContainText(`${leaf} assigned to Base 3`);
+  });
+
+  test("clearing an assignment is announced too, and returns the dashed frame", async ({
+    page,
+  }) => {
+    const leaf = await aLeafName(page);
+    const card = page
+      .getByRole("region", CANVAS)
+      .locator(".node-card")
+      .filter({ hasText: leaf })
+      .first();
+
+    await card.click();
+    const select = page.getByRole("dialog").getByLabel("Gathered at");
+    await select.selectOption("base-3");
+    await select.selectOption("");
+
+    await expect(page.locator('[aria-live="polite"]')).toContainText(
+      "no longer assigned",
+    );
+    await page.keyboard.press("Escape");
+    await expect(card).toHaveAttribute("data-identity", "unassigned");
+  });
+
+  test("assigning does not cross the resolve boundary again", async ({ page }) => {
+    /*
+     * An assignment is stage 2's business. A canvas that re-resolved on one
+     * would be doing stage 1's work for a change stage 1 does not see.
+     */
+    const before = (await crossings(page)).resolve;
+    const leaf = await aLeafName(page);
+
+    await page
+      .getByRole("region", CANVAS)
+      .locator(".node-card")
+      .filter({ hasText: leaf })
+      .first()
+      .click();
+    await page.getByRole("dialog").getByLabel("Gathered at").selectOption("base-3");
+    await page.keyboard.press("Escape");
+
+    expect((await crossings(page)).resolve).toBe(before);
+  });
+});

--- a/web/tests/fixtures/assignment-harness.tsx
+++ b/web/tests/fixtures/assignment-harness.tsx
@@ -1,0 +1,125 @@
+import { createRoot } from "react-dom/client";
+import { StrictMode, useEffect, useState, type ReactNode } from "react";
+
+import type { Curated, Plan, RollupRequest } from "../../src/boundary";
+import { useLeafAssignment } from "../../src/canvas/useLeafAssignment";
+
+import "../../src/styles/tokens.css";
+import "../../src/styles/base.css";
+
+/*
+ * The assignment hook, with the constants the application does not have.
+ *
+ * Governing: SPEC-0006 REQ "Leaf Assignment to Bases"
+ *
+ * "Reassigning a leaf MUST cause the affected figures to be recomputed
+ * through the boundary." `RollupRequest` requires curated constants and the
+ * application has no source for them, so the shell holds assignments and
+ * dispatches nothing. This fixture supplies them, which is what makes the
+ * dispatch observable at all — the same shape every SPEC-0007 card story
+ * ships in, for the same reason.
+ *
+ * The client is a stand-in rather than the real boundary: what this proves
+ * is that a change reaches `rollup` with the assignment on it, and the real
+ * module's answer is not what the requirement is about. The captured
+ * requests are exposed so a test can assert what crossed rather than that
+ * something did.
+ */
+
+const CONSTANTS: Curated = {
+  biodomeCropSlots: "4",
+  faunaYieldPerCycle: "1",
+  faunaCycleSeconds: "1800",
+  stepsPerProcessor: "1",
+  depotThreshold: "1000",
+  processSeconds: "36",
+  panelsPerBattery: "3",
+} as Curated;
+
+const PLAN: Plan = {
+  target: "ANTIMATTER",
+  quantity: "1",
+  methods: {},
+  recipes: {},
+} as Plan;
+
+declare global {
+  interface Window {
+    __assignment: {
+      /** Every rollup request the hook issued, in order. */
+      requests: () => RollupRequest[];
+      dispatches: () => number;
+    };
+  }
+}
+
+const requests: RollupRequest[] = [];
+
+function Harness(): ReactNode {
+  const [client] = useState(() => ({
+    rollup: async (request: RollupRequest): Promise<unknown> => {
+      requests.push(request);
+      return Promise.resolve({ kind: "ok" });
+    },
+  }));
+
+  const { assignments, assign, dispatches } = useLeafAssignment({
+    client,
+    plan: PLAN,
+    constants: CONSTANTS,
+  });
+
+  /*
+   * Published from an effect rather than during render: assigning to a
+   * global while rendering is a side effect, and React may render twice.
+   */
+  useEffect(() => {
+    window.__assignment = {
+      requests: () => requests,
+      dispatches: () => dispatches,
+    };
+  }, [dispatches]);
+
+  return (
+    <main>
+      <p data-dispatches={String(dispatches)}>dispatches: {dispatches}</p>
+      <p data-assigned={assignments["COBALT"] ?? ""}>
+        cobalt: {assignments["COBALT"] ?? "none"}
+      </p>
+      <button
+        type="button"
+        onClick={() => {
+          assign("COBALT", "base-2");
+        }}
+      >
+        assign cobalt
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          assign("COBALT", "base-5");
+        }}
+      >
+        reassign cobalt
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          assign("COBALT", null);
+        }}
+      >
+        clear cobalt
+      </button>
+    </main>
+  );
+}
+
+const root = document.getElementById("root");
+if (root) {
+  createRoot(root).render(
+    <StrictMode>
+      <Harness />
+    </StrictMode>,
+  );
+  document.body.dataset["ready"] = "true";
+}

--- a/web/tests/fixtures/assignment.html
+++ b/web/tests/fixtures/assignment.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Leaf assignment fixture</title>
+  </head>
+  <body>
+    <!--
+      Governing: SPEC-0006 REQ "Leaf Assignment to Bases"
+
+      Its own page because it supplies the curated constants the
+      application has no source for, which is what makes the stage-2
+      dispatch observable.
+    -->
+    <div id="root"></div>
+    <script type="module" src="./assignment-harness.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #88
Part of #84

Implements SPEC-0006 REQ "Leaf Assignment to Bases".

> **Stacked on #134.** Base is `feat/87-method-and-recipe-selection`, not `main` — the assignment control lives in the node popover #87 builds, exactly as the design handoff describes ("base assignment fully operable via the popover select"). **Merge #134 first**, then this retargets cleanly.

## Two gaps found and split rather than papered over

**The URL-hash round trip is #135.** #88's criterion said an assignment "appears in plan state as SPEC-0002 encodes it, and survives a URL-hash round trip". Verified against the code:

| | |
|---|---|
| `Plan` (TS and Go wire) | `{target, quantity, methods, recipes}` — **no assignments** |
| `RollupRequest` | carries `assignments` as a **sibling of** `plan` |
| SPEC-0002 | eleven requirements, **none** covering assignment encoding |
| `encodePlanToHash` | serialises `Plan` only |

This builds to the narrower reading — assignments travel to the domain through the documented boundary contract, which `RollupRequest.assignments` satisfies. Nothing here claims a link survives them. #135 carries the wider question, and notes **SPEC-0007's site configuration has the identical gap**.

**The application has no curated constants.** `RollupRequest` requires them; they exist only in test fixtures, and the base planner card that would own them is not mounted. So `constants: null` in the shell is the honest shape, not a stub: assignments are held and their colours rendered, and the stage-2 dispatch is proven in a fixture that supplies real constants — the same shape every SPEC-0007 card story ships in.

## A bug the tests found

The first version dispatched from an effect on `assignments`, guarded with "skip when the map is empty" to avoid a mount dispatch. That guard **suppressed the clear** — and clearing is a real change: a leaf no longer gathered at a base changes that base's totals exactly as reassigning it does.

The dispatch now happens in the handler. That also removes a StrictMode hazard: an effect cannot tell the first render from a real change without a flag, and StrictMode double-invokes both the effect and the flag. It is mutation #1 below.

## Where each claim is checked

Deliberately not all in one place, because the three claims are observable in different places:

- **keyboard-operable end to end** — the real application, driven with keys from the card through Enter into the select, not by calling a handler
- **recomputes through the boundary** — the fixture, because a shell that cannot dispatch cannot demonstrate a dispatch
- **the canvas adjusts nothing itself** — the source, since a canvas that recomputed *and* adjusted passes both of the above

A base id that no longer maps to a slot reads as unassigned rather than as an uncoloured border — the case a link or an older session produces.

## Verification

**307 tests pass** (up from 294), 13 new. lint, lint:css, typecheck, format:check, check:tokens, build all clean. **52/52 mutations red**, five new:

| Mutation | Catches |
|---|---|
| **clearing an assignment stops recomputing** | the shipped bug, above |
| the rollup goes out without the assignment on it | what actually crosses |
| a non-leaf is offered a base it cannot be gathered at | leaf-only control |
| an assigned leaf stops taking its base colour | the border requirement |
| the assignment announcement stops naming the base | the live-region requirement |

No protected paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)