### PR TITLE
test(web): close the gaps the five test stories actually name

### DIFF
--- a/web/scripts/mutation-check.sh
+++ b/web/scripts/mutation-check.sh
@@ -49,7 +49,10 @@ CONTROL="src/canvas/NodeControl.tsx"
 ASSIGN="src/canvas/useLeafAssignment.ts"
 BASES="src/canvas/bases.ts"
 
-MUTABLE="$MUTABLE $LAYOUT $TREE $METHODS $CONTROL $ASSIGN $BASES"
+PLANNERCARD="src/card/BasePlannerCard.tsx"
+POWERBLOCK="src/card/PowerBlock.tsx"
+
+MUTABLE="$MUTABLE $LAYOUT $TREE $METHODS $CONTROL $ASSIGN $BASES $PLANNERCARD $POWERBLOCK"
 
 # shellcheck disable=SC2086
 restore() { git checkout -- $MUTABLE 2>/dev/null || true; }
@@ -572,6 +575,34 @@ check "the assignment announcement stops naming the base" \
   tests/canvas/assignment.spec.ts "$SHELL" \
   "      const label = BASES.find((base) => base.id === baseId)?.label;" \
   "      const label: string | undefined = undefined;"
+
+# ----------------------------------------------------------------------
+# The absences the test stories asked for and nothing was enforcing.
+#
+# `numericConversions` catches Number()/parseInt/Math., and deliberately not
+# `-` or `/`. So "no quantity-divided-by-rate appears in the card's source"
+# was written at the top of tests/card/discipline.spec.ts and enforced by
+# nothing, and "no subtraction of draw from generation" had only a rendered
+# assertion — which cannot tell a computed balance from the payload's when
+# the two agree, and they always will.
+# ----------------------------------------------------------------------
+
+check "the card computes a plant count it was given" \
+  tests/card/discipline.spec.ts "$PLANNERCARD" \
+  '        <Figure label="Plants" value={q(row.plants)} />' \
+  '        <Figure label="Plants" value={q(row.required / row.yieldPerPlant.min)} />'
+
+check "the card subtracts draw from generation" \
+  tests/card/discipline.spec.ts "$POWERBLOCK" \
+  '        <Figure label="Balance" value={formatQuantity(budget.balance)} />' \
+  '        <Figure label="Balance" value={formatQuantity(budget.generation - budget.draw)} />'
+
+# The two payloads differ in one boolean. A card that stated the unsizeable
+# fix whenever the count was zero would pass every other power assertion.
+check "an unsizeable fix is claimed for a fix the domain sized" \
+  tests/card/power.spec.ts "$POWERBLOCK" \
+  "  const sized = budget.inDeficit && !budget.fixUnsized;" \
+  "  const sized = false;"
 
 echo
 if [ "$failures" -gt 0 ]; then

--- a/web/tests/canvas/edges.spec.ts
+++ b/web/tests/canvas/edges.spec.ts
@@ -211,3 +211,86 @@ test("the per-unit figure is text, not a line thickness", async ({ page }) => {
 
   expect(new Set(widths).size, "edge width varies, and only quantity varies").toBe(1);
 });
+
+test("with edge styling actually removed, every fact it carried is still there", async ({
+  page,
+}) => {
+  /*
+   * #89's acceptance criterion words this precisely: the test "removes
+   * styling rather than reasoning about it, so 'the fact is also in the
+   * text' is observed and not argued".
+   *
+   * The companion test above argues it — it reads each edge's method off a
+   * data attribute and finds the same word on the card. That is a claim
+   * about the model, and it would still pass if the styling were the only
+   * thing a *person* could see.
+   *
+   * So this one flattens the styling for real: every edge is forced to one
+   * stroke, one dash pattern and one width. The first assertion is that the
+   * flattening worked — without it, "the facts survived" would be true
+   * because nothing was removed.
+   */
+  await resolve(page, "ANTIMATTER");
+  const canvas = page.getByRole("region", CANVAS);
+
+  const before = await canvas.locator(".tree-edge").evaluateAll((nodes) =>
+    nodes.map((node) => {
+      const style = getComputedStyle(node);
+      return `${style.stroke}|${style.strokeDasharray}`;
+    }),
+  );
+  expect(
+    new Set(before).size,
+    "the edges were already identical, so removing styling proves nothing",
+  ).toBeGreaterThan(1);
+
+  await page.addStyleTag({
+    content: `.tree-edge, .tree-edge[data-method] {
+      stroke: rgb(128 128 128) !important;
+      stroke-dasharray: none !important;
+      stroke-width: 1.5px !important;
+    }
+    .edge-label, .edge-label[data-method] {
+      color: rgb(128 128 128) !important;
+      background-color: transparent !important;
+      border-color: transparent !important;
+    }`,
+  });
+
+  const after = await canvas.locator(".tree-edge").evaluateAll((nodes) =>
+    nodes.map((node) => {
+      const style = getComputedStyle(node);
+      return `${style.stroke}|${style.strokeDasharray}`;
+    }),
+  );
+  expect(new Set(after).size, "the styling did not actually flatten").toBe(1);
+
+  /*
+   * Now every fact the appearance carried has to be readable as text. The
+   * per-unit quantity is on the edge's own label; the method it fed is on
+   * the card it points at.
+   */
+  const expected = await payloadEdges(page);
+  const labels = await canvas
+    .locator(".edge-label")
+    .evaluateAll((nodes) => nodes.map((node) => node.textContent ?? ""));
+  expect([...labels].sort()).toEqual([...expected.map((edge) => edge.perUnit)].sort());
+
+  const methodsOnCards = await canvas
+    .locator(".react-flow__node")
+    .evaluateAll((nodes) =>
+      Object.fromEntries(
+        nodes.map((node) => [
+          node.getAttribute("data-id") ?? "",
+          node.querySelector(".node-method")?.textContent ?? "",
+        ]),
+      ),
+    );
+  for (const edge of expected) {
+    const target = edge.id.split("->")[1] ?? "";
+    expect(
+      methodsOnCards[target],
+      `with styling gone, nothing says the edge into ${target} feeds a ${edge.targetMethod} step`,
+    ).toContain(edge.targetMethod);
+  }
+});

--- a/web/tests/canvas/method-control.spec.ts
+++ b/web/tests/canvas/method-control.spec.ts
@@ -347,6 +347,35 @@ test.describe("in the shell", () => {
     await expect(card).toBeFocused();
   });
 
+  test("the backdrop returns focus too — the third route", async ({ page }) => {
+    /*
+     * #90 asks for every close route "each tested separately": Escape, the
+     * backdrop, and the close control. The trap's backdrop route is proven
+     * once on the shell's own popover in a11y-primitives.spec.ts; this
+     * asserts it on *this* dialog, because a surface that added its own
+     * backdrop handler would break here and nowhere else.
+     */
+    const card = page
+      .getByRole("region", CANVAS)
+      .locator(".node-card")
+      .filter({ hasText: "Antimatter" })
+      .first();
+
+    await card.click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    /*
+     * A corner, not the centre. The backdrop spans the viewport, so its
+     * midpoint is underneath the dialog — `force: true` skips the
+     * actionability check but still clicks the centre point, which lands on
+     * the dialog and dismisses nothing. This cost a debugging detour.
+     */
+    await page.locator(".popover-backdrop").click({ position: { x: 8, y: 8 } });
+
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await expect(card).toBeFocused();
+  });
+
   test("focus stays inside the control while it is open", async ({ page }) => {
     await openControlFor(page, "Chromatic Metal");
     const dialog = page.getByRole("dialog");

--- a/web/tests/card/configuration.spec.ts
+++ b/web/tests/card/configuration.spec.ts
@@ -123,3 +123,38 @@ test("every control is reachable and operable by keyboard", async ({ page }) => 
     await expect(control).not.toHaveAttribute("tabindex", /.*/);
   }
 });
+
+test("fill duration, generator count and panel count each cross the boundary too", async ({
+  page,
+}) => {
+  /*
+   * #101 lists four fields, not one: "changing class, fill duration,
+   * generator count or panel count issues a boundary call". Only the class
+   * was covered, and the class is the field most obviously connected to a
+   * recompute — the risk is a later change that treats a panel count as
+   * "display only" and adjusts a figure in place, which is precisely what
+   * SPEC-0007 forbids and what no rendered assertion would notice.
+   *
+   * Each field is driven separately and the count must move for each. A
+   * single test changing all three would pass if two of them dispatched.
+   */
+  const calls = async (): Promise<number> =>
+    Number(await page.locator("body").getAttribute("data-rollup-calls"));
+
+  for (const [testid, value] of [
+    ["fill-seconds", "7200"],
+    ["em-generators", "5"],
+    ["solar-panels", "12"],
+  ] as const) {
+    const before = await calls();
+    const control = page.locator(`${CARD} [data-testid="${testid}"]`);
+    await expect(control, `${testid} is not on the card`).toHaveCount(1);
+
+    await control.fill(value);
+    await control.blur();
+
+    await expect
+      .poll(calls, { timeout: 10_000, message: `${testid} did not recompute` })
+      .toBeGreaterThan(before);
+  }
+});

--- a/web/tests/card/discipline.spec.ts
+++ b/web/tests/card/discipline.spec.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { expect, test } from "@playwright/test";
 
-import { numericConversions } from "../helpers/source-checks";
+import { domainArithmetic, numericConversions } from "../helpers/source-checks";
 
 /*
  * Governing: SPEC-0007 REQ "Card Composition From the Build Payload",
@@ -64,4 +64,64 @@ test("the checker still catches the mistake it exists to catch", () => {
    */
   const broken = `const plants = Math.ceil(Number(row.required) / Number(row.yieldPerPlant.min));`;
   expect(numericConversions("broken.tsx", broken).length).toBeGreaterThan(0);
+});
+
+/*
+ * The half this file's own header claimed and did not perform.
+ *
+ * `numericConversions` matches `Number(`, `parseInt`, `Math.` and `+` on a
+ * quantity-shaped name. It does not match `/` or `-`, because the shared
+ * checker deliberately leaves arithmetic operators alone — `+` concatenates
+ * strings everywhere and flagging it would get the checker switched off.
+ *
+ * So "no quantity-divided-by-rate appears in the card's source" was written
+ * at the top of this file and enforced by nothing. `domainArithmetic` is
+ * the operator half, scoped to the domain's own vocabulary and to spaced
+ * operators so hyphenated class names and JSX's `/>` cannot match.
+ */
+
+test("no card source divides a quantity by a rate or subtracts one figure from another", () => {
+  const sources = cardSources();
+  expect(sources.length).toBeGreaterThan(0);
+
+  for (const { file, source } of sources) {
+    expect(
+      domainArithmetic(file, source),
+      `card/${file} computes a figure the payload already carries`,
+    ).toEqual([]);
+  }
+});
+
+test("the operator checker catches both constructs it exists for", () => {
+  /*
+   * The two the requirements name. The first is SPEC-0007's farm row: a
+   * card carrying `required` and `yieldPerPlant` can produce the plant
+   * count itself, and must not. The second is the power shortfall, where
+   * the computed answer equals the payload's — which is exactly why no
+   * rendered assertion can tell them apart.
+   */
+  expect(
+    domainArithmetic("x.tsx", "const plants = required / yieldPerPlant.min;"),
+  ).toHaveLength(1);
+  expect(domainArithmetic("x.tsx", "const shortfall = generation - draw;")).toHaveLength(
+    1,
+  );
+  expect(domainArithmetic("x.tsx", "const each = total / panels;")).toHaveLength(1);
+});
+
+test("the operator checker does not fire on the code the card actually contains", () => {
+  /*
+   * The companion, and the reason the pattern is narrow. A checker that
+   * matched a hyphenated class name, a JSX self-close or a loop counter
+   * would be reported as a false positive and switched off, which is how a
+   * rule stops being enforced without anyone deciding to stop enforcing it.
+   */
+  expect(domainArithmetic("x.tsx", '<span className="card-row-name" />')).toEqual([]);
+  expect(domainArithmetic("x.tsx", "<Figure label={label} value={value} />")).toEqual([]);
+  expect(
+    domainArithmetic("x.tsx", "for (let i = 0; i < rows.length - 1; i += 1) {"),
+  ).toEqual([]);
+  expect(domainArithmetic("x.tsx", "const total = formatQuantity(row.total);")).toEqual(
+    [],
+  );
 });

--- a/web/tests/card/power.spec.ts
+++ b/web/tests/card/power.spec.ts
@@ -14,6 +14,8 @@ const FIXTURE = "/tests/fixtures/card-power.html";
 const SIZED = '[data-base="Sized Deficit"]';
 const UNSIZED = '[data-base="Unsized Deficit"]';
 const SURPLUS = '[data-base="Surplus"]';
+/* Same zero additional generators as UNSIZED, with the flag off. */
+const ZERO_SIZED = '[data-base="Zero Sized"]';
 
 test.beforeEach(async ({ page }) => {
   await page.goto(FIXTURE, { waitUntil: "load" });
@@ -151,4 +153,35 @@ test("no completion fraction is rendered anywhere", async ({ page }) => {
     expect(text).not.toMatch(/complete/i);
     await expect(footer.locator("progress, meter")).toHaveCount(0);
   }
+});
+
+test("the same zero renders differently when the domain could size the fix", async ({
+  page,
+}) => {
+  /*
+   * #101's criterion, precisely: "Distinct from `fixUnsized: false` with the
+   * same zero — the two payloads differ in one boolean and must render
+   * differently."
+   *
+   * Without this, "fixUnsized shows the deficit and states the fix needs a
+   * class" passes against a card that states it whenever the additional
+   * generator count is zero, regardless of the flag. Both fixtures below are
+   * in deficit with `additionalGenerators` of zero; only one has the flag.
+   */
+  const unsized = page.locator(UNSIZED);
+  const sizedAtZero = page.locator(ZERO_SIZED);
+
+  await expect(unsized).toBeVisible();
+  await expect(sizedAtZero).toBeVisible();
+
+  /* Both are deficits, and both say so. */
+  await expect(unsized).toContainText("180");
+  await expect(sizedAtZero).toContainText("180");
+
+  /* Only the unsized one says the fix needs a class. */
+  await expect(unsized).toContainText(/class/i);
+  await expect(
+    sizedAtZero.getByText(/needs a (generator )?class/i),
+    "a fix the domain sized is being reported as unsizeable",
+  ).toHaveCount(0);
 });

--- a/web/tests/fixtures/card-power-harness.tsx
+++ b/web/tests/fixtures/card-power-harness.tsx
@@ -109,6 +109,30 @@ const unsizedBudget: PowerBudget = {
   verified: true,
 };
 
+/*
+ * The contrast case #101 names: the *same* zero additional generators, with
+ * the flag off.
+ *
+ * `unsizedBudget` above is a deficit the domain could not size. This one is
+ * a deficit it sized at zero — the two payloads differ in exactly one
+ * boolean, and the card has to render them differently. Without this,
+ * "fixUnsized shows the deficit and states the fix needs a class" passes
+ * against a card that says it unconditionally whenever the count is zero.
+ */
+const sizedAtZeroBudget: PowerBudget = {
+  base: "Zero Sized",
+  generation: exact("200"),
+  draw: exact("380"),
+  balance: exact("-180"),
+  deficit: exact("180"),
+  inDeficit: true,
+  perGenerator: exact("50"),
+  batteries: exact("0"),
+  additionalGenerators: exact("0"),
+  fixUnsized: false,
+  verified: true,
+};
+
 const surplusBudget: PowerBudget = {
   base: "Surplus",
   generation: exact("600"),
@@ -149,6 +173,17 @@ export function Cards(): ReactNode {
         configuration={{
           site: baseNamed("Unsized Deficit").site,
           power: { solarPanels: exact("10") },
+        }}
+        onConfigure={() => {}}
+      />
+      {/* Same zero as the card above it, with the flag off. */}
+      <BasePlannerCard
+        base={baseNamed("Zero Sized")}
+        identity={4}
+        budget={sizedAtZeroBudget}
+        configuration={{
+          site: baseNamed("Zero Sized").site,
+          power: { emClass: "B", emGenerators: exact("2") },
         }}
         onConfigure={() => {}}
       />

--- a/web/tests/helpers/source-checks.ts
+++ b/web/tests/helpers/source-checks.ts
@@ -143,3 +143,46 @@ const SYNC_MARKER =
 export function syncMarkers(file: string, source: string): Finding[] {
   return scan(file, source, SYNC_MARKER);
 }
+
+/*
+ * Arithmetic on a domain figure, by operator rather than by conversion.
+ *
+ * Governing: SPEC-0005 REQ "The View Computes No Domain Values", SPEC-0007
+ * REQ "Card Composition From the Build Payload", REQ "Power Position",
+ * REQ "Duration Display"
+ *
+ * `numericConversions` catches the step a view has to take *first* —
+ * `Number(...)`, `parseFloat`, `Math.` — and deliberately leaves arithmetic
+ * operators alone, because `+` concatenates strings throughout this
+ * codebase and a checker that flagged it would be switched off within a
+ * week.
+ *
+ * That reasoning does not extend to `-` and `/`. Neither has a string
+ * meaning in JavaScript, and both are exactly the operators the two
+ * requirements name:
+ *
+ *   SPEC-0007 forbids computing a count from a quantity and a rate *even
+ *   where both are in the payload* — a farm row carries `required` and
+ *   `yieldPerPlant`, and `plants` is already the answer. That is division.
+ *
+ *   The shortfall is the domain's figure. Subtracting draw from generation
+ *   produces the same number the payload already carries, which is why a
+ *   behavioural test cannot tell the two apart: a card that computed the
+ *   balance and happened to agree renders identically.
+ *
+ * Both operands are required to be spaced, which is what the formatter
+ * produces and what keeps `data-method`, `card-row-name` and JSX's `/>`
+ * out of the match. The terms are the domain's vocabulary rather than every
+ * identifier, so a loop counter is not a finding.
+ */
+const DOMAIN_TERMS =
+  "quantity|total|required|generation|draw|yield|yieldPerPlant|rate|perUnit|shortfall|balance|plants|biodomes|panels|generators|applications|seconds|duration";
+
+const DOMAIN_ARITHMETIC = new RegExp(
+  `\\b(?:${DOMAIN_TERMS})\\w*\\s+[-/]\\s+|\\s+[-/]\\s+\\w*(?:${DOMAIN_TERMS})\\b`,
+  "i",
+);
+
+export function domainArithmetic(file: string, source: string): Finding[] {
+  return scan(file, source, DOMAIN_ARITHMETIC);
+}

--- a/web/tests/shell/data-custody.spec.ts
+++ b/web/tests/shell/data-custody.spec.ts
@@ -393,3 +393,32 @@ test("the data custody surface passes the accessibility audit", async ({ page })
     .analyze();
   expect(results.violations).toEqual([]);
 });
+
+test("the backdrop dismisses the confirmation and returns focus, removing nothing", async ({
+  page,
+}) => {
+  /*
+   * #115 asks for every close route "each tested separately". Escape and
+   * the close control are covered above; this is the third, and it carries
+   * a second assertion the others do not: a backdrop click is the easiest
+   * route to dismiss by accident, so it must also be the route that is
+   * certain to have deleted nothing.
+   */
+  await withStoredPlace(page);
+  const opener = page.getByRole("button", { name: "Delete stored data" });
+
+  await opener.click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+
+  /*
+   * A corner, not the centre. The backdrop spans the viewport, so its
+   * midpoint is underneath the dialog — `force: true` skips the
+   * actionability check but still clicks the centre point, which lands on
+   * the dialog and dismisses nothing. This cost a debugging detour.
+   */
+  await page.locator(".popover-backdrop").click({ position: { x: 8, y: 8 } });
+
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(opener).toBeFocused();
+  expect(await storedCounts(page)).toEqual({ places: 1, workspace: 1 });
+});


### PR DESCRIPTION
Closes #89
Closes #100
Closes #101
Closes #115
Part of #84, #94, #110

## What this is, and what it deliberately is not

The five test stories were **audited against the existing suite before anything was written**. Most of what they ask for already exists — each implementation story shipped its own tests — so this closes the gaps rather than restating coverage.

Written as specified, these five would have produced roughly fifty duplicate tests and buried the handful of things genuinely missing. The audit is the deliverable as much as the code is.

| Story | Requirements | Already covered | Gap closed here |
|---|---|---|---|
| #89 rendering, ordering, layout | 6 | 5 | edge-facts must *remove* styling, not argue |
| #100 composition, identity, producers | 9 | 8 | source check for quantity ÷ rate |
| #101 power, deficit, provenance | 13 | 10 | subtraction source check · `fixUnsized` contrast · 3 more reconfig fields |
| #115 preferences, empty state, deletion | 10 | 9 | backdrop close route |
| #90 node card, controls, provenance | 8 | 5 | backdrop route · **2 blocked on #132** |

Things I expected to be gaps and verified were not: #90's "colour is never alone, enumerated from the component's own status table" is already done — `a11y-baseline.spec.ts` iterates `STATUSES` *and* guards the enumeration itself. I checked rather than assumed.

## The two that matter

Both are absences no rendered assertion can catch.

`numericConversions` matches `Number(`, `parseInt`, `Math.` and deliberately **not** `-` or `/` — the shared checker's own comment explains why: `+` concatenates strings throughout the codebase and flagging it "would be turned off within a week". That reasoning does not extend to the other two operators, and both are precisely what the requirements name.

**Division.** *"No quantity-divided-by-rate appears in the card's source"* is written at the top of `tests/card/discipline.spec.ts` — and was enforced by nothing. The file's stated purpose and its actual check disagreed. A farm row carries `required` and `yieldPerPlant`, so `required / yieldPerPlant.min` looks like the plant count and is not; SPEC-0007 requires the domain's `plants` *even where both are in the payload*.

**Subtraction.** *"No subtraction of draw from generation"* had only a rendered assertion — which **cannot distinguish a computed balance from the payload's when the two agree, and they always will**. I raised this reviewing #128 and it is now enforced.

`domainArithmetic` is the operator half: scoped to the domain's vocabulary and to *spaced* operators, so hyphenated class names and JSX's `/>` cannot match. Both real source trees are clean; the mutations prove the checker sees it when they are not.

## Also closed

- **Edge facts, observed not argued.** #89's criterion asks the test to *remove* styling. The existing test reads a `data-` attribute and finds the same word on a card — a claim about the model. The new one flattens every edge to one stroke and dash, **asserts the flattening actually worked**, then requires every fact to still be readable as text.
- **`fixUnsized` contrast.** A new fixture base with the *same* zero additional generators and the flag off. One boolean apart, and they must render differently — without it, the existing test passes against a card that states the unsizeable fix whenever the count is zero.
- **Reconfiguration beyond class.** #101 lists four fields; only the extractor class was covered. Fill duration, generator count and panel count now each dispatch, driven separately so a partial regression cannot hide.
- **Backdrop close route**, on the method control and the deletion confirmation, each asserted separately.

## A test bug worth recording

My first backdrop tests failed and the product was fine. The backdrop spans the viewport, so its **centre point sits underneath the dialog** — `click({force: true})` skips the actionability check but still clicks the centre, which lands on the dialog and dismisses nothing. A direct DOM `.click()` closed it immediately. Both tests now click a corner, and the comment says why.

## Not here

Two of #90's requirements — the recipe control's options and its behaviour at 61 options — need a control that does not exist. That is **#132**, blocked on design. #90 stays open for them; everything else it names is covered.

## Verification

**315 tests pass** (up from 307). lint, lint:css, typecheck, format:check, check:tokens, build all clean. **55/55 mutations red**, three new:

| Mutation | Catches |
|---|---|
| the card computes a plant count it was given | division |
| the card subtracts draw from generation | subtraction |
| an unsizeable fix is claimed for a fix the domain sized | the one-boolean contrast |

No protected paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)