### PR TITLE
docs: ADR-0015 and SPEC-0010 — the Base Atlas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 .sdd/
 
+# qmd's local hybrid-search index (ADR-0024 makes qmd a hard dependency).
+# A machine-local sqlite database plus embeddings, rebuilt by /sdd:index —
+# committed, it is megabytes of binary that is stale the next commit.
+.qmd/
+
 # Local Claude Code settings — machine-specific, not shared.
 .claude/settings.local.json
 

--- a/docs/adrs/ADR-0010-places-first-and-the-shell.md
+++ b/docs/adrs/ADR-0010-places-first-and-the-shell.md
@@ -140,7 +140,7 @@ Build the shell chrome against the current direction and revisit when sharing fo
 * Good, because the question genuinely can be answered later — nothing is technically impossible in either direction
 * Bad, because chrome built against plan → base bakes that direction into every surface, and the revisit becomes a rewrite of the thing just built
 * Bad, because SPEC-0007 already deferred once and the deferral is why `BasePlannerCard` renders only in a fixture; deferring the same question twice is a pattern rather than a judgement
-* Bad, because ADR-0010's sharing model needs to know what a share references, and it cannot be specified while the referent is undecided
+* Bad, because ADR-0014's sharing model needs to know what a share references, and it cannot be specified while the referent is undecided
 
 ## Architecture Diagram
 

--- a/docs/adrs/ADR-0011-base-atlas-coordinate-space-and-route-graph.md
+++ b/docs/adrs/ADR-0011-base-atlas-coordinate-space-and-route-graph.md
@@ -1,0 +1,227 @@
+---
+status: proposed
+date: 2026-08-29
+decision-makers: [Jon Stump]
+extends: [ADR-0010]
+related: [ADR-0003, ADR-0004, ADR-0006, ADR-0007, ADR-0008]
+---
+
+# ADR-0011: The Base Atlas — an authored coordinate space, and a route graph that is presentation
+
+## Context and Problem Statement
+
+`docs/design/bases-map/` is a complete, high-fidelity design for the Base Atlas: a pixel map of every base, dashed district territories, and traceable harvest-run routes with numbered waypoints and per-leg travel methods. It has a handoff document and an interactive prototype. It has no ADR, no spec, no issues, and no implementation.
+
+It is not an optional extra, and the evidence is that two accepted decisions already reason about it as though it exists. ADR-0006 carries a section titled "Base Atlas: present in the route graph, absent from the coordinate space" and argues at length that a freighter joins harvest runs while being excluded from spatial layout. ADR-0007 weighs and rejects an option on the grounds that "the Atlas dossier is a summary panel, and settlement state is too dense for it." Both make load-bearing arguments about a surface nobody has specified.
+
+The surface introduces two things this codebase does not have. **A coordinate space**: bases acquire positions, and the handoff is explicit that they are player-arranged rather than read from the game — authored data with no in-game source of truth, which needs a home. **A route graph**: a harvest run is an ordered sequence of stops with a travel method per leg. So: where do positions and runs live, is a run authored or derived, and does the route graph belong in the Go domain alongside the rollup or in the view?
+
+## Decision Drivers
+
+* **The domain/view boundary is strict and worth keeping strict.** SPEC-0005 REQ "The View Computes No Domain Values" is enforced mechanically, by source scan, in three suites. Anything routed through the domain needs a boundary crossing — an ADR-sized commitment under ADR-0003 — so the question of whether a route *is* a domain value has to be answered rather than assumed.
+* **ADR-0006 must not be contradicted.** A freighter appears in the route graph as a node and is never positioned. Whatever shape positions take, "has a position" cannot be a property every place carries.
+* **ADR-0008 already settled where durable user data lives.** SPEC-0009 gives one `PlaceRecord` type in a local-first IndexedDB workspace. Positions and runs, if durable, live there and inherit its schema-version and eviction rules — not a second store.
+* **Authored data is not derived data, and calling it derived would be a lie.** The design shows two runs matching the planner's two targets, which invites "derive runs from assignments". A plan carries a *set* of bases; a run is a *sequence* with a travel method per leg. Two of a run's three components have no source in any plan.
+* **A pixel map of clickable buildings is the hardest accessibility case in the project.** SPEC-0005 requires WCAG 2.1 AA, colour never the sole carrier, and keyboard operability. A surface whose primary structure is spatial cannot meet that by bolting on an alternative afterwards.
+* **KISS, and the project's own precedent.** SPEC-0006 REQ "Layout Geometry Is Not a Domain Value" already drew this line once for the tree canvas: positions are the view's business, quantities are the domain's. A second surface should not draw it in a different place.
+
+## Considered Options
+
+* **A. Domain-owned: positions and routes are domain values, computed across a new boundary crossing**
+* **B. Authored data, view-rendered: positions and runs are player-authored records in the SPEC-0009 store**
+* **C. Derived: runs computed from plan assignments, positions auto-laid-out from the plan graph**
+* **D. Defer the Atlas until save import lands and supplies real coordinates**
+
+## Decision Outcome
+
+Chosen option: **B — the Atlas is authored data rendered by the view, with no new boundary crossing.**
+
+The load-bearing argument is narrower than "routes are presentation", and it is worth stating precisely, because the obvious objection is that "the shortest run across five bases" is exactly the kind of thing the domain exists to compute.
+
+**There is no distance to minimise.** Atlas positions are player-arranged for legibility; the handoff says so outright. They are not the game's coordinates, they are not to scale, and they are not derived from anything. And the travel between stops is a teleporter or a portal — constant-cost, and unaffected by how far apart two buildings sit on the player's arrangement. So a shortest-path computation over this graph would be optimising a metric that is fiction against a cost that is uniform. It is not that the domain *may not* compute the route; it is that there is no well-posed question to ask it. Option A would add a boundary crossing to answer a question the data cannot pose.
+
+That is a different claim from "routes are presentation because rendering is the view's job", and if the premise ever changes — if positions come to mean real in-game distance, or if travel acquires a real per-leg cost — the conclusion changes with it. That contingency is recorded in Consequences rather than buried.
+
+### (a) The coordinate space: an optional position on `PlaceRecord`
+
+A position is a nullable field on the existing `PlaceRecord`, not a new record type and not a required property.
+
+**Optional is the whole point.** ADR-0006 requires a freighter to be a route node that is never positioned, so a schema making position mandatory would contradict an accepted decision on its first record. A place without a position is a first-class state, not an error and not a missing value to be filled in with a default — the same rule SPEC-0007 REQ "Absent Data Is Absent" already applies to the card. An unpositioned place appears in the run panel and the place list, and simply does not appear on the map.
+
+The position is authored: two integers in the Atlas's own grid space, meaningful only relative to other positions in the same workspace. It carries no relationship to `GalacticAddress` or to the in-game `Position` that ADR-0006 rejects as stale, and MUST NOT be seeded from either.
+
+**What a shared place now carries.** ADR-0008 makes sharing per place precisely because "sharing a whole workspace discloses every location a player has", and treats base locations as the thing not to hand out by pasting a link. Adding a position to `PlaceRecord` puts a coordinate inside the record that sharing sends. The disclosure is real but small, and it is small for the same reason the domain has no metric to optimise: an Atlas position is the player's arrangement of their own map, not a galactic address, and it locates a base relative to the other bases in one workspace and nowhere else. A recipient learns where the owner chose to draw it, not where to fly. That is a weaker disclosure than the notes and screenshots a share already carries, and it does not reopen ADR-0008's decision — but the share confirmation should say the arrangement travels with the place, because a player who has spent an hour laying out a map will reasonably assume it is theirs.
+
+Adding a field to `PlaceRecord` is a schema change under SPEC-0009, so it takes a `schemaVersion` increment and inherits the rule that an unrecognised version loads nothing rather than partially populating. It also inherits REQ "Storage Is Evictable and the Application Must Not Imply Otherwise": a player's arrangement of their own map is exactly the kind of work that feels permanent and is not, and the surface must not imply otherwise.
+
+### (b) Districts are a tag, and the rectangle is layout
+
+A district is a name on a place, not a record with a geometry.
+
+The dashed rectangle is the **bounding box of its members' positions**, computed in the view at render time. This follows SPEC-0006 REQ "Layout Geometry Is Not a Domain Value" exactly: a rectangle enclosing points is geometry, the points are the authored data, and storing the rectangle would create a second source of truth that goes stale the moment a place moves.
+
+A place with no district is the handoff's "1 ungrouped outpost" — again a first-class state, drawn on the map outside any territory, and not an error.
+
+### (c) The route graph: authored, seeded, and never inferred
+
+A harvest run is a **player-authored record** in the workspace: an ordered list of stops, each stop naming a place, with a travel method per leg.
+
+It may be **seeded** from a plan's base assignments — that is where the design's two runs matching the planner's two targets comes from, and it is a genuine convenience. But seeding is a one-time copy, not a binding. After it, the run is the player's, and editing the plan does not silently reorder their route.
+
+The reason is that a plan does not contain a run. It contains a set of bases with leaves assigned to them. The order in which a player visits those bases, and whether a given leg is a teleporter or a portal, are facts about the player's base network and their habits, not about the plan. Deriving a run would mean inventing both.
+
+A run belongs to the **workspace, not to a plan**. A player may hold several plans; runs outlive any of them. A run MAY record the plan that seeded it, for provenance, and MUST NOT be invalidated when that plan changes or is deleted. The design's RUN toggle names runs after targets, which is a naming convention the player inherits from seeding and may change.
+
+**One run is active at a time.** This is kept from the design deliberately, and it resolves the handoff's third open question: overlapping waypoint chips where two runs share a mid-route stop only arise if two runs are drawn at once. Holding the constraint makes the defect unreachable rather than fixing it.
+
+Freighters participate as stops exactly as ADR-0006 requires — a node in the sequence with no position — which is representable precisely because position is optional in (a).
+
+### (d) The list is the surface; the map is a view of it
+
+The non-spatial equivalent of the Atlas is not a fallback bolted on for compliance. **The ordered list is canonical and the map renders it.**
+
+Concretely: the run panel's ordered legs and the place list are always present, carry every operation the map carries, and are the structure the map decorates. The surface MUST NOT have a map-only operation — if a place can be selected, opened, added to a run, or repositioned by clicking a building, each of those must be reachable from the list. Repositioning by dragging therefore implies a non-spatial means of setting a position, which is the one production consequence of this rule that is not free.
+
+Run identity cannot rest on the run colour the design assigns (STASIS aqua, CAKE yellow). The numbered waypoints and the per-leg method chips already carry order and method without colour; the active run's name in the toggle carries identity. That is the existing `StatusBadge` rule — a glyph and a word beside every colour — applied to a surface that had been leaning on hue.
+
+This is named here rather than left to the spec because it is a shaping constraint, not an implementation detail: a surface designed map-first and made accessible afterwards produces a different component tree than one designed list-first and drawn.
+
+### (e) Deliberately deferred
+
+* **Whether the Atlas is a top-level surface or a view within bases.** ADR-0010 owns navigation and this ADR must not pre-empt it. What this decision does assert is the constraint ADR-0010 has to satisfy: the Atlas renders *places*, not plans, so it belongs to the place-scoped surface family, and it must be reachable with no plan loaded.
+* **Deep-linking from a run stop to that base's card** — the handoff's second open question. It is a navigation concern and goes to ADR-0010 for the same reason.
+* **Whether districts ever become authored rectangles** rather than derived bounding boxes. Deriving is correct while a district is a grouping; if a player ever wants a territory that is not the hull of its members, that is a new decision.
+
+### Consequences
+
+* Good, because the strict domain/view boundary survives intact and no new WASM crossing is added — the rollup's three stages remain the whole of the boundary surface.
+* Good, because ADR-0006's freighter split is representable rather than special-cased: "route node, no position" falls straight out of position being optional.
+* Good, because positions and runs reuse the SPEC-0009 store, its versioning, and its eviction honesty, instead of adding a second place for durable user data to live.
+* Good, because a district that is the bounding box of its members cannot go stale relative to the places in it.
+* Good, because "the list is canonical" turns the project's hardest accessibility case into a shaping constraint decided up front rather than a spec-time retrofit.
+* Bad, because the chosen option rests on a premise that could change. If Atlas positions ever mean real in-game distance, or travel acquires a per-leg cost, the "no metric to minimise" argument fails and route optimisation becomes genuine domain work — with the boundary crossing this decision avoided.
+* Bad, because seeded-then-owned runs will drift from the plans that seeded them, and a player who edits a plan and expects their run to follow will be surprised. The alternative is worse, but the surprise is real.
+* Bad, because "no map-only operation" makes repositioning cost more than a drag handle: it requires a non-spatial way to set a position, which the prototype does not have and the design did not consider.
+* Bad, because sharing a place now discloses its Atlas position as well as its notes. The position is arrangement rather than geography, so the disclosure is weak — but it is a new thing leaving the device on a path ADR-0008 built deliberately narrow.
+* Bad, because a `PlaceRecord` schema bump invalidates stored workspaces under SPEC-0009's load-nothing rule. There is no data in the field yet, so the cost is theoretical today and will not be later.
+* Neutral, because holding "one active run" keeps a rendering defect unreachable at the price of a feature nobody has asked for.
+
+### Confirmation
+
+* **No new boundary crossing appears.** `cmd/planner` still exposes exactly `resolve`, `rollup` and `power`; no Atlas, route, or position call is added. Verified by grep against the bridge surface, since the requirement is an absence.
+* **No Atlas arithmetic in the domain.** `internal/domain` contains no position, distance, or route type — the coordinate space does not exist on the Go side at all.
+* **A place with no position renders.** A freighter and an unpositioned base both appear in the run panel and the place list, and neither appears on the map. Asserted against a fixture carrying both, because ADR-0006 makes the freighter case mandatory rather than incidental.
+* **No position is seeded from the save.** No code path assigns an Atlas position from `GalacticAddress` or `Position` — the same grep-for-absence ADR-0006 already requires of the freighter card.
+* **Every map operation exists in the list.** Enumerated as a test over the surface's operations rather than a review note: for each operation reachable by clicking a building or a waypoint, an equivalent is reachable from the list without a pointer.
+* **Run identity survives colour removal.** The active run is identifiable with every colour stripped from the document — the assertion SPEC-0007's card tests already make, applied to the Atlas.
+* **The schema bump is exercised.** A workspace written at the previous `schemaVersion` loads nothing and reports both versions, rather than loading places without positions.
+
+## Pros and Cons of the Options
+
+### A. Domain-owned: positions and routes are domain values
+
+Positions and runs cross into the Go domain; a new boundary stage computes optimal or near-optimal harvest runs and returns an ordered route.
+
+* Good, because it is the orthodox reading of SPEC-0005 — "shortest run across five bases" looks exactly like a domain computation, and putting it in the view looks like an exception.
+* Good, because route optimisation would be deterministic and testable in Go, where the project's strongest test discipline already lives.
+* Good, because it would be the right answer immediately if travel ever acquires a real per-leg cost.
+* Bad, because there is no metric to optimise. Positions are player-arranged fiction and teleporter travel is uniform-cost, so the computation would minimise a distance that means nothing.
+* Bad, because it adds a fourth boundary crossing — an ADR-sized commitment under ADR-0003 — to answer a question the data cannot pose.
+* Bad, because it would make the domain depend on authored view state, inverting the direction every other stage runs in.
+
+### B. Authored data, view-rendered (chosen)
+
+Positions are an optional field on `PlaceRecord`; runs are workspace records seeded from plans and owned by the player; the view renders both and the domain never sees them.
+
+* Good, because it keeps the boundary at three stages and the domain free of view-authored state.
+* Good, because it matches SPEC-0006's existing ruling that layout geometry is the view's and quantities are the domain's, rather than drawing the same line differently on a second surface.
+* Good, because optional position expresses ADR-0006's freighter split directly, with no conditional.
+* Good, because runs survive the plans that seeded them, which is what a route through a player's own base network actually is.
+* Bad, because it depends on the no-metric premise, and that premise is an argument rather than a fact of the codebase.
+* Bad, because a player who expects their run to track their plan gets a one-time seed and then divergence.
+* Neutral, because it makes the Atlas the first surface holding durable data the domain never validates.
+
+### C. Derived: runs computed from plan assignments, positions auto-laid-out
+
+Runs are recomputed from the current plan's base assignments; positions come from a layout algorithm over the plan graph rather than from the player.
+
+* Good, because it needs no new authored data and no schema change at all.
+* Good, because runs would never drift from plans, since they would not exist independently of them.
+* Good, because auto-layout removes the drag-repositioning production feature the prototype never built.
+* Bad, because a plan contains a set, not a sequence, and carries nothing at all about travel method — so two of a run's three components would be invented and presented as derived.
+* Bad, because auto-layout throws away the thing the surface is for. A city-builder map is legible because the player arranged it; a force-directed graph of the same bases is a different and worse artefact.
+* Bad, because a freighter has no plan assignment and no position, so it would fall out of both the layout and the route — directly contradicting ADR-0006.
+
+### D. Defer until save import supplies real coordinates
+
+Leave the Atlas unspecified until ADR-0002's import lands and `GalacticAddress` gives genuine in-game positions.
+
+* Good, because it is no work now, and real coordinates would settle the coordinate-space question by supplying one.
+* Good, because it avoids a schema bump before there is any stored data to migrate.
+* Bad, because two accepted ADRs already argue from this surface's existence. Deferring leaves ADR-0006's freighter split and ADR-0007's dossier rejection resting on something unspecified.
+* Bad, because ADR-0006 already established that in-game coordinates are stale for a freighter and rejected them as a location source. Waiting for them is waiting for something the project has decided not to use.
+* Bad, because the harvest run is described by the repo owner as a core component of the tool, and deferring a core component is a decision to ship without it rather than an absence of decision.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    SAVE[".hg save (ADR-0002)"] -.->|"never seeds a position"| POS
+
+    subgraph STORE["SPEC-0009 workspace · IndexedDB"]
+        PLACE["PlaceRecord<br/>kind · name · notes · ticks"]
+        POS["position?<br/>optional, authored"]
+        DIST["district?<br/>optional tag"]
+        RUN["RunRecord<br/>ordered stops · method per leg"]
+        PLACE --- POS
+        PLACE --- DIST
+    end
+
+    PLAN["Plan · base assignments"] -->|"seeds once, no binding"| RUN
+    RUN -->|"stops reference"| PLACE
+
+    subgraph DOMAIN["Go domain (ADR-0003)"]
+        STAGES["resolve · rollup · power"]
+    end
+
+    STORE -.->|"never crosses"| DOMAIN
+
+    subgraph VIEW["React view (ADR-0004)"]
+        LIST["Ordered list · run legs + places<br/>CANONICAL"]
+        MAP["Pixel map<br/>a rendering of the list"]
+        BOX["District rectangle<br/>= bounding box, computed at render"]
+        LIST --> MAP
+        POS --> BOX
+    end
+
+    PLACE --> LIST
+    RUN --> LIST
+
+    FR["Freighter (ADR-0006)"] -->|"route node"| RUN
+    FR -.->|"never positioned"| MAP
+```
+
+## More Information
+
+**What this decision does not touch.** Navigation is ADR-0010's, and this ADR extends it rather than restating it: whether the Atlas is a top-level surface or a view inside bases, and whether a run stop deep-links to a base card, are both deferred there with the constraint that the Atlas is place-scoped and must be reachable with no plan loaded. The settlement dossier question is ADR-0007's and stays settled — this decision gives the Atlas no denser a panel than the one ADR-0007 already judged too small for settlement state.
+
+**On the handoff's open questions.** Question 1 (drag-repositioning and district drawing are unprototyped production features) is answered in principle: positions are authored, so a means of authoring them is required, and (d) adds that a non-spatial means is required alongside any drag. The interaction itself is spec work. Question 2 is deferred to ADR-0010 as above. Question 3 (overlapping waypoint chips on a shared mid-route stop) is resolved by keeping one active run at a time, which makes the overlap unreachable.
+
+**The premise to watch.** The whole of the chosen option rests on Atlas positions being arrangement rather than geography, and on teleporter travel being uniform-cost. Both are true today and both are stated in the design. If either changes — a real distance, or a per-leg cost that varies — option A becomes correct and this decision should be superseded rather than amended, because the boundary crossing it declines is the substance of it.
+
+**Sequencing.** Nothing here is blocked. The store exists (SPEC-0009 is implemented), the place record exists, and the two things this adds to it are a nullable field and a new record type. The spec that follows this ADR can be written against a working store rather than a proposed one.
+
+**References.**
+
+* ADR-0010 — the application shell, which this extends; navigation and the place-record-independent-of-plan model
+* ADR-0006 — the freighter as a route node never given a map position; the constraint (a) and (c) are shaped by
+* ADR-0007 — the Atlas dossier as a summary panel, and why settlement state does not fit in it
+* ADR-0008 / SPEC-0009 — the local-first store, `PlaceRecord`, the schema-version rule, eviction honesty, and the per-place sharing unit a position now travels inside
+* ADR-0009 — player identity, and the rule that authentication transmits no place record by itself
+* ADR-0003 — the Go domain and why a fourth boundary crossing is an ADR-sized commitment
+* ADR-0004 — the React view that renders what it is given
+* SPEC-0005 REQ "The View Computes No Domain Values", Accessibility Requirements — the rule this decision had to answer to rather than around
+* SPEC-0006 REQ "Layout Geometry Is Not a Domain Value" — the same line, drawn once already for the tree canvas
+* SPEC-0007 REQ "Absent Data Is Absent" — the precedent for an absent position being a state rather than a gap
+* `docs/design/bases-map/handoff.md` — the design this specifies, and the source of the three open questions
+* `docs/design/bases-map/Bases Map.dc.html` — the interactive prototype

--- a/docs/adrs/ADR-0011-base-atlas-coordinate-space-and-route-graph.md
+++ b/docs/adrs/ADR-0011-base-atlas-coordinate-space-and-route-graph.md
@@ -66,6 +66,8 @@ A place with no district is the handoff's "1 ungrouped outpost" — again a firs
 
 A harvest run is a **player-authored record** in the workspace: an ordered list of stops, each stop naming a place, with a travel method per leg.
 
+A stop names a place by the SPEC-0009 place `id` — which ADR-0010 §1 makes the same identifier as `BaseID`, so a run, a plan's assignments and the Atlas all point at one thing. No second key is minted for routing.
+
 It may be **seeded** from a plan's base assignments — that is where the design's two runs matching the planner's two targets comes from, and it is a genuine convenience. But seeding is a one-time copy, not a binding. After it, the run is the player's, and editing the plan does not silently reorder their route.
 
 The reason is that a plan does not contain a run. It contains a set of bases with leaves assigned to them. The order in which a player visits those bases, and whether a given leg is a teleporter or a portal, are facts about the player's base network and their habits, not about the plan. Deriving a run would mean inventing both.
@@ -88,13 +90,33 @@ This is named here rather than left to the spec because it is a shaping constrai
 
 ### (e) Deliberately deferred
 
-* **Whether the Atlas is a top-level surface or a view within bases.** ADR-0010 owns navigation and this ADR must not pre-empt it. What this decision does assert is the constraint ADR-0010 has to satisfy: the Atlas renders *places*, not plans, so it belongs to the place-scoped surface family, and it must be reachable with no plan loaded.
-* **Deep-linking from a run stop to that base's card** — the handoff's second open question. It is a navigation concern and goes to ADR-0010 for the same reason.
+* **~~Whether the Atlas is a top-level surface~~ — now answered, see (f).** This was deferred while ADR-0010 was in flight. It has since merged, and the answer follows from its own criterion rather than from a fresh judgement here.
+* **Deep-linking from a run stop to that base's card** — the handoff's second open question. ADR-0010 §4 settles the mechanism: cross-navigation links like the design's "view planner →" are content links inside `main`, not a second navigation landmark. Whether a run stop carries one is a spec-level question about the run panel, and the mechanism it would use is no longer open.
 * **Whether districts ever become authored rectangles** rather than derived bounding boxes. Deriving is correct while a district is a grouping; if a player ever wants a territory that is not the hull of its members, that is a new decision.
+
+### (f) The Atlas is a surface, on ADR-0010's own criterion
+
+ADR-0010 §4 makes surfaces shell view state — no router, selection held by the shell, and exactly one `role="navigation"` landmark. It enumerates them as "bases, tree, planner — plus the freighter and settlement surfaces ADR-0006 and ADR-0007 add."
+
+**The Atlas is not in that list, and the omission is an artefact of sequencing rather than a decision.** ADR-0010 was written while this one was, at a point when the Atlas was the one designed surface with no ADR behind it — and it quotes the design's "view atlas →" among the cross-navigation links it rules on, so the surface was in view even though it was not enumerated.
+
+It joins the list, and the reason is ADR-0010's own test for the entry surface: the bases surface opens the application because it is "the only surface that renders correctly with no domain call at all". By (a) through (c), so does the Atlas — positions, districts and runs are all authored records in the SPEC-0009 store, and nothing on this surface waits for the module. The Atlas meets the criterion ADR-0010 used to choose what the application opens on.
+
+This adopts ADR-0010's navigation mechanism rather than adding to it. No router, one landmark, and the surface set grows by one.
+
+**What the shell must not do with it:** a run references places, and ADR-0010 §6 puts plan state in the URL hash and player-authored data in the store. Runs and positions are player-authored, so a shared hash MUST NOT carry them. A share that reproduced someone's map arrangement and harvest routes from a link would put durable data inside the mechanism ADR-0008 built specifically to keep it out of.
+
+### (g) A run stop naming a place that no longer exists
+
+ADR-0010 §1 rules that a plan assignment naming a deleted place resolves to unassigned — the leaves reappear in the unassigned group rather than the plan being destroyed or a dangling id being rendered.
+
+A run needs the same rule and cannot use the same mechanism, because a sequence has no unassigned bucket to put a stop in. So: **the stop is retained and rendered as unresolved.** Deleting a place MUST NOT delete a run, MUST NOT silently drop the stop, and MUST NOT renumber the waypoints around the gap.
+
+Dropping it silently would reorder a route the player authored, which is the harvest-run equivalent of destroying their work; renumbering would do it while looking tidy. An unresolved stop is visible, is removable deliberately, and keeps the order the player chose until they change it. This is ADR-0010's principle — never destroy, never lie — applied to the one shape it did not cover.
 
 ### Consequences
 
-* Good, because the strict domain/view boundary survives intact and no new WASM crossing is added — the rollup's three stages remain the whole of the boundary surface.
+* Good, because the strict domain/view boundary survives intact and this decision adds no WASM crossing of its own. ADR-0010 §5 already adds a catalogue call for target search, so the boundary is growing — but it grows for a reason the Atlas does not share, and the Atlas adds nothing to it.
 * Good, because ADR-0006's freighter split is representable rather than special-cased: "route node, no position" falls straight out of position being optional.
 * Good, because positions and runs reuse the SPEC-0009 store, its versioning, and its eviction honesty, instead of adding a second place for durable user data to live.
 * Good, because a district that is the bounding box of its members cannot go stale relative to the places in it.
@@ -102,18 +124,21 @@ This is named here rather than left to the spec because it is a shaping constrai
 * Bad, because the chosen option rests on a premise that could change. If Atlas positions ever mean real in-game distance, or travel acquires a per-leg cost, the "no metric to minimise" argument fails and route optimisation becomes genuine domain work — with the boundary crossing this decision avoided.
 * Bad, because seeded-then-owned runs will drift from the plans that seeded them, and a player who edits a plan and expects their run to follow will be surprised. The alternative is worse, but the surprise is real.
 * Bad, because "no map-only operation" makes repositioning cost more than a drag handle: it requires a non-spatial way to set a position, which the prototype does not have and the design did not consider.
+* Good, because the Atlas satisfies ADR-0010's no-domain-call criterion, so adding it to the surface set costs the shell nothing structurally.
 * Bad, because sharing a place now discloses its Atlas position as well as its notes. The position is arrangement rather than geography, so the disclosure is weak — but it is a new thing leaving the device on a path ADR-0008 built deliberately narrow.
 * Bad, because a `PlaceRecord` schema bump invalidates stored workspaces under SPEC-0009's load-nothing rule. There is no data in the field yet, so the cost is theoretical today and will not be later.
 * Neutral, because holding "one active run" keeps a rendering defect unreachable at the price of a feature nobody has asked for.
 
 ### Confirmation
 
-* **No new boundary crossing appears.** `cmd/planner` still exposes exactly `resolve`, `rollup` and `power`; no Atlas, route, or position call is added. Verified by grep against the bridge surface, since the requirement is an absence.
+* **No Atlas call appears on the boundary.** The bridge surface carries no route, position, district, or distance entry point. Stated as an absence rather than as a count, because ADR-0010 §5 adds a catalogue call and a fixed number would fail for a reason unrelated to this decision.
 * **No Atlas arithmetic in the domain.** `internal/domain` contains no position, distance, or route type — the coordinate space does not exist on the Go side at all.
 * **A place with no position renders.** A freighter and an unpositioned base both appear in the run panel and the place list, and neither appears on the map. Asserted against a fixture carrying both, because ADR-0006 makes the freighter case mandatory rather than incidental.
 * **No position is seeded from the save.** No code path assigns an Atlas position from `GalacticAddress` or `Position` — the same grep-for-absence ADR-0006 already requires of the freighter card.
 * **Every map operation exists in the list.** Enumerated as a test over the surface's operations rather than a review note: for each operation reachable by clicking a building or a waypoint, an equivalent is reachable from the list without a pointer.
 * **Run identity survives colour removal.** The active run is identifiable with every colour stripped from the document — the assertion SPEC-0007's card tests already make, applied to the Atlas.
+* **A shared hash carries no arrangement.** A hash encoded from a workspace with positions and runs decodes to plan state alone — asserted by the same one-path decode test SPEC-0005 already requires, extended to prove the absence.
+* **A deleted place leaves its runs intact.** A test deletes a place that a run stops at, then asserts the run still exists, the stop is present and marked unresolved, and the remaining waypoint numbers are unchanged.
 * **The schema bump is exercised.** A workspace written at the previous `schemaVersion` loads nothing and reports both versions, rather than loading places without positions.
 
 ## Pros and Cons of the Options
@@ -133,7 +158,7 @@ Positions and runs cross into the Go domain; a new boundary stage computes optim
 
 Positions are an optional field on `PlaceRecord`; runs are workspace records seeded from plans and owned by the player; the view renders both and the domain never sees them.
 
-* Good, because it keeps the boundary at three stages and the domain free of view-authored state.
+* Good, because it adds nothing to the boundary and keeps the domain free of view-authored state.
 * Good, because it matches SPEC-0006's existing ruling that layout geometry is the view's and quantities are the domain's, rather than drawing the same line differently on a second surface.
 * Good, because optional position expresses ADR-0006's freighter split directly, with no conditional.
 * Good, because runs survive the plans that seeded them, which is what a route through a player's own base network actually is.
@@ -213,7 +238,7 @@ graph TD
 
 **References.**
 
-* ADR-0010 — the application shell, which this extends; navigation and the place-record-independent-of-plan model
+* ADR-0010 — the application shell this extends: places first, `BaseID` as the place record's `id`, surfaces as shell view state under one navigation landmark, and the hash-owns-the-plan / store-owns-the-player split that puts positions and runs in the store
 * ADR-0006 — the freighter as a route node never given a map position; the constraint (a) and (c) are shaped by
 * ADR-0007 — the Atlas dossier as a summary panel, and why settlement state does not fit in it
 * ADR-0008 / SPEC-0009 — the local-first store, `PlaceRecord`, the schema-version rule, eviction honesty, and the per-place sharing unit a position now travels inside

--- a/docs/adrs/ADR-0015-base-atlas-coordinate-space-and-route-graph.md
+++ b/docs/adrs/ADR-0015-base-atlas-coordinate-space-and-route-graph.md
@@ -6,7 +6,7 @@ extends: [ADR-0010]
 related: [ADR-0003, ADR-0004, ADR-0006, ADR-0007, ADR-0008]
 ---
 
-# ADR-0011: The Base Atlas — an authored coordinate space, and a route graph that is presentation
+# ADR-0015: The Base Atlas — an authored coordinate space, and a route graph that is presentation
 
 ## Context and Problem Statement
 
@@ -233,6 +233,14 @@ graph TD
 **On the handoff's open questions.** Question 1 (drag-repositioning and district drawing are unprototyped production features) is answered in principle: positions are authored, so a means of authoring them is required, and (d) adds that a non-spatial means is required alongside any drag. The interaction itself is spec work. Question 2 is deferred to ADR-0010 as above. Question 3 (overlapping waypoint chips on a shared mid-route stop) is resolved by keeping one active run at a time, which makes the overlap unreachable.
 
 **The premise to watch.** The whole of the chosen option rests on Atlas positions being arrangement rather than geography, and on teleporter travel being uniform-cost. Both are true today and both are stated in the design. If either changes — a real distance, or a per-leg cost that varies — option A becomes correct and this decision should be superseded rather than amended, because the boundary crossing it declines is the substance of it.
+
+### The number, and why it is not 0011
+
+This decision was drafted as ADR-0011, on the grounds that 0011 was the next free *file* in `docs/adrs/`. It is not the next free *number*: ADR-0008's "ADRs that spawn from this one" table reserves 0011 for server hosting, retention and deletion, and three live references point at that reservation — ADR-0008's own retention commitment, and two lines in `docs/openspec/specs/durable-store/design.md` that defer the retention story to it.
+
+ADR-0010 met the same collision from the other side and settled it by moving rather than displacing, for the reason that applies here unchanged: renumbering into a reserved slot displaces live pointers to save one number. So the Atlas is 0015, after hosting (0011), sync (0012), blobs (0013) and sharing (0014).
+
+Recorded rather than silently renamed, because "check the directory for the next free number" is the instruction that produced the collision, and the directory is not where the reservations live.
 
 **Sequencing.** Nothing here is blocked. The store exists (SPEC-0009 is implemented), the place record exists, and the two things this adds to it are a nullable field and a new record type. The spec that follows this ADR can be written against a working store rather than a proposed one.
 

--- a/docs/openspec/specs/base-atlas/design.md
+++ b/docs/openspec/specs/base-atlas/design.md
@@ -1,0 +1,161 @@
+# Base Atlas — Design
+
+## Context
+
+`docs/design/bases-map/` has been a complete, high-fidelity design for a long time: a pixel map of every base, dashed district territories, harvest runs with numbered waypoints and per-leg travel methods, a handoff document and an interactive prototype. It had no ADR, no spec, no issues and no implementation, while two accepted decisions already reasoned about it as though it existed — ADR-0006 carries a section on the freighter's place in the route graph, and ADR-0007 rejects an option on the grounds that the Atlas dossier is too small for settlement state.
+
+[ADR-0015](../../../adrs/ADR-0015-base-atlas-coordinate-space-and-route-graph.md) closed that gap by answering the three structural questions: where positions and runs live (the SPEC-0009 store), whether a run is authored or derived (authored, seeded once), and whether the route graph belongs in the Go domain (no). This spec turns those answers into requirements.
+
+The starting conditions are good. SPEC-0009 is implemented, so the workspace and the place record exist. The two things this surface adds to the store are a nullable field and a new record type. Nothing here is blocked on the module, on save import, or on an account.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Give positions, districts and runs a home in the existing store, with the schema discipline SPEC-0009 already enforces.
+- Make the freighter's "route node, never positioned" split fall out of the schema rather than out of a conditional.
+- Make the ordered list canonical, up front, so the component tree is shaped by it rather than retrofitted around it.
+- Keep the domain/view boundary exactly where it is: the Atlas adds nothing to it.
+- Preserve player work — a deleted place must not silently reorder a route the player authored.
+
+### Non-Goals
+
+- **Route optimisation.** There is no metric. See "There is no distance to minimise" below.
+- **Real coordinates.** Atlas positions are arrangement, not geography, and are never seeded from `GalacticAddress` or the in-game `Position`.
+- **The shell's navigation model.** ADR-0010 §4 owns it; this spec adopts it and adds one surface.
+- **Multiple runs drawn at once.** Held at one deliberately, which makes the overlapping-waypoint defect unreachable.
+- **Authored district rectangles.** A district is a grouping and its territory is the hull of its members. A territory that is not that hull is a new decision, not a spec detail.
+- **Accounts, sync, sharing mechanics.** ADR-0008 stages 2 and 3, ADR-0009, and the ADRs reserved at 0011–0014.
+
+## Decisions
+
+### There is no distance to minimise
+
+The obvious objection to keeping routes out of the domain is that "the shortest run across five bases" looks exactly like the kind of thing a domain computes. It is not, and the reason is narrower than "rendering is the view's job".
+
+Atlas positions are the player's arrangement of their own map. They are not the game's coordinates, not to scale, and not derived from anything. Travel between stops is a teleporter or a portal — constant cost, unaffected by how far apart two buildings sit in that arrangement. A shortest-path computation over this graph would minimise a fiction against a uniform cost. It is not that the domain may not compute the route; there is no well-posed question to ask it.
+
+This is why REQ "The Atlas Makes No Boundary Call" forbids ranking, optimising or costing a route while permitting bounding-box and waypoint geometry. The line is not "no arithmetic in the view" — SPEC-0006 already permits layout geometry. The line is between geometry that positions what the player authored and arithmetic that claims a route is better than another.
+
+**The premise to watch:** if positions ever mean real in-game distance, or travel acquires a per-leg cost, this argument fails and route optimisation becomes genuine domain work. ADR-0015 records that as a supersession trigger, not an amendment.
+
+### Optional position, because the freighter requires it
+
+ADR-0006 requires a freighter to be a route node that is never positioned. A schema making position mandatory would contradict an accepted decision on its first record.
+
+So position is nullable on `PlaceRecord`, and the freighter needs no special case. REQ "A Freighter Is a Route Node Without a Position" makes the absence of a special case testable: a conditional on place kind in the positioning or map-rendering path is the defect, not the fix. This is the same shape as SPEC-0007 REQ "Absent Data Is Absent" — an absent value is a state, not a gap to fill with a default.
+
+Two integers, in the Atlas's own grid space, meaningful only relative to other positions in the same workspace. Never seeded from the save. That last clause is a grep-for-absence assertion, the same one ADR-0006 already requires of the freighter card, and it exists because `GalacticAddress` is right there in the import path and looks like the obvious source.
+
+### District as tag, rectangle as render-time geometry
+
+Storing the rectangle would create a second source of truth that goes stale the moment a member moves. Deriving it means the territory cannot disagree with its members, and moving a place writes one field.
+
+This is SPEC-0006 REQ "Layout Geometry Is Not a Domain Value" applied unchanged: a rectangle enclosing points is geometry, the points are the authored data. Drawing the same line differently on a second surface is how two surfaces end up with two answers to one question.
+
+A place with no district is drawn outside every territory. There is no "ungrouped" pseudo-district record, because inventing one would make an absence into a value and then require code to distinguish the real districts from it.
+
+### Runs are authored, seeded once, and owned by the workspace
+
+The design shows two runs matching the planner's two targets, which invites "derive runs from assignments". A plan carries a set of bases; a run carries a sequence and a travel method per leg. Two of a run's three components have no source in any plan, so deriving would mean inventing both and presenting the invention as derived.
+
+Seeding is the honest version of that convenience: a one-time copy that produces an ordinary authored run. REQ "Seeding Is a One-Time Copy" makes the absence of a binding testable — the plan gains a base and the run does not move.
+
+Runs belong to the workspace rather than to a plan, because a player holds several plans and a route through their own base network outlives any of them. A run may record its seeding plan for provenance, and must survive that plan's deletion.
+
+The cost is real and is recorded in ADR-0015: a player who edits a plan and expects their run to follow gets divergence instead. The alternative — a live binding that silently reorders a route the player arranged — is worse.
+
+### Retain the unresolved stop; never renumber around a gap
+
+ADR-0010 §1 rules that a plan assignment naming a deleted place resolves to unassigned. A run cannot use that mechanism, because a sequence has no unassigned bucket.
+
+Dropping the stop silently would reorder a route the player authored. Renumbering the remaining stops would do the same while looking tidy — the tidier failure is the worse one, because the player has no signal that anything happened. So the stop stays, in place, marked unresolved, removable deliberately.
+
+REQ "A Stop Naming a Deleted Place Is Retained and Unresolved" asserts the numbering explicitly (stops four and five are still four and five) because "the run still exists" is satisfiable by an implementation that quietly renumbers.
+
+### The list is canonical, and that is a component-tree decision
+
+A pixel map of clickable buildings is the hardest accessibility case in this project. It cannot be met by bolting an alternative on afterwards, because a surface designed map-first grows operations that only the map has, and the alternative then chases them.
+
+So the run panel's ordered legs and the place list are the surface, and the map renders them. REQ "The Ordered List Is Canonical" forbids any map-only operation, which has one non-free consequence: repositioning by dragging implies a non-spatial way to set a position, which the prototype does not have and the design did not consider. That is stated as a requirement rather than left to implementation, because it is the requirement that costs something.
+
+Run identity cannot rest on the run colours the design assigns. The numbered waypoints and per-leg method chips already carry order and method without hue; the active run's name carries identity. That is the existing `StatusBadge` rule — a glyph and a word beside every colour — applied to a surface that had been leaning on colour alone.
+
+### Nothing new on the boundary, stated as an absence
+
+REQ "The Atlas Makes No Boundary Call" is written as "no position, route, district, distance or travel entry point exists" rather than "the boundary has exactly N calls". ADR-0010 §5 adds a catalogue call for target search; a fixed count would fail for a reason that has nothing to do with the Atlas.
+
+The complementary assertion — the Atlas renders completely with the module unloaded — is also what makes the Atlas eligible as the shell's entry surface under ADR-0010's own criterion. It is asserted here as a property of this surface, not as a claim about what the shell chooses to open on.
+
+## Architecture
+
+```mermaid
+graph TD
+    SAVE[".hg save (ADR-0002)"] -.->|"never seeds"| POS
+
+    subgraph STORE["SPEC-0009 workspace · IndexedDB"]
+        PLACE["PlaceRecord<br/>id = BaseID · kind · name · notes"]
+        POS["position?<br/>{x, y} authored, nullable"]
+        DIST["district?<br/>optional tag"]
+        RUN["RunRecord<br/>ordered stops · method per leg<br/>seededFromPlan? (provenance only)"]
+        PLACE --- POS
+        PLACE --- DIST
+    end
+
+    PLAN["Plan · base assignments<br/>(URL hash)"] -->|"seeds once · no binding"| RUN
+    RUN -->|"stops reference place id"| PLACE
+    PLAN -.->|"hash carries no position or run"| STORE
+
+    subgraph DOMAIN["Go domain (ADR-0003)"]
+        STAGES["resolve · rollup · power · catalogue"]
+    end
+
+    STORE -.->|"never crosses"| DOMAIN
+
+    subgraph VIEW["React view (ADR-0004) · Atlas surface"]
+        LIST["Run legs + place list<br/><b>CANONICAL</b>"]
+        MAP["Pixel map<br/>a rendering of the list"]
+        BOX["District rectangle<br/>= bounding box, render-time"]
+        LIST --> MAP
+        POS --> BOX
+        BOX --> MAP
+    end
+
+    PLACE --> LIST
+    RUN --> LIST
+
+    FR["Freighter (ADR-0006)"] -->|"stop in the sequence"| RUN
+    FR -.->|"no position, never drawn"| MAP
+
+    DEL["Place deleted"] -->|"stop retained, marked unresolved"| RUN
+```
+
+**Component shape that follows from the list being canonical.** The run panel and place list are the data-bearing components; the map is a sibling that consumes the same props and renders them spatially. No operation is defined on the map component that is not defined on a list component, and the map holds no state the list does not. An operation added to the map later without a list equivalent is a requirement violation, not a design drift.
+
+**Where the geometry lives.** Bounding boxes and waypoint placement are computed in the map component at render time from positions passed in as props. Nothing geometric is stored, memoised into the store, or sent anywhere.
+
+## Risks / Trade-offs
+
+- **The no-metric premise is an argument, not a fact of the codebase.** If it changes, REQ "The Atlas Makes No Boundary Call" is wrong rather than merely outdated, and ADR-0015 should be superseded. Watch for: positions meaning real distance, or travel acquiring a per-leg cost.
+- **Seeded-then-owned runs drift from their plans.** A player who edits a plan and expects their route to follow will be surprised. Mitigated only by making the seeding visibly one-time in the UI; not mitigated in the data model, by design.
+- **Non-spatial repositioning is real production work.** Neither the prototype nor the handoff has it. It is the price of "no map-only operation" and it is not small.
+- **The schema bump invalidates stored workspaces** under SPEC-0009's load-nothing rule. Cost is theoretical today because the field has no data in it; it will not be theoretical after the first release that ships positions.
+- **Sharing now discloses arrangement.** Weak disclosure — arrangement rather than geography — but it is a new thing leaving the device on a path ADR-0008 built deliberately narrow. REQ "Sharing a Place Discloses Its Arrangement" makes the player aware rather than reversing the decision.
+- **One active run is a constraint nobody asked for.** It buys the overlapping-waypoint defect being unreachable. If a player ever wants two runs drawn, that defect comes back and needs a real answer.
+
+## Migration Plan
+
+1. **Schema first.** Increment `schemaVersion`, add nullable `position` and `district` to `PlaceRecord`, add the run record. SPEC-0009's load-nothing rule handles the old version; the version-mismatch report is exercised as part of this change rather than after it.
+2. **List before map.** Build the run panel and place list against the store, with every operation, before any map component exists. This is the order the canonical-list requirement implies, and building it in the other order is how a map-only operation gets created.
+3. **Map as a renderer.** Add the map consuming the same props. Bounding boxes and waypoints computed at render.
+4. **Seeding last.** The seed-from-plan convenience is additive and depends on nothing else here.
+
+No data migration is needed: there are no stored positions or runs to move, and the new fields are nullable on existing records that the version bump discards anyway.
+
+## Open Questions
+
+- **Does a run stop deep-link to that base's card?** ADR-0015 §(e) defers it and notes that ADR-0010 §4 already settles the mechanism — a content link inside `main`, not a second landmark. This spec permits it (see REQ "The Atlas Is a Surface in the Shell") and does not require it.
+- **What is the non-spatial position control?** Numeric fields, a grid picker, and "place relative to" are all viable. The requirement fixes that one must exist, not which.
+- **How is a district assigned from the list?** REQ "The Ordered List Is Canonical" requires a non-spatial means; the interaction is unspecified.
+- **Do districts ever become authored rectangles?** ADR-0015 defers it: deriving is correct while a district is a grouping. A territory that is not the hull of its members is a new decision.
+- **Does the Atlas become the shell's entry surface?** It meets ADR-0010's criterion. Whether it is chosen is the shell's call, not this spec's.

--- a/docs/openspec/specs/base-atlas/spec.md
+++ b/docs/openspec/specs/base-atlas/spec.md
@@ -1,0 +1,306 @@
+---
+status: draft
+date: 2026-08-29
+implements: [ADR-0015, ADR-0004]
+requires: [SPEC-0005, SPEC-0009]
+---
+
+# SPEC-0010: Base Atlas
+
+## Graph Edges
+
+- **Implements:** [ADR-0015](../../../adrs/ADR-0015-base-atlas-coordinate-space-and-route-graph.md) — the Atlas as authored data rendered by the view, with no new boundary crossing
+- **Implements:** [ADR-0004](../../../adrs/ADR-0004-react-view-layer.md) — the React view layer this surface belongs to
+- **Requires:** [SPEC-0005](../view-foundations/spec.md) — tokens, styling discipline, the no-arithmetic rule, state boundaries and the accessibility baseline, inherited rather than restated
+- **Requires:** [SPEC-0009](../durable-store/spec.md) — the workspace, the place record, `schemaVersion`, deletion, and eviction honesty that positions and runs live inside
+
+Governing context that is not a frontmatter edge, because this spec depends on the decisions rather than on a spec realizing them: [ADR-0010](../../../adrs/ADR-0010-places-first-and-the-shell.md) (surfaces as shell view state, `BaseID` as the place `id`, hash-owns-the-plan), [ADR-0006](../../../adrs/ADR-0006-freighter-surface.md) (the freighter as a route node never positioned), [ADR-0008](../../../adrs/ADR-0008-durable-user-data-store.md) (the per-place sharing unit a position now travels inside). [SPEC-0006](../tree-canvas/spec.md) REQ "Layout Geometry Is Not a Domain Value" is precedent this spec follows and does not depend on.
+
+Notably **absent**: SPEC-0001 and SPEC-0002. Every other view surface requires them. The Atlas makes no boundary call at all, and REQ "The Atlas Makes No Boundary Call" states that as a requirement rather than leaving it as an omission.
+
+## Overview
+
+The map of a player's base network: bases and other places drawn at positions the player arranged, grouped into districts, with harvest runs traced across them as ordered stops.
+
+Realizes [ADR-0015](../../../adrs/ADR-0015-base-atlas-coordinate-space-and-route-graph.md). The design reference is `docs/design/bases-map/handoff.md` with the interactive prototype `docs/design/bases-map/Bases Map.dc.html`. The handoff marks its own figures illustrative, so no number in it is normative here.
+
+Two things arrive with this surface that the project does not otherwise have. A **coordinate space**: places acquire positions that the player authors and the game never supplies. A **route graph**: a harvest run is an ordered sequence of stops with a travel method per leg. ADR-0015 decided both are authored data rendered by the view, and that no part of either crosses into the Go domain — not because rendering is the view's job, but because there is no distance to minimise. Atlas positions are arrangement, not geography, and teleporter travel is uniform-cost.
+
+Everything SPEC-0005 requires of a view surface, and everything SPEC-0009 requires of durable data, is inherited and not restated. This spec adds what is specific to the Atlas.
+
+**The shaping constraint.** The ordered list is canonical and the map renders it. This is stated first because it changes the component tree rather than decorating it: a surface designed map-first and made accessible afterwards is a different build than one designed list-first and drawn. REQ "The Ordered List Is Canonical" is the requirement; every other requirement in this spec is written to be satisfiable by the list alone.
+
+## Requirements
+
+### Requirement: Position Is Optional and Authored
+
+A place's Atlas position MUST be a nullable field on the SPEC-0009 `PlaceRecord`. It MUST NOT be a separate record type, and it MUST NOT be a required property of a place.
+
+A position MUST be two integers in the Atlas's own grid space, meaningful only relative to other positions in the same workspace. It MUST NOT be derived from, seeded from, or reconciled against `GalacticAddress` or the in-game `Position`, and no code path may assign one from save-file contents.
+
+A place with no position is a first-class state, not an error and not a value awaiting a default. An unpositioned place MUST appear in the place list and MUST be available as a run stop; it MUST NOT appear on the map, and the application MUST NOT substitute an origin, a centre point, or any other placeholder coordinate for it.
+
+#### Scenario: An unpositioned place is not a broken place
+
+- **WHEN** a workspace holds a place that has never been positioned
+- **THEN** the place appears in the place list, is selectable as a run stop, is absent from the map, and no error or empty-state warning is raised about it
+
+#### Scenario: The save never supplies a position
+
+- **WHEN** a place is created by save import from a save carrying `GalacticAddress` and `Position`
+- **THEN** its Atlas position is null
+
+### Requirement: A Freighter Is a Route Node Without a Position
+
+A freighter MUST be representable as a run stop while carrying no position, per [ADR-0006](../../../adrs/ADR-0006-freighter-surface.md). The surface MUST NOT special-case the freighter to achieve this: it follows from position being optional, and any conditional on place kind in the positioning or map-rendering path is a defect.
+
+The freighter MUST NOT be drawn on the map, MUST NOT be enclosed by a district rectangle, and MUST NOT contribute a point to any bounding box.
+
+#### Scenario: The freighter rides the run and stays off the map
+
+- **WHEN** an active run stops at a freighter between two positioned bases
+- **THEN** the freighter appears in the run's ordered legs at its authored position in the sequence, and does not appear on the map
+
+### Requirement: A District Is a Tag and Its Rectangle Is Derived
+
+A district MUST be a name carried on a place. There MUST NOT be a district record, and a district's geometry MUST NOT be stored.
+
+The dashed territory a district renders as MUST be the bounding box of its positioned members, computed in the view at render time. Because the rectangle is derived, moving a member MUST change the territory with no separate update, and no stored rectangle may exist to go stale.
+
+A place with no district is a first-class state. It MUST be drawn on the map outside any territory, and MUST NOT be assigned a default district or an "ungrouped" pseudo-district record.
+
+#### Scenario: The territory follows its members
+
+- **WHEN** a member of a district is repositioned outside the current territory
+- **THEN** the rendered rectangle encloses the new arrangement, with nothing written to the store beyond the moved place's position
+
+#### Scenario: An ungrouped place is drawn
+
+- **WHEN** a positioned place carries no district
+- **THEN** it appears on the map outside every territory, and no district record was created for it
+
+### Requirement: A Harvest Run Is Player-Authored
+
+A harvest run MUST be a record in the SPEC-0009 workspace: an ordered list of stops, each stop naming a place, with a travel method recorded per leg.
+
+A stop MUST reference a place by the SPEC-0009 place `id` — the same identifier ADR-0010 §1 makes `BaseID`. No second key may be minted for routing.
+
+A run MUST belong to the workspace and MUST NOT belong to a plan. A run MAY record the plan that seeded it, for provenance. It MUST NOT be invalidated, reordered, or deleted when that plan changes or is deleted.
+
+A run MUST NOT be derived from plan assignments. A plan carries a set of bases; a run carries a sequence and a per-leg method, neither of which a plan contains.
+
+#### Scenario: A run outlives its plan
+
+- **WHEN** the plan that seeded a run is edited to add, remove and reorder its base assignments, and is then deleted
+- **THEN** the run's stops, their order, and their per-leg methods are unchanged
+
+### Requirement: Seeding Is a One-Time Copy
+
+A run MAY be seeded from a plan's base assignments. Seeding MUST produce an ordinary authored run and MUST NOT establish a binding: after seeding, no subsequent change to the plan may alter the run.
+
+A seeded run MUST have its travel methods and its stop order set to values the player can see and change, rather than being left implicit or recomputed at render.
+
+A seeded run's name MAY be taken from the plan's targets as a convenience, and MUST be editable.
+
+#### Scenario: Seeding does not subscribe
+
+- **WHEN** a run is seeded from a plan and the plan then gains a base
+- **THEN** the run's stops are unchanged and no prompt reorders them
+
+### Requirement: One Run Is Active at a Time
+
+The Atlas MUST render at most one run at a time. Selecting a run MUST deselect the previously active one.
+
+This constraint MUST hold in the rendering path rather than being enforced only in the run switcher: the map MUST NOT be capable of drawing two runs' waypoints simultaneously.
+
+#### Scenario: Two runs sharing a stop cannot collide
+
+- **WHEN** two runs both stop at the same place and one is activated
+- **THEN** only the active run's waypoints are drawn, so no stop carries two waypoint markers
+
+### Requirement: A Stop Naming a Deleted Place Is Retained and Unresolved
+
+Deleting a place MUST NOT delete a run that stops at it, MUST NOT silently drop the stop, and MUST NOT renumber the waypoints around the gap.
+
+The stop MUST be retained in place, in its original position in the sequence, and MUST be rendered as unresolved — visibly, with the unresolved state carried by more than colour. It MUST be removable by a deliberate player action, and its removal MUST then renumber the sequence as any other removal does.
+
+#### Scenario: A deleted place leaves the route standing
+
+- **WHEN** a place that is the third of five stops in a run is deleted
+- **THEN** the run still exists, the third stop is present and marked unresolved, and the fourth and fifth stops are still numbered four and five
+
+#### Scenario: Unresolved is not a colour
+
+- **WHEN** the unresolved stop is rendered with every colour stripped from the document
+- **THEN** its unresolved state is still stated
+
+### Requirement: The Ordered List Is Canonical
+
+The run panel's ordered legs and the place list MUST be present on the surface at all times, and MUST carry every operation the map carries. The map MUST be a rendering of that list.
+
+The surface MUST NOT have a map-only operation. For every operation reachable by clicking, dragging, or otherwise pointing at a building, a waypoint, or a territory, an equivalent operation MUST be reachable from the list without a pointing device.
+
+In particular, if a place can be repositioned by dragging, a non-spatial means of setting that place's position MUST exist. If a district can be drawn or resized spatially, a non-spatial means of setting district membership MUST exist.
+
+#### Scenario: Every map operation has a list equivalent
+
+- **WHEN** the surface's operations are enumerated
+- **THEN** each operation reachable from the map is reachable from the list, and no operation exists that requires a pointer
+
+#### Scenario: Position is settable without dragging
+
+- **WHEN** a player using only a keyboard sets a place's Atlas position
+- **THEN** the position is stored and the map reflects it
+
+### Requirement: Run Identity Does Not Rest on Colour
+
+The active run MUST be identifiable by its name. Order MUST be carried by the numbered waypoints and method MUST be carried by the per-leg chips, each with a text label. Run colour MUST be reinforcement only.
+
+Per SPEC-0005's baseline, this is the existing rule that a glyph and a word accompany every colour, applied to a surface the design had leaning on hue.
+
+#### Scenario: Identity survives colour removal
+
+- **WHEN** the Atlas is rendered with every colour stripped from the document
+- **THEN** the active run's name, the order of its stops, and each leg's travel method are all still stated
+
+### Requirement: The Atlas Makes No Boundary Call
+
+The Atlas MUST NOT call the WASM boundary. No position, route, district, distance, or travel entry point may appear on the bridge surface, and `internal/domain` MUST contain no position, distance, or route type.
+
+The view MUST NOT compute a distance, a path length, a travel time, or an ordering of stops by any metric. Bounding-box geometry and waypoint placement are layout, permitted by SPEC-0006 REQ "Layout Geometry Is Not a Domain Value"; anything that would rank, optimise, or cost a route is not layout and is forbidden here.
+
+This is stated as an absence rather than as a count of boundary calls, because ADR-0010 §5 adds a catalogue call for unrelated reasons and a fixed number would fail for a reason unconnected to this surface.
+
+#### Scenario: The domain does not know the Atlas exists
+
+- **WHEN** the Go domain and the boundary surface are searched for position, route, district or distance types and entry points
+- **THEN** none exist
+
+#### Scenario: The Atlas renders with the module absent
+
+- **WHEN** the Atlas is rendered in a workspace with places, districts and a run, and the WASM module has not loaded
+- **THEN** the surface renders completely, with no loading state and no deferred content
+
+### Requirement: The Atlas Is a Surface in the Shell
+
+The Atlas MUST be one of the shell's surfaces, selected by shell view state per ADR-0010 §4. It MUST NOT introduce a router, and MUST NOT introduce a second `role="navigation"` landmark.
+
+Because the Atlas renders correctly with no domain call, it MUST NOT gate its own rendering on module readiness, and MUST NOT block the shell's entry render.
+
+Cross-navigation from the Atlas to another surface — a run stop linking to a base's card, an "open planner" link — MUST be a content link inside `main`, not a navigation landmark.
+
+#### Scenario: One navigation landmark
+
+- **WHEN** the shell is rendered with the Atlas selected
+- **THEN** exactly one `role="navigation"` landmark exists in the document
+
+### Requirement: Positions and Runs Never Enter the Hash
+
+The URL hash MUST carry plan state only. A hash encoded from a workspace holding positions, districts and runs MUST decode to plan state alone, with no position, no district, and no run present in the encoded value.
+
+The Atlas MUST NOT read a position, a district, or a run from the hash, and MUST NOT accept one if present.
+
+#### Scenario: A shared link carries no arrangement
+
+- **WHEN** a hash is encoded from a workspace with positioned places, districts and two runs
+- **THEN** the encoded value contains no position, district or run, and decoding it yields plan state only
+
+### Requirement: Sharing a Place Discloses Its Arrangement
+
+Because position is a field on `PlaceRecord`, the ADR-0008 per-place share carries it. The share confirmation MUST state that the place's Atlas position and district travel with it, before the share is created.
+
+The share MUST NOT carry any run, because a run is a workspace record and not a place record.
+
+#### Scenario: The player is told what leaves with the place
+
+- **WHEN** a player shares a positioned place in a district
+- **THEN** the confirmation names the position and district as included, and the resulting share contains no run
+
+### Requirement: The Schema Change Fails Legibly
+
+Adding position and district to `PlaceRecord`, and adding the run record, is a schema change under SPEC-0009. It MUST take a `schemaVersion` increment, and MUST inherit REQ "Versioned, and Fails Legibly": a workspace written at the previous version loads nothing and reports both versions, rather than loading places with positions omitted.
+
+Positions and runs MUST inherit SPEC-0009 REQ "Storage Is Evictable and the Application Must Not Imply Otherwise". An arrangement the player spent time on MUST NOT be presented as permanent, and the surface MUST NOT describe it as saved in terms stronger than the store can honour.
+
+#### Scenario: The bump is exercised, not assumed
+
+- **WHEN** a workspace written at the previous `schemaVersion` is opened
+- **THEN** nothing loads, and both the stored and the expected version are reported
+
+## Security Requirements
+
+This capability is part of a browser-rendered client application. It ships as static assets and a WASM module, with no server component and no HTTP endpoints of its own. There is no endpoint table in this spec because there are no endpoints; each topic below is recorded with its applicability so an uncovered topic is visible rather than absent.
+
+### Authentication
+
+Not applicable. This capability defines no endpoints and no protected resources. ADR-0009's player identity transmits no place record by itself, and nothing in this spec changes that.
+
+### Rate Limiting
+
+Not applicable. All rendering and all edits are local and player-invoked; there is no shared resource to exhaust.
+
+### Security Headers
+
+Deferred to the application shell, which owns document delivery. This capability contributes no headers, introduces no requirement for inline script or `eval`, and MUST NOT weaken any policy the shell sets.
+
+### Request Body Size Limits
+
+Not applicable. This capability accepts no uploaded file. A position is two integers and a run is a list of place ids and method values, all authored in-process. If a background image or map screenshot is ever added, [SPEC-0009](../durable-store/spec.md) REQ "Screenshots Are Local-Only" governs it and this spec adds nothing.
+
+### CSRF Protection
+
+Not applicable. There are no state-changing requests; every edit is a local store write.
+
+### Redirect Validation
+
+Plan state arrives in the URL hash, which is untrusted input. [SPEC-0005](../view-foundations/spec.md) § Security Requirements → Redirect Validation already governs it, and this capability inherits those rules and adds no redirect of its own. REQ "Positions and Runs Never Enter the Hash" narrows the surface further by forbidding this spec's data from the hash in either direction.
+
+Place names, district names and run names are player-authored text and MUST be rendered as text. This capability MUST NOT introduce a path that renders any such value as markup, including in map labels, waypoint chips and territory captions.
+
+## Accessibility Requirements
+
+This spec involves user-facing UI, and it is the project's hardest accessibility case: a pixel map of clickable buildings. The following are MANDATORY per WCAG 2.1 AA, and add to SPEC-0005's baseline — including its token contrast constraints — which is not restated here.
+
+REQ "The Ordered List Is Canonical" is the structural answer and is a functional requirement rather than an accessibility one, because it shapes the component tree. Everything below assumes it.
+
+### WCAG 2.1 AA Compliance
+
+All UI components produced by this spec MUST meet WCAG 2.1 Level AA conformance as the minimum accessibility target.
+
+### ARIA Landmarks
+
+The Atlas MUST expose the run panel and the place list as navigable regions, so a screen-reader user can move between the route and the places without traversing the map. The map itself MUST NOT be the only route to either.
+
+The surface MUST NOT add a `role="navigation"` landmark; per ADR-0010 §4 the shell holds the only one.
+
+### Icon-Only Controls
+
+Every icon-only control — waypoint markers, travel-method chips, place-kind glyphs, district handles — MUST carry an `aria-label`. A glyph MUST NOT be the sole accessible name of anything; each is accompanied by its text label.
+
+### Dynamic Content Regions
+
+Activating a run, repositioning a place, changing a leg's travel method, and adding or removing a stop MUST be announced through an `aria-live="polite"` region naming what changed. Announcements MUST NOT be `assertive`: each is the expected result of the player's own action.
+
+An operation that renumbers waypoints MUST announce the resulting count, so a player who cannot see the sequence learns the route length changed.
+
+### Keyboard Navigation
+
+Every operation on this surface MUST be reachable and operable by keyboard, per REQ "The Ordered List Is Canonical". This includes setting a position, assigning a district, ordering stops, setting a leg's method, activating a run, and removing an unresolved stop.
+
+The map MUST NOT be a keyboard trap, and MUST be skippable in a single tab stop.
+
+### Focus Management
+
+Focus MUST remain stable across a re-render: reordering a run MUST leave focus on the moved stop, and repositioning a place MUST leave focus on the control that moved it.
+
+Where an operation removes the focused element — deleting a stop, or deleting a place a stop names — focus MUST move to a documented, predictable destination rather than being lost to the document body.
+
+#### Scenario: Focus follows the moved stop
+
+- **WHEN** a stop is moved from position four to position two using the keyboard
+- **THEN** focus remains on that stop, and a polite live region states its new position
+
+#### Scenario: The map is skippable
+
+- **WHEN** a keyboard user tabs through the surface
+- **THEN** the map is passed in a single tab stop and the run panel and place list are reached without entering it

--- a/docs/openspec/specs/durable-store/design.md
+++ b/docs/openspec/specs/durable-store/design.md
@@ -22,7 +22,7 @@ There is a smaller gap that bites sooner. SPEC-0005 permits the view to hold "vi
 ### Non-Goals
 
 - Accounts, identity, sign-in. ADR-0008 stage 2; ADR-0009's subject
-- Sharing and permissions. Stage 3; ADR-0010's subject
+- Sharing and permissions. Stage 3; ADR-0014's subject
 - Multi-device sync and conflict resolution. ADR-0012's subject — `updatedAt` and `revision` are reserved here, and nothing reads them yet
 - Blob and screenshot storage. ADR-0013's subject. Stage 1 may hold an image locally; sharing or syncing one is out
 - Server hosting, retention operations. ADR-0011's subject. The *deletion* story is owed at stage 1 and is in scope; the *retention* story is not, because there is nothing retaining anything


### PR DESCRIPTION
Adds the decision and the specification for the Base Atlas: the map of a player's base network, its districts, and the harvest runs traced across it.

`docs/design/bases-map/` has been a complete, high-fidelity design for a long time — handoff document, interactive prototype, the lot — with no ADR, no spec, no issues and no implementation. Two accepted decisions already reasoned about it as though it existed: ADR-0006 carries a section on the freighter's place in the route graph, and ADR-0007 rejects an option on the grounds that the Atlas dossier is too small for settlement state. This closes that gap.

## ADR-0015 — an authored coordinate space, and a route graph that is presentation

Three structural questions, answered: positions and runs live in the SPEC-0009 store; a run is authored (seeded once from a plan, never derived); the route graph does not cross into the Go domain.

**The load-bearing argument is narrower than "routes are presentation".** The obvious objection is that "the shortest run across five bases" is exactly what a domain exists to compute. It isn't, because **there is no distance to minimise**: Atlas positions are the player's arrangement of their own map — the handoff says so outright, they are not the game's coordinates and not to scale — and travel between stops is a teleporter or a portal, constant-cost and unaffected by how far apart two buildings sit in that arrangement. A shortest-path computation here would minimise a fiction against a uniform cost. Not "the domain may not"; there is no well-posed question to ask it.

That premise is an argument rather than a fact of the codebase, so it is recorded as a supersession trigger: if positions ever mean real distance, or travel acquires a per-leg cost, route optimisation becomes genuine domain work and this decision should be superseded rather than amended.

The rest follows from it:

- **Position is a nullable field on `PlaceRecord`**, not a new record type. Optional is the whole point — ADR-0006 requires a freighter to be a route node that is never positioned, so a mandatory position would contradict an accepted decision on its first record.
- **A district is a tag; its dashed territory is the bounding box of its members, computed at render.** Storing the rectangle would create a second source of truth that goes stale the moment a place moves. Same line SPEC-0006 already drew for the tree canvas.
- **A run is authored, may be seeded once from a plan, and belongs to the workspace rather than to any plan.** A plan carries a set; a run carries a sequence and a per-leg method. Two of a run's three components have no source in a plan, so deriving would mean inventing both.
- **One run renders at a time**, which makes the handoff's overlapping-waypoint question unreachable rather than fixed.
- **The ordered list is canonical and the map renders it** — a shaping constraint decided up front, because a pixel map of clickable buildings is the project's hardest accessibility case and cannot be met by bolting an alternative on afterwards.
- **A run stop naming a deleted place is retained and marked unresolved**, never dropped and never renumbered around. ADR-0010's principle — never destroy, never lie — applied to the one shape it didn't cover.
- **The Atlas joins ADR-0010's surface list**, on ADR-0010's own criterion: it renders correctly with no domain call at all.

Also included: the numbering note. This was drafted as ADR-0011 on the grounds that 0011 was the next free *file*. It is not the next free *number* — ADR-0008's spawned-ADRs table reserves 0011 for server hosting and retention, with three live pointers at that reservation. Renumbered to 0015, after hosting, sync, blobs and sharing, and recorded in the file rather than silently renamed, because "check the directory for the next free number" is the instruction that produced the collision and the directory is not where the reservations live.

## SPEC-0010 — Base Atlas

Twelve requirements, each traceable to an ADR-0015 confirmation: optional authored position never seeded from the save; freighter as a route node with no special case; district as tag with a render-time bounding box; run authored, seeded once, workspace-owned; one active run; unresolved stop retained without renumbering; the canonical list with no map-only operation; run identity off colour; no boundary call and renders with the module absent; shell surface under one navigation landmark; nothing in the URL hash; the share confirmation naming the arrangement it discloses; and the `PlaceRecord` schema bump inheriting SPEC-0009's load-nothing rule.

Graph edges: `implements: [ADR-0015, ADR-0004]`, `requires: [SPEC-0005, SPEC-0009]`. The interesting edge is the missing one — every other view surface requires SPEC-0001 and SPEC-0002, and the Atlas requires neither. That absence is written as a requirement ("The Atlas Makes No Boundary Call") rather than left silent in the frontmatter.

Security Requirements record all six topics with their applicability; there is no endpoint table because there are no endpoints. Accessibility Requirements build on the canonical-list constraint rather than treating the map as primary.

`design.md` carries the rationale: why there is no metric, why the freighter needs no conditional, why seeding is honest where deriving would not be, why "retain the unresolved stop" beats the tidier failure, and a migration plan that builds the list before the map — because building it the other way round is how a map-only operation gets created.

## Also in this branch

- `docs/adrs/ADR-0010-places-first-and-the-shell.md` and `docs/openspec/specs/durable-store/design.md`: two stale references to ADR-0010 for the sharing model, repointed to ADR-0014, which is where ADR-0008's table actually reserves it.
- `.gitignore`: qmd's local index directory.

## Status

ADR-0015 is `proposed` and SPEC-0010 is `draft`. No code changes, no issues opened. `/sdd:plan SPEC-0010` is the next step once the ADR is accepted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsufroW5o7HXQ46hpnZvQa)_