### PR TITLE
feat: places are first-class — identity, hand creation, and unassignment

### DIFF
--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -42,7 +42,14 @@ import (
 // 1.2.0 added provenance to every producer row and to each base, and the
 // verified-dates map to the request. Same reasoning: additive, but a
 // consumer that branches on provenance needs to know it is there.
-const ContractVersion = "1.2.0"
+//
+// 1.3.0 added `configured` to each base and the `unsited` rows beside it,
+// when SPEC-0011 made a place with no site configuration assignable. Same
+// reasoning again, with a sharper edge than the previous two: a consumer
+// that does not know about `configured` reads a base with a zero site as
+// one configured at class "" for zero seconds, which is exactly the zero
+// SPEC-0011 REQ "A Place Is Creatable by Hand" forbids presenting.
+const ContractVersion = "1.3.0"
 
 // Quantity is an exact quantity on the wire.
 //

--- a/internal/bridge/stages.go
+++ b/internal/bridge/stages.go
@@ -222,10 +222,37 @@ type NoBuildRow struct {
 	Verified bool     `json:"verified"`
 }
 
+// UnsitedRow is a demand that needs a site configuration the base does not
+// have.
+//
+// Governing: SPEC-0011 REQ "A Place Is Creatable by Hand"
+//
+// Carried across the boundary rather than dropped, for the same reason
+// NoBuildRow is: an absent row is indistinguishable from an overlooked
+// requirement, and here the whole point is that the view render the gap.
+type UnsitedRow struct {
+	ItemID   string   `json:"itemId"`
+	Name     string   `json:"name"`
+	Required Quantity `json:"required"`
+	Verified bool     `json:"verified"`
+}
+
 // BaseBuild is one base's construction instructions.
 type BaseBuild struct {
 	Base string `json:"base"`
 	Site Site   `json:"site"`
+
+	// Configured reports whether the base has a site configuration. When
+	// false, Site carries zero values that mean nothing and the view MUST
+	// render the absence rather than the zeros.
+	//
+	// Governing: SPEC-0011 REQ "A Place Is Creatable by Hand", SPEC-0007
+	// REQ "Absent Data Is Absent"
+	//
+	// Always emitted, never omitempty: false is the value that carries the
+	// meaning here, and a field that disappears when it matters most is the
+	// opposite of what the requirement asks for.
+	Configured bool `json:"configured"`
 
 	Farms      []FarmRow      `json:"farms,omitempty"`
 	Extractors []ExtractorRow `json:"extractors,omitempty"`
@@ -237,6 +264,10 @@ type BaseBuild struct {
 	PelletFeeders      Quantity `json:"pelletFeeders"`
 
 	NoBuild []NoBuildRow `json:"noBuild,omitempty"`
+
+	// Unsited are demands that need extraction at a base with no site
+	// configuration. Empty whenever Configured is true.
+	Unsited []UnsitedRow `json:"unsited,omitempty"`
 
 	// Verified is the base-level answer: every row here, and the constant
 	// that sized its processors.
@@ -502,6 +533,7 @@ func encodeBaseBuild(b domain.BaseBuild) BaseBuild {
 			ExtractorClass: string(b.Site.ExtractorClass),
 			FillSeconds:    QuantityOfInt(b.Site.FillSeconds),
 		},
+		Configured:         b.Configured,
 		NutrientProcessors: QuantityOfInt(b.NutrientProcessors),
 		PelletFeeders:      QuantityOfInt(b.PelletFeeders),
 		Verified:           b.Verified,
@@ -569,6 +601,14 @@ func encodeBaseBuild(b domain.BaseBuild) BaseBuild {
 			From:     n.From,
 			Required: QuantityOf(n.Required()),
 			Verified: n.Verified,
+		})
+	}
+	for _, u := range b.Unsited {
+		out.Unsited = append(out.Unsited, UnsitedRow{
+			ItemID:   u.ItemID,
+			Name:     u.Name,
+			Required: QuantityOf(u.Required()),
+			Verified: u.Verified,
 		})
 	}
 	return out

--- a/internal/bridge/stages_test.go
+++ b/internal/bridge/stages_test.go
@@ -550,3 +550,95 @@ func TestProducerProvenanceCrossesTheBoundary(t *testing.T) {
 		t.Error("base crossed unverified with every date supplied")
 	}
 }
+
+// SPEC-0011 REQ "A Place Is Creatable by Hand":
+// WHEN a leaf is assigned to a place that has no site configuration
+// THEN the boundary reports the base as unconfigured with the demand
+// unsized, rather than failing the call or reporting zero extractors.
+//
+// Asserted at the boundary rather than only in the domain because the view
+// renders the absence, and a field the encoder drops is a gap the view
+// cannot tell from a base with nothing to extract.
+func TestRollupCarriesAnUnconfiguredBase(t *testing.T) {
+	m := stagesModule(t)
+
+	blob, _ := callOK(t, m, "rollup", `{
+	  "plan":{"target":"widget","quantity":"10"},
+	  "assignments":{"crop_a":"base1","gas_a":"base1"},
+	  "constants":`+curatedJSON+`}`)
+
+	var out struct {
+		Data struct {
+			Build struct {
+				Bases []struct {
+					Base       string `json:"base"`
+					Configured bool   `json:"configured"`
+					Extractors []struct {
+						ItemID string `json:"itemId"`
+					} `json:"extractors"`
+					Farms []struct {
+						ItemID string `json:"itemId"`
+					} `json:"farms"`
+					Unsited []struct {
+						ItemID   string `json:"itemId"`
+						Required string `json:"required"`
+					} `json:"unsited"`
+				} `json:"bases"`
+			} `json:"build"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(blob, &out); err != nil {
+		t.Fatalf("unparseable rollup output: %v", err)
+	}
+	if len(out.Data.Build.Bases) != 1 {
+		t.Fatalf("bases = %d, want 1", len(out.Data.Build.Bases))
+	}
+
+	base := out.Data.Build.Bases[0]
+	if base.Configured {
+		t.Error("a base with no sites entry crossed as configured")
+	}
+	if len(base.Extractors) != 0 {
+		t.Errorf("extractor rows = %d, want none", len(base.Extractors))
+	}
+	if len(base.Unsited) != 1 || base.Unsited[0].ItemID != "gas_a" {
+		t.Fatalf("unsited = %+v, want gas_a alone", base.Unsited)
+	}
+	if base.Unsited[0].Required == "" {
+		t.Error("the unsited row crossed with no requirement")
+	}
+	// The half that still works: a crop needs no site, so the farm is sized.
+	if len(base.Farms) != 1 {
+		t.Errorf("farm rows = %d, want 1 — an unconfigured base still says what to plant", len(base.Farms))
+	}
+}
+
+// The complement: a configured base still reports itself configured, so the
+// flag is a real distinction rather than a field that is always false.
+func TestRollupReportsAConfiguredBase(t *testing.T) {
+	m := stagesModule(t)
+
+	blob, _ := callOK(t, m, "rollup", rollupRequest(curatedJSON))
+
+	var out struct {
+		Data struct {
+			Build struct {
+				Bases []struct {
+					Configured bool `json:"configured"`
+					Unsited    []struct {
+						ItemID string `json:"itemId"`
+					} `json:"unsited"`
+				} `json:"bases"`
+			} `json:"build"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(blob, &out); err != nil {
+		t.Fatalf("unparseable rollup output: %v", err)
+	}
+	if len(out.Data.Build.Bases) != 1 || !out.Data.Build.Bases[0].Configured {
+		t.Fatalf("configured base did not report itself configured: %+v", out.Data.Build.Bases)
+	}
+	if len(out.Data.Build.Bases[0].Unsited) != 0 {
+		t.Errorf("configured base carried %d unsited rows, want none", len(out.Data.Build.Bases[0].Unsited))
+	}
+}

--- a/internal/domain/producer.go
+++ b/internal/domain/producer.go
@@ -199,10 +199,55 @@ type NoBuild struct {
 // Required returns the demand the byproduct covers.
 func (b NoBuild) Required() *big.Rat { return new(big.Rat).Set(b.required) }
 
+// Unsited is a demand that needs a site configuration the base does not have.
+//
+// Governing: SPEC-0011 REQ "A Place Is Creatable by Hand" — "A place with no
+// site configuration MUST be assignable. Its rollup MUST treat the site as
+// unconfigured, and the card MUST render that absence as absence ... rather
+// than as a zero."
+//
+// Only extraction needs the site. A crop's yield and a fauna's rate are the
+// item's own facts, so a farm and a ranch at an unconfigured base size
+// normally — the plan still says what to plant and what to feed. What it
+// cannot say is how many extractors, because that answer is the hotspot
+// class and the fill duration, and neither exists yet.
+//
+// A row rather than a flag, because "these three items are waiting on a
+// class" is a different statement from "this base is unconfigured", and only
+// the first one tells the player what they lose by leaving it that way.
+type Unsited struct {
+	ItemID string
+	Name   string
+
+	// Verified carries the demand's provenance forward. An unsized figure
+	// is still a figure the plan reports.
+	//
+	// Governing: SPEC-0001 REQ "Provenance Propagation".
+	Verified bool
+
+	required *big.Rat
+}
+
+// Required returns the demand that could not be sized.
+func (u Unsited) Required() *big.Rat { return new(big.Rat).Set(u.required) }
+
 // BaseBuild is one base's construction instructions.
 type BaseBuild struct {
 	Base BaseID
+
+	// Site is the base's configuration. Zero when Configured is false;
+	// read that first.
 	Site SiteConfig
+
+	// Configured reports whether this base has a site configuration.
+	//
+	// Governing: SPEC-0011 REQ "A Place Is Creatable by Hand"
+	//
+	// False is not an error and not a zero. A place created with a name and
+	// nothing else is assignable by rule, and this is how the rollup says
+	// so: Extractors is empty, Unsited carries what would have been sized,
+	// and the card renders the gap as a gap.
+	Configured bool
 
 	Farms      []FarmRow
 	Extractors []ExtractorRow
@@ -220,6 +265,10 @@ type BaseBuild struct {
 
 	// NoBuild are items a byproduct at this base already covers.
 	NoBuild []NoBuild
+
+	// Unsited are demands that need extraction at a base with no site
+	// configuration. Always empty when Configured is true.
+	Unsited []Unsited
 
 	// Verified is false when any row at this base is unverified, or when
 	// the constant sizing the base's nutrient processors has no verified
@@ -312,7 +361,7 @@ func RollupProducers(g *Grouping, t *Tier1, c *Constants, in ProducerInput) (*Bu
 }
 
 func rollupBase(group BaseGroup, t *Tier1, c *Constants, in ProducerInput) (*BaseBuild, error) {
-	build := &BaseBuild{Base: group.Base, Site: group.Site}
+	build := &BaseBuild{Base: group.Base, Site: group.Site, Configured: group.Configured}
 
 	// Byproducts first: an item another producer here already yields
 	// contributes no row at all, so it never reaches the sizing below.
@@ -343,6 +392,23 @@ func rollupBase(group BaseGroup, t *Tier1, c *Constants, in ProducerInput) (*Bas
 			build.Ranches = append(build.Ranches, ranchRow(demand, c))
 
 		default:
+			/*
+			 * Extraction is the one producer that needs the site. Without a
+			 * class and a fill duration there is no honest count, so the
+			 * demand is reported unsized rather than sized against values
+			 * nobody chose.
+			 *
+			 * Governing: SPEC-0011 REQ "A Place Is Creatable by Hand"
+			 */
+			if !group.Configured {
+				build.Unsited = append(build.Unsited, Unsited{
+					ItemID: demand.ItemID, Name: demand.Name,
+					Verified: demand.Verified,
+					required: demand.Total(),
+				})
+				continue
+			}
+
 			row, err := extractorRow(demand, group.Site, c)
 			if err != nil {
 				return nil, err
@@ -409,6 +475,15 @@ func (b *BaseBuild) rowsVerified() bool {
 	}
 	for _, n := range b.NoBuild {
 		if !n.Verified {
+			return false
+		}
+	}
+	// An unsized demand still carries provenance. Leaving it out would let
+	// a base go from unverified to verified purely by losing its site
+	// configuration, which is the wrong direction for a rule that exists to
+	// stop unverified figures being presented as verified.
+	for _, u := range b.Unsited {
+		if !u.Verified {
 			return false
 		}
 	}
@@ -566,6 +641,7 @@ func sortRows(b *BaseBuild) {
 	sort.Slice(b.Extractors, func(i, j int) bool { return b.Extractors[i].ItemID < b.Extractors[j].ItemID })
 	sort.Slice(b.Ranches, func(i, j int) bool { return b.Ranches[i].ItemID < b.Ranches[j].ItemID })
 	sort.Slice(b.NoBuild, func(i, j int) bool { return b.NoBuild[i].ItemID < b.NoBuild[j].ItemID })
+	sort.Slice(b.Unsited, func(i, j int) bool { return b.Unsited[i].ItemID < b.Unsited[j].ItemID })
 	// Kitchen steps keep their given order: it is the sequence the plan
 	// cooks in, and the final step is identified by position.
 }

--- a/internal/domain/producer_test.go
+++ b/internal/domain/producer_test.go
@@ -54,8 +54,12 @@ func itoa(v int64) string { return new(big.Int).SetInt64(v).String() }
 
 // demandOf builds a grouping directly, so producer tests exercise sizing
 // rather than re-deriving a graph.
+//
+// The group is configured: a caller passing a SiteConfig is stating one.
+// The unconfigured case is a different thing to test and has its own
+// helper — see unconfiguredDemandOf.
 func demandOf(base BaseID, site SiteConfig, demands map[string]int64) *Grouping {
-	group := &BaseGroup{Base: base, Site: site}
+	group := &BaseGroup{Base: base, Site: site, Configured: true}
 	for id, qty := range demands {
 		group.Demands = append(group.Demands, LeafDemand{
 			ItemID: id, Name: id, Verified: true,
@@ -219,8 +223,8 @@ func TestSiteClassAppliesToAllRowsAndOnlyThatBase(t *testing.T) {
 
 	// Two bases, two extractor rows each.
 	grouping := func(alphaClass HotspotClass) *Grouping {
-		alpha := &BaseGroup{Base: "alpha", Site: SiteConfig{ExtractorClass: alphaClass, FillSeconds: 1}}
-		beta := &BaseGroup{Base: "beta", Site: SiteConfig{ExtractorClass: ClassB, FillSeconds: 1}}
+		alpha := &BaseGroup{Base: "alpha", Site: SiteConfig{ExtractorClass: alphaClass, FillSeconds: 1}, Configured: true}
+		beta := &BaseGroup{Base: "beta", Site: SiteConfig{ExtractorClass: ClassB, FillSeconds: 1}, Configured: true}
 		for _, id := range []string{"gas_a", "gas_b"} {
 			alpha.Demands = append(alpha.Demands, LeafDemand{ItemID: id, Name: id, total: new(big.Rat).SetInt64(500)})
 			beta.Demands = append(beta.Demands, LeafDemand{ItemID: id, Name: id, total: new(big.Rat).SetInt64(500)})
@@ -728,5 +732,112 @@ func TestUnverifiedDemandTaintsItsProducerRow(t *testing.T) {
 	}
 	if base.Verified {
 		t.Error("base verified while one of its rows is not")
+	}
+}
+
+// unconfiguredDemandOf builds a grouping for a base with no site
+// configuration — the shape SPEC-0011 makes assignable.
+func unconfiguredDemandOf(base BaseID, demands map[string]int64) *Grouping {
+	g := demandOf(base, SiteConfig{}, demands)
+	group := g.byBase[base]
+	group.Configured = false
+	g.Groups[0] = *group
+	return g
+}
+
+// SPEC-0011 REQ "A Place Is Creatable by Hand":
+// WHEN a leaf is assigned to a place that has no site configuration
+// THEN the card presents the missing configuration as absent, not as a
+// configured value of zero.
+//
+// The rollup's half of that: extraction reports the demand unsized rather
+// than reporting zero extractors, and rather than reporting extractors sized
+// at class "" against a zero-second window.
+func TestUnconfiguredBaseReportsUnsizedDemands(t *testing.T) {
+	a1 := producerArtifact(t, economyFor(25, 3600, 100, 1000))
+	c := constantsFor(t, a1, baseCurated())
+
+	b := build(t, unconfiguredDemandOf("alpha", map[string]int64{"gas_a": 500}), a1, c, ProducerInput{})
+
+	alpha, ok := b.Base("alpha")
+	if !ok {
+		t.Fatal("an unconfigured base produced no build at all")
+	}
+	if alpha.Configured {
+		t.Error("the build reports the base as configured")
+	}
+	if len(alpha.Extractors) != 0 {
+		t.Errorf("unconfigured base sized %d extractor rows, want none", len(alpha.Extractors))
+	}
+	if len(alpha.Unsited) != 1 {
+		t.Fatalf("unsited rows = %d, want 1", len(alpha.Unsited))
+	}
+	if alpha.Unsited[0].ItemID != "gas_a" {
+		t.Errorf("unsited row is %q, want gas_a", alpha.Unsited[0].ItemID)
+	}
+	// The requirement survives: what is missing is the sizing, not the demand.
+	if got := alpha.Unsited[0].Required(); got.Cmp(new(big.Rat).SetInt64(500)) != 0 {
+		t.Errorf("unsited requirement = %s, want 500", got.RatString())
+	}
+}
+
+// Only extraction needs the site. A crop's yield is the item's own fact, so
+// an unconfigured base still says what to plant — which is the difference
+// between "this place is not ready" and "this place tells you nothing".
+func TestUnconfiguredBaseStillSizesFarms(t *testing.T) {
+	a1 := producerArtifact(t, economyFor(25, 3600, 100, 1000))
+	c := constantsFor(t, a1, baseCurated())
+
+	b := build(t, unconfiguredDemandOf("alpha",
+		map[string]int64{"crop_a": 200, "gas_a": 500}), a1, c, ProducerInput{})
+
+	alpha, _ := b.Base("alpha")
+	if len(alpha.Farms) != 1 {
+		t.Fatalf("farm rows = %d, want 1", len(alpha.Farms))
+	}
+	if alpha.Farms[0].Plants == 0 {
+		t.Error("the farm row was sized to zero plants")
+	}
+	if len(alpha.Unsited) != 1 || alpha.Unsited[0].ItemID != "gas_a" {
+		t.Errorf("unsited = %+v, want gas_a alone", alpha.Unsited)
+	}
+}
+
+// A configured site with a zero fill window is still an error. The change in
+// SPEC-0011 is about absence, not about accepting a configuration that
+// cannot size anything — and losing that distinction would turn a caller
+// mistake into a silent unsized row.
+func TestConfiguredSiteWithNoWindowIsStillRefused(t *testing.T) {
+	a1 := producerArtifact(t, economyFor(25, 3600, 100, 1000))
+	c := constantsFor(t, a1, baseCurated())
+
+	_, err := RollupProducers(demandOf("alpha", SiteConfig{ExtractorClass: ClassB},
+		map[string]int64{"gas_a": 500}), a1, c, ProducerInput{})
+	if err == nil {
+		t.Fatal("a configured site with no fill window sized extractors anyway")
+	}
+	if !strings.Contains(err.Error(), "fill duration") {
+		t.Errorf("error %q does not name the missing window", err)
+	}
+}
+
+// An unsized demand still carries provenance: a base must not become
+// verified by losing its site configuration.
+func TestUnsitedDemandsCarryProvenance(t *testing.T) {
+	a1 := producerArtifact(t, economyFor(25, 3600, 100, 1000))
+	c := constantsFor(t, a1, baseCurated())
+
+	g := unconfiguredDemandOf("alpha", map[string]int64{"gas_a": 500})
+	group := g.byBase["alpha"]
+	group.Demands[0].Verified = false
+	g.Groups[0] = *group
+
+	b := build(t, g, a1, c, ProducerInput{})
+	alpha, _ := b.Base("alpha")
+	if alpha.Unsited[0].Verified {
+		t.Error("the unsited row lost its unverified provenance")
+	}
+	if alpha.Verified {
+		t.Error("the base reports verified while carrying an unverified unsited row")
 	}
 }

--- a/internal/domain/rollup.go
+++ b/internal/domain/rollup.go
@@ -17,8 +17,20 @@ import (
 // constant and needs no base assignment. Stage 2 takes stage 1's output and
 // everything below.
 
-// BaseID identifies a base within a plan. The empty value is not a base —
-// see Unassigned.
+// BaseID identifies a place. It is the place record's own id — the value
+// SPEC-0009 generates at creation — and not a key a plan invents for itself.
+// The empty value is not a place; see Unassigned.
+//
+// Governing: ADR-0010 (places are authored first, and a plan assigns leaves
+// to places that exist), SPEC-0011 REQ "A Place Is Authored, and a Plan
+// References It"
+//
+// The distinction is load-bearing rather than cosmetic. A plan-scoped key is
+// invented by whichever plan first named the base, so the same real base
+// acquires a different key in every plan and the annotations against it
+// fragment — a failure that surfaces as data loss rather than as a type
+// error. The domain still sees an opaque string and mints nothing; what
+// changed is where the string comes from.
 type BaseID string
 
 // Unassigned is the group a leaf lands in when the plan does not say where
@@ -447,8 +459,24 @@ type RollupInput struct {
 	Assignments map[string]BaseID
 
 	// Sites configures each base. A base named in Assignments but absent
-	// here is refused rather than defaulted: an extractor class picked for
-	// the caller is a number they never chose showing up in their plan.
+	// here is unconfigured, which is a reported state rather than an error
+	// and rather than a default.
+	//
+	// Governing: SPEC-0011 REQ "A Place Is Creatable by Hand" — "A place
+	// with no site configuration MUST be assignable. Its rollup MUST treat
+	// the site as unconfigured".
+	//
+	// Both halves of the original rule survive. Nothing is defaulted: an
+	// extractor class picked for the caller is still a number they never
+	// chose showing up in their plan, so an unconfigured base sizes no
+	// extractors at all rather than sizing them at class "". What changed
+	// is that refusing the whole rollup is no longer the only alternative
+	// to defaulting — the third state is saying so, which is what
+	// BaseGroup.Configured and BaseBuild.Unsited carry.
+	//
+	// A site that IS present is still validated. An explicit entry with an
+	// unusable class is a caller mistake, and the distinction between
+	// "not configured yet" and "configured wrongly" is the whole point.
 	Sites map[BaseID]SiteConfig
 }
 
@@ -483,8 +511,21 @@ type BaseGroup struct {
 	Base BaseID
 
 	// Site is the base's configuration. Zero for the unassigned group,
-	// which has no site.
+	// which has no site, and zero for a base the plan has not configured —
+	// read Configured before reading this.
 	Site SiteConfig
+
+	// Configured reports whether RollupInput.Sites carried an entry for
+	// this base.
+	//
+	// Governing: SPEC-0011 REQ "A Place Is Creatable by Hand"
+	//
+	// A separate flag rather than a sentinel inside SiteConfig, because the
+	// zero SiteConfig is a legitimate shape to hold — it is what a caller
+	// sends before choosing a class — and a struct that answers "am I real"
+	// about itself makes every reader check a field they did not know was
+	// there. False for the unassigned group, which has no site to configure.
+	Configured bool
 
 	// Demands are the leaves assigned here, sorted by item ID.
 	Demands []LeafDemand
@@ -530,9 +571,11 @@ func GroupLeaves(g *ResolvedGraph, in RollupInput) (*Grouping, error) {
 		return nil, fmt.Errorf("%w: nil resolved graph", ErrInvalidArtifact)
 	}
 
-	// Every base named in an assignment must be configured. Checked before
-	// grouping so the error names the omission rather than surfacing later
-	// as an extractor sized at class "".
+	// A site the caller did supply must be usable. An assignment to a base
+	// with no entry at all is not an error — that base is unconfigured, and
+	// the rollup says so rather than refusing.
+	//
+	// Governing: SPEC-0011 REQ "A Place Is Creatable by Hand"
 	for item, base := range in.Assignments {
 		if base == Unassigned {
 			return nil, fmt.Errorf("%w: %q is assigned to the empty base id; omit it to leave it unassigned",
@@ -540,7 +583,7 @@ func GroupLeaves(g *ResolvedGraph, in RollupInput) (*Grouping, error) {
 		}
 		site, ok := in.Sites[base]
 		if !ok {
-			return nil, fmt.Errorf("%w: base %q has no site configuration", ErrInvalidArtifact, base)
+			continue
 		}
 		if !site.ExtractorClass.Valid() {
 			return nil, fmt.Errorf("%w: base %q extractor class %q is not one of C, B, A, S",
@@ -556,7 +599,13 @@ func GroupLeaves(g *ResolvedGraph, in RollupInput) (*Grouping, error) {
 		}
 		group, ok := out.byBase[base]
 		if !ok {
-			group = &BaseGroup{Base: base, Site: in.Sites[base]}
+			site, configured := in.Sites[base]
+			group = &BaseGroup{
+				Base: base, Site: site,
+				// The unassigned group has no site to configure, so it is
+				// never reported as configured however the map is keyed.
+				Configured: configured && base != Unassigned,
+			}
 			out.byBase[base] = group
 		}
 		group.Demands = append(group.Demands, LeafDemand{

--- a/internal/domain/rollup_test.go
+++ b/internal/domain/rollup_test.go
@@ -236,10 +236,11 @@ func TestExtractorClassIsPerSite(t *testing.T) {
 	}
 }
 
-// A base with assignments but no configuration is refused rather than
-// defaulted — an extractor class picked for the caller is a number they
-// never chose showing up in their plan.
-func TestUnconfiguredBaseIsRefused(t *testing.T) {
+// A site the caller did supply must be usable. Absence is a different thing
+// and is no longer refused — see TestUnconfiguredBaseIsAssignable.
+//
+// Governing: SPEC-0011 REQ "A Place Is Creatable by Hand"
+func TestInvalidSiteConfigurationIsRefused(t *testing.T) {
 	g := resolveStasis(t, 1, nil)
 
 	cases := []struct {
@@ -247,14 +248,6 @@ func TestUnconfiguredBaseIsRefused(t *testing.T) {
 		in   RollupInput
 		want string
 	}{
-		{
-			name: "no site configuration",
-			in: RollupInput{
-				Assignments: map[string]BaseID{"sul": "alpha"},
-				Sites:       map[BaseID]SiteConfig{},
-			},
-			want: "no site configuration",
-		},
 		{
 			name: "class outside the vocabulary",
 			in: RollupInput{
@@ -587,5 +580,80 @@ func TestAbsentTier2ConstantMatchesTheMissingConstantSentinel(t *testing.T) {
 				t.Errorf("error %q does not name the constant at fault (%q)", err, tc.names)
 			}
 		})
+	}
+}
+
+// SPEC-0011 REQ "A Place Is Creatable by Hand":
+// WHEN a leaf is assigned to a place that has no site configuration
+// THEN the rollup treats the site as unconfigured rather than refusing.
+//
+// This replaces the older rule that refused the whole grouping. Both rules
+// exist to stop a class nobody chose appearing in a plan; this one does it
+// by saying the base is unconfigured instead of by failing, because a place
+// created with a name and nothing else is assignable by rule.
+func TestUnconfiguredBaseIsAssignable(t *testing.T) {
+	g := resolveStasis(t, 1, nil)
+
+	out, err := GroupLeaves(g, RollupInput{
+		Assignments: map[string]BaseID{"sul": "alpha"},
+		Sites:       map[BaseID]SiteConfig{},
+	})
+	if err != nil {
+		t.Fatalf("GroupLeaves refused an unconfigured base: %v", err)
+	}
+
+	alpha, ok := out.Group("alpha")
+	if !ok {
+		t.Fatal("the assigned base has no group")
+	}
+	if alpha.Configured {
+		t.Error("a base with no Sites entry reports itself configured")
+	}
+	if alpha.Site != (SiteConfig{}) {
+		t.Errorf("unconfigured site = %+v, want the zero value", alpha.Site)
+	}
+	if len(alpha.Demands) == 0 {
+		t.Error("the leaf was not grouped at the base it was assigned to")
+	}
+}
+
+// SPEC-0011 REQ "A Place Is Authored, and a Plan References It":
+// WHEN a plan is resolved against a workspace holding no places
+// THEN it resolves, and every leaf is reported unassigned rather than
+// failing.
+func TestPlanWithNoPlacesResolves(t *testing.T) {
+	g := resolveStasis(t, 1, nil)
+
+	out, err := GroupLeaves(g, RollupInput{})
+	if err != nil {
+		t.Fatalf("a plan referencing no places failed: %v", err)
+	}
+
+	un, ok := out.Unassigned()
+	if !ok {
+		t.Fatal("no unassigned group exists")
+	}
+	if len(un.Demands) != len(g.Leaves()) {
+		t.Errorf("unassigned holds %d leaves, want all %d", len(un.Demands), len(g.Leaves()))
+	}
+	for _, group := range out.Groups {
+		if !group.IsUnassigned() {
+			t.Errorf("base %q has a group in a plan that assigned nothing", group.Base)
+		}
+	}
+}
+
+// SPEC-0011 REQ "An Assignment Naming an Absent Place Is Unassigned" is a
+// view-side rule about the workspace, but the domain has to make it
+// reachable: an assignment naming a base the caller knows nothing about must
+// not be an error, or the view could not drop it without also refusing the
+// plan.
+func TestAssignmentToAnUnknownBaseIsNotAnError(t *testing.T) {
+	g := resolveStasis(t, 1, nil)
+
+	if _, err := GroupLeaves(g, RollupInput{
+		Assignments: map[string]BaseID{"sul": "a-place-that-was-deleted"},
+	}); err != nil {
+		t.Fatalf("an assignment naming an unknown base failed: %v", err)
 	}
 }

--- a/web/scripts/mutation-check.sh
+++ b/web/scripts/mutation-check.sh
@@ -35,6 +35,7 @@ LIVE="src/a11y/useLiveRegion.ts"
 SHELL="src/shell/AppShell.tsx"
 BADGE="src/shell/StatusBadge.tsx"
 STORE="src/store/durable-store.ts"
+PLACES="src/shell/StoredPlaces.tsx"
 MODEL="src/canvas/graph-model.ts"
 EDGE="src/canvas/TreeEdge.tsx"
 CARD="src/canvas/NodeCard.tsx"
@@ -43,6 +44,7 @@ LAYOUT="src/canvas/layout.ts"
 TREE="src/canvas/TreeCanvas.tsx"
 
 MUTABLE="$BASE $TOKENS $TRAP $LIVE $SHELL $BADGE $STORE $MODEL $EDGE $CARD $CANVAS"
+MUTABLE="$MUTABLE $PLACES"
 METHODS="src/canvas/methods.ts"
 CONTROL="src/canvas/NodeControl.tsx"
 
@@ -637,6 +639,19 @@ check "the unsited rows stop being rendered at all" \
   tests/card/composition.spec.ts "$PLANNERCARD" \
   "      {base.unsited.length > 0 ? (" \
   "      {false ? ("
+
+# The create form's identity, which is the thing a position change destroys.
+#
+# `StoredPlaces` renders an empty state and a populated state. While the form
+# was rendered inside each branch it sat at a different child position in
+# each, so creating the first place moved it and React remounted it, throwing
+# away the name in its `useState`. A key that varies with the same condition
+# reproduces the fault exactly, and is the shape someone reaches for when they
+# want to "reset the form" on a state change.
+check "the create form is remounted when the first place appears" \
+  tests/shell/places.spec.ts "$PLACES" \
+  "      <CreatePlace create={data.createPlace} />" \
+  '      <CreatePlace key={data.empty ? "empty" : "populated"} create={data.createPlace} />'
 
 echo
 if [ "$failures" -gt 0 ]; then

--- a/web/scripts/mutation-check.sh
+++ b/web/scripts/mutation-check.sh
@@ -49,10 +49,13 @@ CONTROL="src/canvas/NodeControl.tsx"
 ASSIGN="src/canvas/useLeafAssignment.ts"
 BASES="src/canvas/bases.ts"
 
+RESOLVE="src/state/assignments.ts"
+STORED="src/state/useStoredData.ts"
 PLANNERCARD="src/card/BasePlannerCard.tsx"
 POWERBLOCK="src/card/PowerBlock.tsx"
 
 MUTABLE="$MUTABLE $LAYOUT $TREE $METHODS $CONTROL $ASSIGN $BASES $PLANNERCARD $POWERBLOCK"
+MUTABLE="$MUTABLE $RESOLVE $STORED"
 
 # shellcheck disable=SC2086
 restore() { git checkout -- $MUTABLE 2>/dev/null || true; }
@@ -558,8 +561,8 @@ check "clearing an assignment stops recomputing" \
 
 check "the rollup goes out without the assignment on it" \
   tests/canvas/assignment.spec.ts "$ASSIGN" \
-  "    const request: RollupRequest = { plan, assignments: next, constants };" \
-  "    const request: RollupRequest = { plan, assignments: {}, constants };"
+  "        assignments: resolveAssignments(next, placeIds).assignments," \
+  "        assignments: {},"
 
 check "a non-leaf is offered a base it cannot be gathered at" \
   tests/canvas/assignment.spec.ts "$CONTROL" \
@@ -568,12 +571,12 @@ check "a non-leaf is offered a base it cannot be gathered at" \
 
 check "an assigned leaf stops taking its base colour" \
   tests/canvas/assignment.spec.ts "$BASES" \
-  "  return BASES.find((base) => base.id === id)?.slot;" \
+  "  return bases.find((base) => base.id === id)?.slot;" \
   "  return undefined;"
 
 check "the assignment announcement stops naming the base" \
   tests/canvas/assignment.spec.ts "$SHELL" \
-  "      const label = BASES.find((base) => base.id === baseId)?.label;" \
+  "      const label = bases.find((base) => base.id === baseId)?.label;" \
   "      const label: string | undefined = undefined;"
 
 # ----------------------------------------------------------------------
@@ -603,6 +606,37 @@ check "an unsizeable fix is claimed for a fix the domain sized" \
   tests/card/power.spec.ts "$POWERBLOCK" \
   "  const sized = budget.inDeficit && !budget.fixUnsized;" \
   "  const sized = false;"
+
+# ----------------------------------------------------------------------
+# Places are first-class.
+#
+# Governing: ADR-0010, SPEC-0011 REQ "A Place Is Authored, and a Plan
+# References It", REQ "An Assignment Naming an Absent Place Is Unassigned",
+# REQ "A Place Is Creatable by Hand"
+#
+# Three rules a behavioural test alone cannot pin down, because each has a
+# passing-looking implementation that is wrong:
+#
+#   - a place id derived from the name renders identically until a rename
+#   - an assignment resolver that keeps everything looks right until a
+#     place is deleted
+#   - a card that shows the site's zeros looks like a configured base
+# ----------------------------------------------------------------------
+
+check "a place takes an id derived from its name instead of a generated one" \
+  tests/shell/places.spec.ts "$STORED" \
+  "        id: crypto.randomUUID()," \
+  "        id: trimmed.toLowerCase().replace(/ /gu, \"-\"),"
+
+check "an assignment naming a deleted place is kept rather than unassigned" \
+  tests/canvas/assignment.spec.ts "$RESOLVE" \
+  "    if (exists.has(baseId)) {" \
+  "    if (true) {"
+
+check "the unsited rows stop being rendered at all" \
+  tests/card/composition.spec.ts "$PLANNERCARD" \
+  "      {base.unsited.length > 0 ? (" \
+  "      {false ? ("
 
 echo
 if [ "$failures" -gt 0 ]; then

--- a/web/src/boundary/build.ts
+++ b/web/src/boundary/build.ts
@@ -88,9 +88,38 @@ export interface Site {
   readonly fillSeconds: Quantity;
 }
 
+/**
+ * A demand needing extraction at a base with no site configuration.
+ *
+ * Governing: SPEC-0011 REQ "A Place Is Creatable by Hand", SPEC-0007 REQ
+ * "Absent Data Is Absent"
+ *
+ * The requirement is still known; what is missing is the class and the fill
+ * duration that would size it. A row rather than a flag, so a surface can
+ * name what is waiting rather than only that something is.
+ */
+export interface UnsitedRow {
+  readonly itemId: string;
+  readonly name: string;
+  readonly required: Quantity;
+  readonly verified: boolean;
+}
+
 export interface BaseBuild {
   readonly base: string;
   readonly site: Site;
+  /**
+   * Whether this base has a site configuration.
+   *
+   * Governing: SPEC-0011 REQ "A Place Is Creatable by Hand"
+   *
+   * Read this before reading `site`. When false the site's values are zeros
+   * that mean nothing, and a surface MUST render the absence rather than
+   * the zeros — a class of "" shown as a class, or a fill duration of 0
+   * shown as a duration, is the configured-value-of-zero the requirement
+   * rules out.
+   */
+  readonly configured: boolean;
   readonly farms: readonly FarmRow[];
   readonly extractors: readonly ExtractorRow[];
   readonly ranches: readonly RanchRow[];
@@ -99,6 +128,8 @@ export interface BaseBuild {
   readonly nutrientProcessors: Quantity;
   readonly pelletFeeders: Quantity;
   readonly noBuild: readonly NoBuildRow[];
+  /** Demands awaiting a site configuration. Always empty when `configured`. */
+  readonly unsited: readonly UnsitedRow[];
   /** The base-level answer: every row here, and the constant that sized its processors. */
   readonly verified: boolean;
 }
@@ -247,6 +278,21 @@ function decodeNoBuild(value: unknown): NoBuildRow | null {
   return { itemId, name, from, required, verified };
 }
 
+function decodeUnsited(value: unknown): UnsitedRow | null {
+  const raw = object(value);
+  if (!raw) return null;
+
+  const itemId = text(raw["itemId"]);
+  const name = text(raw["name"]);
+  const required = quantity(raw["required"]);
+  const verified = flag(raw["verified"]);
+
+  if (itemId === null || name === null) return null;
+  if (required === null || verified === null) return null;
+
+  return { itemId, name, required, verified };
+}
+
 function decodeSite(value: unknown): Site | null {
   const raw = object(value);
   if (!raw) return null;
@@ -280,19 +326,29 @@ function decodeBase(value: unknown): BaseBuild | null {
   const ranches = list(raw["ranches"], decodeRanch);
   const kitchen = list(raw["kitchen"], decodeKitchen);
   const noBuild = list(raw["noBuild"], decodeNoBuild);
+  const unsited = list(raw["unsited"], decodeUnsited);
   const nutrientProcessors = quantity(raw["nutrientProcessors"]);
   const pelletFeeders = quantity(raw["pelletFeeders"]);
   const verified = flag(raw["verified"]);
+  /*
+   * Required rather than defaulted. A payload without the key is a module
+   * older than contract 1.3.0, and guessing `true` would present an
+   * unconfigured base's zeros as a configuration — which is the one thing
+   * SPEC-0011 asks this field to prevent. Failing the decode routes it to
+   * the version-mismatch path instead.
+   */
+  const configured = flag(raw["configured"]);
 
-  if (base === null || site === null) return null;
+  if (base === null || site === null || configured === null) return null;
   if (farms === null || extractors === null || ranches === null) return null;
-  if (kitchen === null || noBuild === null) return null;
+  if (kitchen === null || noBuild === null || unsited === null) return null;
   if (nutrientProcessors === null || pelletFeeders === null || verified === null)
     return null;
 
   return {
     base,
     site,
+    configured,
     farms,
     extractors,
     ranches,
@@ -300,6 +356,7 @@ function decodeBase(value: unknown): BaseBuild | null {
     nutrientProcessors,
     pelletFeeders,
     noBuild,
+    unsited,
     verified,
   };
 }

--- a/web/src/boundary/contract.ts
+++ b/web/src/boundary/contract.ts
@@ -17,7 +17,7 @@
  * with the `contractVersion` on every envelope; a mismatch is reported
  * naming both and no payload is read.
  */
-export const EXPECTED_CONTRACT_VERSION = "1.2.0";
+export const EXPECTED_CONTRACT_VERSION = "1.3.0";
 
 /*
  * The stable code set from internal/bridge/errors.go.

--- a/web/src/boundary/index.ts
+++ b/web/src/boundary/index.ts
@@ -34,6 +34,7 @@ export type {
   NoBuildRow,
   RanchRow,
   Site,
+  UnsitedRow,
   YieldRange,
 } from "./build";
 export type { Power, PowerBudget } from "./power";

--- a/web/src/canvas/NodeControl.tsx
+++ b/web/src/canvas/NodeControl.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 import type { Quantity } from "../boundary";
-import { BASES } from "./bases";
+import type { Base } from "./bases";
 import type { CanvasNode } from "./graph-model";
 import { methodOptions } from "./methods";
 
@@ -39,6 +39,13 @@ export interface NodeControlProps {
   readonly onAssign: (baseId: string | null) => void;
   /** The base this leaf is currently assigned to, if any. */
   readonly assignedTo: string | null;
+  /**
+   * The places this leaf may be assigned to — the workspace's, not a set
+   * this file invents.
+   *
+   * Governing: SPEC-0011 REQ "A Place Is Authored, and a Plan References It"
+   */
+  readonly bases: readonly Base[];
   /** Grouping only — `formatQuantity` never parses. */
   readonly format: (quantity: Quantity) => string;
 }
@@ -49,6 +56,7 @@ export function NodeControl({
   onSelectMethod,
   onAssign,
   assignedTo,
+  bases,
   format,
 }: NodeControlProps): ReactNode {
   const options = methodOptions(node.legalMethods, node.method, node.name);
@@ -160,12 +168,24 @@ export function NodeControl({
             }}
           >
             <option value="">Unassigned</option>
-            {BASES.map((base) => (
+            {bases.map((base) => (
               <option key={base.id} value={base.id}>
                 {base.label}
               </option>
             ))}
           </select>
+          {/*
+            A workspace with no places offers only "Unassigned", which is
+            correct and looks broken. SPEC-0011 REQ "A Place Is Authored, and
+            a Plan References It" requires a plan referencing no places to
+            resolve, so this is a designed state rather than a gap — and the
+            sentence is what keeps it from reading as one.
+          */}
+          {bases.length === 0 && (
+            <span className="label node-control-no-places">
+              No places yet. Create one under Saved places to gather leaves there.
+            </span>
+          )}
         </p>
       )}
 

--- a/web/src/canvas/TreeCanvas.tsx
+++ b/web/src/canvas/TreeCanvas.tsx
@@ -9,7 +9,7 @@ import { StatusBadge } from "../shell/StatusBadge";
 import { useViewState } from "../state/useViewState";
 import { toCanvasModel, toLayoutInput, type CanvasModel } from "./graph-model";
 import { layoutGraph, NODE_HEIGHT, NODE_WIDTH, type Placement } from "./layout";
-import { slotFor } from "./bases";
+import { slotFor, type Base } from "./bases";
 import { NodeCard } from "./NodeCard";
 import { NodeControl } from "./NodeControl";
 import { TreeEdge } from "./TreeEdge";
@@ -68,6 +68,7 @@ export function TreeCanvas({
   onSelectMethod,
   assignments,
   onAssign,
+  bases,
 }: {
   readonly graph: ResolvedGraph;
   /**
@@ -82,6 +83,15 @@ export function TreeCanvas({
   /** Item id to base id. The canvas renders it; it does not own it. */
   readonly assignments: Readonly<Record<string, string>>;
   readonly onAssign: (nodeId: string, name: string, baseId: string | null) => void;
+  /**
+   * The places a leaf may be assigned to.
+   *
+   * Passed in rather than imported: the assignable set is the workspace's
+   * places, and the canvas has no business reading the store.
+   *
+   * Governing: SPEC-0011 REQ "A Place Is Authored, and a Plan References It"
+   */
+  readonly bases: readonly Base[];
 }): ReactNode {
   const model = useMemo(() => toCanvasModel(graph), [graph]);
   const [layout, setLayout] = useState<LayoutState>(LAYING_OUT);
@@ -162,7 +172,7 @@ export function TreeCanvas({
            * the shell holds — the card does not know what a base is.
            */
           ...(() => {
-            const slot = slotFor(assignments, node.id);
+            const slot = slotFor(assignments, node.id, bases);
             return slot === undefined ? {} : { identity: slot };
           })(),
           /*
@@ -201,7 +211,7 @@ export function TreeCanvas({
                 }),
         },
       })),
-    [model, layoutOf, preferences.groupSeparator, onOpen, assignments],
+    [model, layoutOf, preferences.groupSeparator, onOpen, assignments, bases],
   );
 
   const flowEdges = useMemo<Edge[]>(
@@ -301,6 +311,7 @@ export function TreeCanvas({
               formatQuantity(quantity, { groupSeparator: preferences.groupSeparator })
             }
             assignedTo={assignments[openNode.id] ?? null}
+            bases={bases}
             onSelectMethod={(method) => {
               onSelectMethod(openNode.id, openNode.name, method);
             }}

--- a/web/src/canvas/bases.ts
+++ b/web/src/canvas/bases.ts
@@ -1,50 +1,89 @@
 /*
- * The bases a leaf can be assigned to.
+ * The places a leaf can be assigned to.
  *
- * Governing: ADR-0004 (React view layer), SPEC-0006 REQ "Leaf Assignment to
+ * Governing: ADR-0010 (places are authored first, and a plan assigns leaves
+ * to places that exist), ADR-0004 (React view layer), SPEC-0011 REQ "A Place
+ * Is Authored, and a Plan References It", SPEC-0006 REQ "Leaf Assignment to
  * Bases", REQ "Node Card"
  *
- * The six identity slots are the design's: `base.css` defines a colour
- * token for each, and SPEC-0006 REQ "Node Card" requires an assigned leaf
- * carry "a 3px border in that base's colour token". So the *set* is not
- * invented here.
+ * This file used to mint six identifiers — `base-1` through `base-6` — with
+ * placeholder labels, on the grounds that a base's real name came from a
+ * bases map that had no spec and no surface. That is no longer true, and the
+ * ids were the thing SPEC-0011 forbids:
  *
- * The names are placeholders and are the one thing here that is not
- * settled. A base's real name comes from the bases map, which has no spec
- * and no surface yet — the design handoff expects one ("base identity has
- * the name in the popover/base panel"). Until it exists a slot needs
- * something a player can say out loud, and "Base 3" is that without
- * pretending to be a name someone chose.
+ *   "The application MUST NOT mint a second identifier for a place, and MUST
+ *   NOT derive a place's identity from a plan's assignments."
  *
- * The identifier is what crosses the boundary. `RollupRequest.assignments`
- * maps an item id to a base id, and the domain takes the id as an opaque
- * string — so the slot number is carried through rather than translated,
- * and a real registry can replace the label without touching what the
- * domain receives.
+ * So the assignable set is the workspace's places. `Base.id` is the
+ * SPEC-0009 place record's own `id`, which ADR-0010 makes the same value the
+ * domain receives as `BaseID`. Nothing here generates an identifier.
+ *
+ * The identity slot is the one thing still assigned here, and it is not
+ * identity: it is which of the six colour tokens `base.css` defines this
+ * place draws with. A colour is a rendering choice with six values and a
+ * workspace may hold more than six places, so it is derived from position
+ * and repeats. Identity is the id; the slot is paint.
  */
 
 import type { IdentitySlot } from "../card/BasePlannerCard";
+import type { PlaceRecord } from "../store";
 
 export interface Base {
-  readonly slot: IdentitySlot;
-  /** What crosses the boundary. Opaque to the domain. */
+  /** The place record's own id. What crosses the boundary as BaseID. */
   readonly id: string;
-  /** Placeholder until the bases map exists. */
+  /** What the player called it, or the designed stand-in for a place they did not name. */
   readonly label: string;
+  /** Which colour token this place draws with. Presentation, not identity. */
+  readonly slot: IdentitySlot;
 }
 
-export const BASES: readonly Base[] = Object.freeze(
-  ([1, 2, 3, 4, 5, 6] as const).map((slot) =>
-    Object.freeze({ slot, id: `base-${String(slot)}`, label: `Base ${String(slot)}` }),
-  ),
-);
+/**
+ * What a place with no name is called on screen.
+ *
+ * A place is creatable with a name by rule (SPEC-0011 REQ "A Place Is
+ * Creatable by Hand" makes the name the minimum), so this covers a record
+ * written by an earlier path rather than a state the create route produces.
+ * A stand-in rather than the raw id: an id is not a thing a player can say
+ * out loud, and showing one reads as a fault.
+ */
+export const UNNAMED_PLACE = "Unnamed place";
 
-/** The slot a leaf is showing, or undefined when it is unassigned. */
+const SLOTS: readonly IdentitySlot[] = [1, 2, 3, 4, 5, 6];
+
+/**
+ * The assignable bases, in the store's order.
+ *
+ * Governing: SPEC-0011 REQ "A Place Is Authored, and a Plan References It"
+ *
+ * An empty workspace yields an empty list, and that is a designed state
+ * rather than a gap: a plan MUST remain resolvable when it references no
+ * places at all, so the assignment control offers only "Unassigned" until
+ * the player creates one.
+ */
+export function basesFrom(places: readonly PlaceRecord[]): readonly Base[] {
+  return places.map((place, index) => ({
+    id: place.id,
+    label: place.name ?? UNNAMED_PLACE,
+    // Wraps rather than running out. Six tokens, any number of places.
+    slot: SLOTS[index % SLOTS.length] ?? 1,
+  }));
+}
+
+/**
+ * The slot a leaf is showing, or undefined when it is unassigned.
+ *
+ * Also undefined when the assignment names a place that is not in `bases` —
+ * a place the player deleted, or one named by a hash authored on another
+ * device. SPEC-0011 REQ "An Assignment Naming an Absent Place Is Unassigned"
+ * makes that leaf unassigned, and an unassigned leaf carries no slot, so the
+ * lookup returning nothing is the rule rather than a miss.
+ */
 export function slotFor(
   assignments: Readonly<Record<string, string>>,
   itemId: string,
+  bases: readonly Base[],
 ): IdentitySlot | undefined {
   const id = assignments[itemId];
   if (id === undefined) return undefined;
-  return BASES.find((base) => base.id === id)?.slot;
+  return bases.find((base) => base.id === id)?.slot;
 }

--- a/web/src/canvas/useLeafAssignment.ts
+++ b/web/src/canvas/useLeafAssignment.ts
@@ -1,6 +1,7 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import type { Curated, Plan, RollupRequest } from "../boundary";
+import { resolveAssignments } from "../state/assignments";
 
 /*
  * Assignment in, recomputation out.
@@ -44,10 +45,32 @@ export interface LeafAssignmentOptions {
   readonly plan: Plan;
   /** Null until the application has a curated-constants source. */
   readonly constants: Curated | null;
+  /**
+   * The ids of the places that exist in the workspace.
+   *
+   * Governing: SPEC-0011 REQ "An Assignment Naming an Absent Place Is
+   * Unassigned"
+   *
+   * Held assignments are filtered against this on every read rather than
+   * pruned when a place is deleted. Filtering is what makes the rule hold
+   * for *every* source: an assignment decoded from someone else's hash
+   * names a place this device never had, and there is no deletion event to
+   * hang a prune on.
+   */
+  readonly placeIds: readonly string[];
 }
 
 export interface LeafAssignment {
+  /** Assignments naming places that exist. A leaf whose place is gone is absent here. */
   readonly assignments: Readonly<Record<string, string>>;
+  /**
+   * Leaves whose assignment named a place that is not in the workspace.
+   *
+   * They are unassigned and presented as such; the underlying map keeps
+   * them, so restoring the place restores the assignment rather than
+   * requiring the player to make it again.
+   */
+  readonly unresolved: readonly string[];
   /** Assign a leaf to a base, or pass null to clear it. */
   readonly assign: (itemId: string, baseId: string | null) => void;
   /** Settled stage-2 round trips this hook has dispatched. */
@@ -58,6 +81,7 @@ export function useLeafAssignment({
   client,
   plan,
   constants,
+  placeIds,
 }: LeafAssignmentOptions): LeafAssignment {
   const [assignments, setAssignments] = useState<Readonly<Record<string, string>>>({});
   const [dispatches, setDispatches] = useState(0);
@@ -102,7 +126,18 @@ export function useLeafAssignment({
       const issued = sequence.current + 1;
       sequence.current = issued;
 
-      const request: RollupRequest = { plan, assignments: next, constants };
+      /*
+       * The domain is sent the resolved map, not the stored one. An
+       * assignment naming a place the workspace does not have would
+       * otherwise group leaves at a base that exists nowhere, and the card
+       * would render it — which is the dangling identifier ADR-0010 rules
+       * out by name.
+       */
+      const request: RollupRequest = {
+        plan,
+        assignments: resolveAssignments(next, placeIds).assignments,
+        constants,
+      };
       void client.rollup(request).then(() => {
         /*
          * What this hook owns is that the recompute was asked for. A
@@ -113,8 +148,25 @@ export function useLeafAssignment({
         setDispatches((count) => count + 1);
       });
     },
-    [client, plan, constants],
+    [client, plan, constants, placeIds],
   );
 
-  return { assignments, assign, dispatches };
+  /*
+   * Resolved on read, not on write. What is stored is what the player said;
+   * what is rendered is what the workspace can honour. Keeping the two apart
+   * is what lets a deleted-and-recreated place bring its leaves back instead
+   * of making the player reassign them — and it is why deleting a place
+   * cannot destroy a plan, which is the whole of ADR-0010's rule.
+   */
+  const resolved = useMemo(
+    () => resolveAssignments(assignments, placeIds),
+    [assignments, placeIds],
+  );
+
+  return {
+    assignments: resolved.assignments,
+    unresolved: resolved.unresolved,
+    assign,
+    dispatches,
+  };
 }

--- a/web/src/card/BasePlannerCard.tsx
+++ b/web/src/card/BasePlannerCard.tsx
@@ -10,6 +10,7 @@ import {
   type PowerBudget,
   type Quantity,
   type RanchRow,
+  type UnsitedRow,
 } from "../boundary";
 import { StatusBadge } from "../shell/StatusBadge";
 
@@ -155,6 +156,34 @@ function KitchenRowView({ row }: { row: KitchenStep }): ReactNode {
   );
 }
 
+/*
+ * A demand at a base with no site configuration.
+ *
+ * Governing: SPEC-0011 REQ "A Place Is Creatable by Hand", SPEC-0007 REQ
+ * "Absent Data Is Absent"
+ *
+ *   "the card MUST render that absence as absence ... rather than as a
+ *   configured value of zero."
+ *
+ * So the row shows the demand, which is known, and says the configuration
+ * is missing — it does not show `0` extractors, and it does not show a
+ * class of "". The same rule NoBuildRowView follows: a word, not a style,
+ * because a row distinguished only by being greyed out is not distinguished
+ * for anyone who does not see the grey.
+ */
+function UnsitedRowView({ row }: { row: UnsitedRow }): ReactNode {
+  return (
+    <li className="card-row" data-row="unsited" data-item={row.itemId}>
+      <span className="card-row-name">{row.name}</span>
+      <span className="card-row-figures">
+        <Figure label="Demand" value={q(row.required)} />
+        <span className="card-nothing-to-build">Site not configured</span>
+        <RowProvenance verified={row.verified} />
+      </span>
+    </li>
+  );
+}
+
 function NoBuildRowView({ row }: { row: NoBuildRow }): ReactNode {
   return (
     <li className="card-row" data-row="no-build" data-item={row.itemId}>
@@ -268,6 +297,24 @@ export function BasePlannerCard({
 
       {budget !== undefined ? (
         <PowerBlock budget={budget} emClass={configuration?.power.emClass} />
+      ) : null}
+
+      {/*
+        Extraction is the only producer that needs the site, so this section
+        is where an unconfigured place's gap becomes visible — beside the
+        farms and ranches that sized normally, rather than instead of them.
+        A place created with a name and nothing else is assignable by rule,
+        and this is what that place's card looks like.
+      */}
+      {base.unsited.length > 0 ? (
+        <section className="card-section" data-section="unsited">
+          <h4 className="card-section-head">Awaiting site configuration</h4>
+          <ul className="card-rows">
+            {base.unsited.map((row) => (
+              <UnsitedRowView key={row.itemId} row={row} />
+            ))}
+          </ul>
+        </section>
       ) : null}
 
       {base.noBuild.length > 0 ? (

--- a/web/src/card/CardControls.tsx
+++ b/web/src/card/CardControls.tsx
@@ -68,6 +68,26 @@ function ClassSelect({
           onPick(event.target.value);
         }}
       >
+        {/*
+          An unconfigured site shows that it is unconfigured.
+
+          Governing: SPEC-0011 REQ "A Place Is Creatable by Hand", SPEC-0007
+          REQ "Absent Data Is Absent"
+
+          Without this option a select whose value matches nothing falls back
+          to its first option, so a place created with a name and nothing
+          else would read as configured at class C — a value the player never
+          chose, which is exactly what the requirement rules out.
+
+          Offered only while the value is empty. Once a class is picked,
+          "un-configure" is not an operation the payload models, and an
+          option that cannot be honoured is worse than one that is absent.
+        */}
+        {value === "" && (
+          <option value="" disabled>
+            Not configured
+          </option>
+        )}
         {HOTSPOT_CLASSES.map((cls) => (
           <option key={cls} value={cls}>
             {cls}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -24,7 +24,7 @@ import { ViewStateProvider } from "../state/ViewStateProvider";
 import { useViewDispatch, useViewState } from "../state/useViewState";
 import { usePlanResolution, type Resolution } from "../state/usePlanResolution";
 import { useStoredData } from "../state/useStoredData";
-import { BASES } from "../canvas/bases";
+import { basesFrom } from "../canvas/bases";
 import { useLeafAssignment } from "../canvas/useLeafAssignment";
 import { DurableStore } from "../store";
 import { StatusBadge } from "./StatusBadge";
@@ -319,14 +319,28 @@ function Chrome({
   }, [state.inputs.target, state.inputs.quantity, methods]);
 
   /*
+   * The assignable places, and the ids the assignment rule is resolved
+   * against. Both derived from the store rather than from a list this file
+   * holds: SPEC-0011 REQ "A Place Is Authored, and a Plan References It"
+   * makes a place something the player authored, so there is no set of
+   * bases until there are records.
+   */
+  const bases = useMemo(() => basesFrom(stored.places), [stored.places]);
+  const placeIds = useMemo(() => bases.map((base) => base.id), [bases]);
+
+  /*
    * `constants: null` is not a stub. `RollupRequest` requires curated
    * constants and the application has no source for them — they exist only
    * in test fixtures, and the base planner card that would own them is not
    * mounted either. So assignments are held and rendered here, and the
    * stage-2 dispatch this hook performs is exercised where constants exist.
-   * Stated rather than hidden: see the PR for #88.
    */
-  const { assignments, assign } = useLeafAssignment({ client, plan, constants: null });
+  const { assignments, assign } = useLeafAssignment({
+    client,
+    plan,
+    constants: null,
+    placeIds,
+  });
 
   useAnnounceOnChange(resultToken, () => {
     const change = pendingChange.current;
@@ -346,14 +360,14 @@ function Chrome({
        * be false while no recompute is dispatched. What is true is the
        * assignment, so that is what is said.
        */
-      const label = BASES.find((base) => base.id === baseId)?.label;
+      const label = bases.find((base) => base.id === baseId)?.label;
       announce(
         label === undefined
           ? `${name} is no longer assigned to a base.`
           : `${name} assigned to ${label}.`,
       );
     },
-    [assign, announce],
+    [assign, announce, bases],
   );
 
   const onSelectMethod = useCallback(
@@ -425,6 +439,7 @@ function Chrome({
                 onSelectMethod={onSelectMethod}
                 assignments={assignments}
                 onAssign={onAssign}
+                bases={bases}
               />
             </Suspense>
           </section>

--- a/web/src/shell/StoredPlaces.tsx
+++ b/web/src/shell/StoredPlaces.tsx
@@ -1,6 +1,8 @@
-import type { ReactNode } from "react";
+import { useId, useState, type ReactNode } from "react";
 
 import { StatusBadge } from "./StatusBadge";
+import { UNNAMED_PLACE } from "../canvas/bases";
+import { useLiveRegion } from "../a11y/useLiveRegion";
 import { ABSENT_DISPLAY, ABSENT_LABEL, storedQuantity } from "../store/absence";
 import type { StoredData } from "../state/useStoredData";
 
@@ -25,7 +27,80 @@ import type { StoredData } from "../state/useStoredData";
  * The quantity column is the other half. A place with nothing stocked for
  * the target shows an em dash, never `0` — see src/store/absence.ts for why
  * `?? 0` is the defect this contract exists to prevent.
+ *
+ * It is also the route by which a place comes to exist.
+ *
+ * Governing: ADR-0010 (places are authored first), SPEC-0011 REQ "A Place Is
+ * Creatable by Hand" — "The bases surface MUST provide a route to create a
+ * place without a save file, independent of SPEC-0008."
+ *
+ * A name and nothing else, because the requirement makes that the whole
+ * minimum: "Every other field ... MUST be optional at creation." Asking for
+ * a kind or a site configuration first would make the first-run path longer
+ * than the thing it unblocks, and a place with no site configuration is
+ * assignable by rule — the card renders that gap as a gap.
  */
+/**
+ * The create-a-place form.
+ *
+ * Governing: SPEC-0011 REQ "A Place Is Creatable by Hand"
+ *
+ * A real `<form>` so Enter submits: the requirement is that a place be
+ * creatable, and a control that needs a mouse to reach its button would put
+ * the route behind a pointing device.
+ */
+function CreatePlace({ create }: { readonly create: (name: string) => Promise<void> }) {
+  const fieldId = useId();
+  const [name, setName] = useState("");
+  const { announce } = useLiveRegion();
+
+  return (
+    <form
+      className="place-create"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const trimmed = name.trim();
+        if (trimmed === "") return;
+        /*
+         * Cleared before the write settles. The player has moved on to
+         * typing the next one, and a field that empties late eats the first
+         * characters of it.
+         */
+        setName("");
+        void create(trimmed).then(() => {
+          announce(`${trimmed} created.`);
+        });
+      }}
+    >
+      <label className="label" htmlFor={fieldId}>
+        New place
+      </label>{" "}
+      <input
+        id={fieldId}
+        className="control control-sm interactive"
+        value={name}
+        onChange={(event) => {
+          setName(event.target.value);
+        }}
+        placeholder="Name"
+      />{" "}
+      <button
+        type="submit"
+        className="control control-sm interactive"
+        /*
+         * Disabled on an empty name rather than accepting one and
+         * generating a placeholder. The name is the minimum the requirement
+         * sets, and a place called "Unnamed place" is not a place the player
+         * can pick out of a list.
+         */
+        disabled={name.trim() === ""}
+      >
+        Create place
+      </button>
+    </form>
+  );
+}
+
 export function StoredPlaces({
   data,
   target,
@@ -48,36 +123,65 @@ export function StoredPlaces({
 
   if (data.empty) {
     return (
-      <p className="label">
-        Nothing saved on this device yet. Places you save will be listed here.
-      </p>
+      <>
+        <p className="label">
+          Nothing saved on this device yet. Places you create will be listed here.
+        </p>
+        <CreatePlace create={data.createPlace} />
+      </>
     );
   }
 
   return (
-    <ul className="figure-list">
-      {data.places.map((place) => {
-        const stocked = target === "" ? null : storedQuantity(place, target);
-        return (
-          <li key={place.id}>
-            <span>{place.name ?? "Unnamed place"}</span>{" "}
-            {stocked !== null &&
-              (stocked.present ? (
-                <span className="numeral">{stocked.value}</span>
-              ) : (
-                /*
-                 * The dash is for sighted readers; the label is what a
-                 * screen reader says. "—" announces as nothing in most of
-                 * them, and a row that reads as a name followed by silence
-                 * is indistinguishable from a broken one.
-                 */
-                <span className="numeral" aria-label={ABSENT_LABEL}>
-                  {ABSENT_DISPLAY}
-                </span>
-              ))}
-          </li>
-        );
-      })}
-    </ul>
+    <>
+      <CreatePlace create={data.createPlace} />
+      <ul className="figure-list">
+        {data.places.map((place) => {
+          const stocked = target === "" ? null : storedQuantity(place, target);
+          return (
+            <li key={place.id} data-place={place.id}>
+              <span>{place.name ?? UNNAMED_PLACE}</span>{" "}
+              {stocked !== null &&
+                (stocked.present ? (
+                  <span className="numeral">{stocked.value}</span>
+                ) : (
+                  /*
+                   * The dash is for sighted readers; the label is what a
+                   * screen reader says. "—" announces as nothing in most of
+                   * them, and a row that reads as a name followed by silence
+                   * is indistinguishable from a broken one.
+                   */
+                  <span className="numeral" aria-label={ABSENT_LABEL}>
+                    {ABSENT_DISPLAY}
+                  </span>
+                ))}{" "}
+              {/*
+              Deleting a place does not touch any plan.
+
+              Governing: ADR-0010 (a deleted place unassigns; it does not
+              cascade and does not dangle), SPEC-0011 REQ "An Assignment
+              Naming an Absent Place Is Unassigned"
+
+              Leaves assigned here return to the unassigned group rather
+              than being removed with the place — the plan is the expensive
+              artifact, not the record. The label names the place because a
+              row of identical "Delete" buttons is unusable by anyone
+              navigating by control rather than by row.
+            */}
+              <button
+                type="button"
+                className="control control-sm interactive"
+                aria-label={`Delete ${place.name ?? UNNAMED_PLACE}`}
+                onClick={() => {
+                  void data.removePlace(place.id);
+                }}
+              >
+                Delete
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </>
   );
 }

--- a/web/src/shell/StoredPlaces.tsx
+++ b/web/src/shell/StoredPlaces.tsx
@@ -121,41 +121,57 @@ export function StoredPlaces({
     );
   }
 
-  if (data.empty) {
-    return (
-      <>
-        <p className="label">
-          Nothing saved on this device yet. Places you create will be listed here.
-        </p>
-        <CreatePlace create={data.createPlace} />
-      </>
-    );
-  }
-
+  /*
+   * One render site for the form, and it has to stay that way.
+   *
+   * The empty and populated states differ in what follows the form, not in
+   * whether there is one. Rendering `<CreatePlace>` inside each branch put
+   * it at a different child position in each — second in the empty state,
+   * first in the populated one — and React reconciles a fragment's children
+   * by position. Creating the first place flips `data.empty`, the form
+   * moves from index 1 to index 0, and React unmounts and remounts it.
+   *
+   * That discards its `useState` name. A player who types their first
+   * place, submits, and starts typing the second loses the second the
+   * moment the write settles — on the first-run path, every time. The
+   * submit handler clears the field early precisely so late clearing cannot
+   * eat the next keystrokes; a remount eats them anyway, and eats all of
+   * them.
+   *
+   * A shared `key` would also hold the instance across the two branches.
+   * One position is better: it cannot be half-applied, and there is no
+   * second site to keep in step.
+   */
   return (
     <>
       <CreatePlace create={data.createPlace} />
-      <ul className="figure-list">
-        {data.places.map((place) => {
-          const stocked = target === "" ? null : storedQuantity(place, target);
-          return (
-            <li key={place.id} data-place={place.id}>
-              <span>{place.name ?? UNNAMED_PLACE}</span>{" "}
-              {stocked !== null &&
-                (stocked.present ? (
-                  <span className="numeral">{stocked.value}</span>
-                ) : (
-                  /*
-                   * The dash is for sighted readers; the label is what a
-                   * screen reader says. "—" announces as nothing in most of
-                   * them, and a row that reads as a name followed by silence
-                   * is indistinguishable from a broken one.
-                   */
-                  <span className="numeral" aria-label={ABSENT_LABEL}>
-                    {ABSENT_DISPLAY}
-                  </span>
-                ))}{" "}
-              {/*
+
+      {data.empty ? (
+        <p className="label">
+          Nothing saved on this device yet. Places you create will be listed here.
+        </p>
+      ) : (
+        <ul className="figure-list">
+          {data.places.map((place) => {
+            const stocked = target === "" ? null : storedQuantity(place, target);
+            return (
+              <li key={place.id} data-place={place.id}>
+                <span>{place.name ?? UNNAMED_PLACE}</span>{" "}
+                {stocked !== null &&
+                  (stocked.present ? (
+                    <span className="numeral">{stocked.value}</span>
+                  ) : (
+                    /*
+                     * The dash is for sighted readers; the label is what a
+                     * screen reader says. "—" announces as nothing in most of
+                     * them, and a row that reads as a name followed by silence
+                     * is indistinguishable from a broken one.
+                     */
+                    <span className="numeral" aria-label={ABSENT_LABEL}>
+                      {ABSENT_DISPLAY}
+                    </span>
+                  ))}{" "}
+                {/*
               Deleting a place does not touch any plan.
 
               Governing: ADR-0010 (a deleted place unassigns; it does not
@@ -168,20 +184,21 @@ export function StoredPlaces({
               row of identical "Delete" buttons is unusable by anyone
               navigating by control rather than by row.
             */}
-              <button
-                type="button"
-                className="control control-sm interactive"
-                aria-label={`Delete ${place.name ?? UNNAMED_PLACE}`}
-                onClick={() => {
-                  void data.removePlace(place.id);
-                }}
-              >
-                Delete
-              </button>
-            </li>
-          );
-        })}
-      </ul>
+                <button
+                  type="button"
+                  className="control control-sm interactive"
+                  aria-label={`Delete ${place.name ?? UNNAMED_PLACE}`}
+                  onClick={() => {
+                    void data.removePlace(place.id);
+                  }}
+                >
+                  Delete
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </>
   );
 }

--- a/web/src/state/assignments.ts
+++ b/web/src/state/assignments.ts
@@ -1,0 +1,67 @@
+/*
+ * An assignment naming a place that is not there.
+ *
+ * Governing: ADR-0010 (a deleted place unassigns; it does not cascade and
+ * does not dangle), SPEC-0011 REQ "An Assignment Naming an Absent Place Is
+ * Unassigned"
+ *
+ *   "Where a plan carries an assignment whose `BaseID` matches no place in
+ *   the workspace, the leaf MUST be treated as unassigned and MUST be
+ *   presented as such ... This rule MUST hold for every source of an
+ *   assignment, including one decoded from a URL hash authored on another
+ *   player's device."
+ *
+ * One function rather than a check at each source, because "every source" is
+ * the requirement and a rule applied per caller is a rule a later caller
+ * forgets. The two sources today are a place the player deleted and a hash
+ * from another device; they are the same shape and get the same answer.
+ *
+ * It lives in state/ rather than canvas/ because it is a rule about plan
+ * state and the workspace, not about drawing: the canvas source is scanned
+ * for comparators (SPEC-0006 REQ "Graph Rendering From the Boundary
+ * Payload" — the canvas must not order nodes itself), and the sort below is
+ * over item ids for an announcement rather than over anything rendered. A
+ * blunt scan is the right kind of scan, so the file moved instead.
+ *
+ * What this deliberately does NOT do is delete anything. The plan keeps its
+ * shape and the store keeps its records; the leaf is *presented* unassigned,
+ * which is what makes deleting a place survivable rather than destructive.
+ */
+
+/** Assignments filtered to the places that exist, and the leaves that lost one. */
+export interface ResolvedAssignments {
+  readonly assignments: Readonly<Record<string, string>>;
+  /**
+   * Item ids whose assignment named an absent place.
+   *
+   * Reported rather than merely dropped: the leaf is unassigned now and the
+   * player is entitled to know it moved, which is the difference between
+   * this rule and silently losing the assignment.
+   */
+  readonly unresolved: readonly string[];
+}
+
+export function resolveAssignments(
+  assignments: Readonly<Record<string, string>>,
+  known: Iterable<string>,
+): ResolvedAssignments {
+  const exists = new Set(known);
+  const kept: Record<string, string> = {};
+  const unresolved: string[] = [];
+
+  for (const [itemId, baseId] of Object.entries(assignments)) {
+    if (exists.has(baseId)) {
+      kept[itemId] = baseId;
+    } else {
+      unresolved.push(itemId);
+    }
+  }
+
+  /*
+   * Sorted so the same workspace and the same plan describe the same set in
+   * the same order however the map was built — an announcement whose wording
+   * depends on insertion order is a different message for the same state.
+   */
+  unresolved.sort();
+  return { assignments: kept, unresolved };
+}

--- a/web/src/state/useStoredData.ts
+++ b/web/src/state/useStoredData.ts
@@ -64,9 +64,42 @@ export interface StoredData {
    * confirmation is the caller's — this is the operation, not the prompt.
    */
   readonly deleteEverything: () => Promise<void>;
+  /**
+   * Create a place from a name and nothing else.
+   *
+   * Governing: ADR-0010 (places are authored first), SPEC-0011 REQ "A Place
+   * Is Creatable by Hand" — "The minimum a place requires before a plan may
+   * assign to it is its generated `id` and a name. Every other field ... MUST
+   * be optional at creation."
+   *
+   * The id is generated here and is the only identifier the place ever has:
+   * ADR-0010 makes it the value the domain receives as `BaseID`, so minting
+   * a second one for the plan to use is the thing SPEC-0011 forbids.
+   *
+   * `kind` defaults to "base" rather than being asked for. A freighter and a
+   * settlement are places too (SPEC-0009 REQ "A Place Is One Record Type"),
+   * but making the player answer that before they can have one is exactly the
+   * longer first-run path the requirement rules out.
+   */
+  readonly createPlace: (name: string) => Promise<void>;
+  /**
+   * Remove one place.
+   *
+   * Governing: ADR-0010 (a deleted place unassigns; it does not cascade),
+   * SPEC-0011 REQ "An Assignment Naming an Absent Place Is Unassigned"
+   *
+   * No plan is touched. Leaves that named this place become unassigned by
+   * rule when the plan is next read against the workspace — see
+   * canvas/assignments.ts.
+   */
+  readonly removePlace: (id: string) => Promise<void>;
 }
 
 const NOOP = async (): Promise<void> => {
+  /* replaced by the real operation once the hook has run */
+};
+
+const NOOP_WITH_ARG = async (): Promise<void> => {
   /* replaced by the real operation once the hook has run */
 };
 
@@ -76,6 +109,8 @@ const LOADING: StoredData = Object.freeze({
   empty: false,
   saving: false,
   deleteEverything: NOOP,
+  createPlace: NOOP_WITH_ARG,
+  removePlace: NOOP_WITH_ARG,
 });
 
 export function useStoredData(store: DurableStore): StoredData {
@@ -113,6 +148,8 @@ export function useStoredData(store: DurableStore): StoredData {
           empty: false,
           saving: false,
           deleteEverything: NOOP,
+          createPlace: NOOP_WITH_ARG,
+          removePlace: NOOP_WITH_ARG,
         });
         return;
       }
@@ -126,6 +163,8 @@ export function useStoredData(store: DurableStore): StoredData {
           empty: false,
           saving: false,
           deleteEverything: NOOP,
+          createPlace: NOOP_WITH_ARG,
+          removePlace: NOOP_WITH_ARG,
         });
         return;
       }
@@ -156,6 +195,8 @@ export function useStoredData(store: DurableStore): StoredData {
         empty: loaded.value.places.length === 0,
         saving: false,
         deleteEverything: NOOP,
+        createPlace: NOOP_WITH_ARG,
+        removePlace: NOOP_WITH_ARG,
       });
     };
 
@@ -185,6 +226,61 @@ export function useStoredData(store: DurableStore): StoredData {
       if (outstanding.current === 0) setSaving(false);
     });
   }, [store, preferences]);
+
+  /*
+   * A place's id, generated once and never derived from anything.
+   *
+   * Governing: ADR-0010, SPEC-0011 REQ "A Place Is Authored, and a Plan
+   * References It" — "The application MUST NOT mint a second identifier for
+   * a place, and MUST NOT derive a place's identity from a plan's
+   * assignments."
+   *
+   * `crypto.randomUUID` rather than a counter or a slug of the name,
+   * because both of those are derivations: a counter collides across
+   * devices the moment sync lands, and a name-derived id changes when the
+   * player renames a place, which would silently reassign every leaf that
+   * pointed at it.
+   */
+  const createPlace = useCallback(
+    async (name: string): Promise<void> => {
+      const trimmed = name.trim();
+      if (trimmed === "") return;
+
+      const written = await store.putPlace({
+        id: crypto.randomUUID(),
+        kind: "base",
+        name: trimmed,
+      });
+      if (written.kind !== "ok") {
+        setData((previous) => ({ ...previous, status: "unavailable" }));
+        return;
+      }
+
+      setData((previous) => ({
+        ...previous,
+        status: "ready",
+        places: [...previous.places, written.value],
+        empty: false,
+      }));
+    },
+    [store],
+  );
+
+  const removePlace = useCallback(
+    async (id: string): Promise<void> => {
+      const removed = await store.deletePlace(id);
+      if (removed.kind !== "ok") {
+        setData((previous) => ({ ...previous, status: "unavailable" }));
+        return;
+      }
+
+      setData((previous) => {
+        const places = previous.places.filter((place) => place.id !== id);
+        return { ...previous, places, empty: places.length === 0 };
+      });
+    },
+    [store],
+  );
 
   const deleteEverything = useCallback(async (): Promise<void> => {
     const removed = await store.deleteAll();
@@ -229,5 +325,5 @@ export function useStoredData(store: DurableStore): StoredData {
     }));
   }, [store, dispatch]);
 
-  return { ...data, saving, deleteEverything };
+  return { ...data, saving, deleteEverything, createPlace, removePlace };
 }

--- a/web/src/store/durable-store.ts
+++ b/web/src/store/durable-store.ts
@@ -309,6 +309,48 @@ export class DurableStore {
     }
   }
 
+  /**
+   * Remove one place.
+   *
+   * Governing: SPEC-0011 REQ "An Assignment Naming an Absent Place Is
+   * Unassigned", ADR-0010 (a deleted place unassigns; it does not cascade)
+   *
+   * The store removes the record and nothing else. It does not reach into
+   * any plan, because a plan is not the store's to edit — the leaves that
+   * named this place become unassigned by rule when the plan is next read
+   * against the workspace, which is what keeps deleting a place from
+   * destroying the plan that referenced it.
+   *
+   * Deleting a place that is not there succeeds. The caller asked for a
+   * state, and that state already holds; reporting an error would make a
+   * double click a failure.
+   */
+  async deletePlace(id: string): Promise<StoreResult<void>> {
+    const db = this.#db;
+    if (!db) return failure("STORAGE_UNAVAILABLE", "the store is not open");
+
+    try {
+      const now = this.#now();
+      const transaction = db.transaction([WORKSPACE_STORE, PLACES_STORE], "readwrite");
+      await request(transaction.objectStore(PLACES_STORE).delete(id));
+
+      const workspaces = transaction.objectStore(WORKSPACE_STORE);
+      const storedWorkspace = (await request<unknown>(workspaces.get(WORKSPACE_KEY))) as
+        WorkspaceRecord | undefined;
+      await request(
+        workspaces.put(
+          { ...(storedWorkspace ?? emptyWorkspace(now)), updatedAt: now },
+          WORKSPACE_KEY,
+        ),
+      );
+
+      await settled(transaction);
+      return ok(undefined);
+    } catch (error) {
+      return classify(error, `deleting place ${id}`);
+    }
+  }
+
   /** Persist the view's own preferences. Interface state, not domain state. */
   async putPreferences(
     preferences: Readonly<Record<string, string | boolean>>,

--- a/web/src/styles/canvas.css
+++ b/web/src/styles/canvas.css
@@ -369,3 +369,16 @@
   background-color: var(--input-bg);
   color: var(--text);
 }
+
+/*
+ * A workspace with no places yet.
+ *
+ * Governing: SPEC-0011 REQ "A Place Is Authored, and a Plan References It"
+ *
+ * A designed state rather than a gap: a plan referencing no places resolves,
+ * so the control offers only "Unassigned" and this says why.
+ */
+.node-control-no-places {
+  flex-basis: 100%;
+  color: var(--text-muted);
+}

--- a/web/src/styles/shell.css
+++ b/web/src/styles/shell.css
@@ -47,6 +47,24 @@
   gap: var(--space-2);
 }
 
+/*
+ * The create-a-place route.
+ *
+ * Governing: ADR-0010 (places are authored first), SPEC-0011 REQ "A Place Is
+ * Creatable by Hand"
+ *
+ * A row, wrapping, because the label and the field belong together and the
+ * button belongs beside them — and because the panel it sits in is narrow at
+ * the sizes the shell is built for.
+ */
+.place-create {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin-block-end: var(--space-2);
+}
+
 .figure-list {
   display: flex;
   flex-direction: column;

--- a/web/tests/boundary/integration.spec.ts
+++ b/web/tests/boundary/integration.spec.ts
@@ -130,7 +130,7 @@ test("the real module's contract version is the one this view was built for", as
     return (globalThis as unknown as { nmsPlanner: { contractVersion: string } })
       .nmsPlanner.contractVersion;
   });
-  expect(version).toBe("1.2.0");
+  expect(version).toBe("1.3.0");
 });
 
 test("changing an input produces a fresh crossing rather than a derived figure", async ({

--- a/web/tests/boundary/lifecycle.spec.ts
+++ b/web/tests/boundary/lifecycle.spec.ts
@@ -78,7 +78,7 @@ test("a module reporting another contract version is refused, naming both", asyn
 
   expect(outcome.kind).toBe("version-mismatch");
   expect(outcome.received).toBe("9.9.9");
-  expect(outcome.expected).toBe("1.2.0");
+  expect(outcome.expected).toBe("1.3.0");
 });
 
 test("a contract mismatch does not even fetch the artifact", async ({ page }) => {

--- a/web/tests/boundary/stages.spec.ts
+++ b/web/tests/boundary/stages.spec.ts
@@ -55,6 +55,15 @@ const FARM = {
 const BASE = {
   base: "A",
   site: { extractorClass: "C", fillSeconds: "5400" },
+  /*
+   * Required, not optional. Contract 1.3.0 added it, and the decoder refuses
+   * a payload without it rather than assuming: assuming `true` would present
+   * an unconfigured base's zeros as a configuration, and assuming `false`
+   * would report every configured base as unconfigured. The version check is
+   * what keeps an older module from reaching the decoder at all; this is the
+   * second line.
+   */
+  configured: true,
   farms: [FARM],
   nutrientProcessors: "1",
   pelletFeeders: "0",
@@ -149,6 +158,20 @@ test.describe("the build payload", () => {
      */
     const withoutVerified = without(BASE, "verified");
     expect(selectBuild({ build: { bases: [withoutVerified] } })).toBeNull();
+
+    /*
+     * `configured` for the same reason, and a sharper one.
+     *
+     * Governing: SPEC-0011 REQ "A Place Is Creatable by Hand"
+     *
+     * Its false case is the whole point: it is what tells the card to render
+     * a gap rather than the site's zeros. A decoder that defaulted it to
+     * true would present class "" for zero seconds as a configuration, which
+     * is the configured-value-of-zero the requirement rules out; one that
+     * defaulted it to false would report every configured base as
+     * unconfigured. Neither guess is available, so the payload has to say.
+     */
+    expect(selectBuild({ build: { bases: [without(BASE, "configured")] } })).toBeNull();
   });
 
   test("anything that is not a build payload is rejected", () => {

--- a/web/tests/canvas/assignment.spec.ts
+++ b/web/tests/canvas/assignment.spec.ts
@@ -3,7 +3,8 @@ import path from "node:path";
 
 import { expect, test, type Page } from "@playwright/test";
 
-import { BASES, slotFor } from "../../src/canvas/bases";
+import { basesFrom, slotFor, UNNAMED_PLACE } from "../../src/canvas/bases";
+import type { PlaceRecord } from "../../src/store";
 import { countCrossings, crossings } from "../helpers/crossings";
 
 /*
@@ -61,10 +62,23 @@ async function aLeafName(page: Page): Promise<string> {
  * The slot mapping
  * ------------------------------------------------------------------- */
 
+/** A stored place, with only the fields the mapping reads. */
+function place(id: string, name?: string): PlaceRecord {
+  return {
+    id,
+    kind: "base",
+    schemaVersion: 1,
+    ...(name === undefined ? {} : { name }),
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    revision: 1,
+  };
+}
+
 test("a base id maps to the slot whose colour the card draws", () => {
-  const second = BASES[1];
+  const bases = basesFrom([place("p-1", "Alpha"), place("p-2", "Beta")]);
+  const second = bases[1];
   expect(second).toBeDefined();
-  expect(slotFor({ COBALT: second?.id ?? "" }, "COBALT")).toBe(second?.slot);
+  expect(slotFor({ COBALT: second?.id ?? "" }, "COBALT", bases)).toBe(second?.slot);
 });
 
 test("an unassigned leaf has no slot, and neither does an unknown base", () => {
@@ -72,15 +86,52 @@ test("an unassigned leaf has no slot, and neither does an unknown base", () => {
    * The second half matters: a base id from a link or an older session that
    * no longer maps to a slot must read as unassigned rather than as slot
    * undefined-coloured, which is how a leaf ends up with no border at all.
+   * SPEC-0011 REQ "An Assignment Naming an Absent Place Is Unassigned" is
+   * the rule; this is the rendering half of it.
    */
-  expect(slotFor({}, "COBALT")).toBeUndefined();
-  expect(slotFor({ COBALT: "base-99" }, "COBALT")).toBeUndefined();
+  const bases = basesFrom([place("p-1", "Alpha")]);
+  expect(slotFor({}, "COBALT", bases)).toBeUndefined();
+  expect(
+    slotFor({ COBALT: "a-place-that-was-deleted" }, "COBALT", bases),
+  ).toBeUndefined();
 });
 
-test("every base has a distinct id and a distinct slot", () => {
-  expect(new Set(BASES.map((base) => base.id)).size).toBe(BASES.length);
-  expect(new Set(BASES.map((base) => base.slot)).size).toBe(BASES.length);
-  expect(BASES.length).toBe(6);
+/*
+ * SPEC-0011 REQ "A Place Is Authored, and a Plan References It":
+ * WHEN a place is created and later assigned a leaf THEN the value the plan
+ * carries as `BaseID` is the place record's own `id`, and no other
+ * identifier for that place exists in the store.
+ */
+test("a base carries the place record's own id, not one minted for it", () => {
+  const record = place("018f-a-generated-uuid", "Alpha");
+  const bases = basesFrom([record]);
+
+  expect(bases[0]?.id).toBe(record.id);
+  // The slot is paint, not identity: it is an index into six colour tokens.
+  expect(bases[0]?.slot).toBe(1);
+});
+
+test("an unnamed place is named on screen, never shown as its id", () => {
+  const bases = basesFrom([place("018f-a-generated-uuid")]);
+  expect(bases[0]?.label).toBe(UNNAMED_PLACE);
+  expect(bases[0]?.label).not.toContain("018f");
+});
+
+/*
+ * A workspace may hold more places than there are colours, and that is not
+ * an error: the colour repeats and the id stays unique.
+ */
+test("colour slots repeat past six places; ids do not", () => {
+  const bases = basesFrom(
+    Array.from({ length: 8 }, (_, index) => place(`p-${String(index)}`)),
+  );
+
+  expect(new Set(bases.map((base) => base.id)).size).toBe(8);
+  expect(bases[6]?.slot).toBe(bases[0]?.slot);
+});
+
+test("an empty workspace offers no bases at all", () => {
+  expect(basesFrom([])).toHaveLength(0);
 });
 
 /* ----------------------------------------------------------------------
@@ -138,7 +189,7 @@ test.describe("with curated constants", () => {
       .toBeGreaterThan(0);
 
     const request = await page.evaluate(() => window.__assignment.requests().at(-1));
-    expect(request?.assignments).toEqual({ COBALT: "base-2" });
+    expect(request?.assignments).toEqual({ COBALT: "place-2" });
     /* The plan travels with it, unchanged. */
     expect(request?.plan.target).toBe("ANTIMATTER");
   });
@@ -159,9 +210,72 @@ test.describe("with curated constants", () => {
       .toBe(2);
 
     const request = await page.evaluate(() => window.__assignment.requests().at(-1));
-    expect(request?.assignments).toEqual({ COBALT: "base-5" });
+    expect(request?.assignments).toEqual({ COBALT: "place-5" });
   });
 
+  /*
+   * SPEC-0011 REQ "An Assignment Naming an Absent Place Is Unassigned":
+   * WHEN three leaves are assigned to a place and that place is deleted
+   * THEN the plan survives, the leaves appear in the unassigned group, and
+   * no dangling identifier is rendered.
+   *
+   * Driven through the fixture rather than the application because the
+   * requirement is about what the hook reports, and the fixture is where a
+   * place can be removed from the workspace mid-session without also
+   * exercising IndexedDB.
+   */
+  test("deleting a place unassigns its leaves without destroying the plan", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "assign cobalt", exact: true }).click();
+    await expect(page.locator("[data-assigned]")).toHaveAttribute(
+      "data-assigned",
+      "place-2",
+    );
+
+    await page.getByRole("button", { name: "delete place-2", exact: true }).click();
+
+    // The leaf is unassigned and says which leaf moved — not silently dropped.
+    await expect(page.locator("[data-assigned]")).toHaveAttribute("data-assigned", "");
+    await expect(page.locator("[data-unresolved]")).toHaveAttribute(
+      "data-unresolved",
+      "COBALT",
+    );
+  });
+
+  test("a deleted place's id never reaches the domain", async ({ page }) => {
+    await page.getByRole("button", { name: "assign cobalt", exact: true }).click();
+    await expect
+      .poll(async () => page.evaluate(() => window.__assignment.dispatches()), {
+        timeout: 10_000,
+      })
+      .toBe(1);
+
+    await page.getByRole("button", { name: "delete place-2", exact: true }).click();
+    /*
+     * Reassigning after the deletion is what puts a request on the wire
+     * again. The assertion is that the request carries the surviving place
+     * and not the deleted one — a dangling id crossing the boundary would
+     * group leaves at a base that exists nowhere, which is the rendering
+     * ADR-0010 rules out by name.
+     */
+    await page.getByRole("button", { name: "reassign cobalt", exact: true }).click();
+    await expect
+      .poll(async () => page.evaluate(() => window.__assignment.dispatches()), {
+        timeout: 10_000,
+      })
+      .toBe(2);
+
+    const request = await page.evaluate(() => window.__assignment.requests().at(-1));
+    expect(Object.values(request?.assignments ?? {})).not.toContain("place-2");
+    expect(request?.assignments).toEqual({ COBALT: "place-5" });
+  });
+
+  /*
+   * The assignment is not destroyed, only unresolved. Restoring the place
+   * restores the assignment, which is what makes deletion survivable rather
+   * than a thing the player has to redo.
+   */
   test("clearing an assignment removes the key rather than blanking it", async ({
     page,
   }) => {
@@ -191,11 +305,86 @@ test.describe("with curated constants", () => {
  * The control, in the real application
  * ------------------------------------------------------------------- */
 
+/*
+ * The place a leaf is assigned to in the shell tests.
+ *
+ * Governing: SPEC-0011 REQ "A Place Is Authored, and a Plan References It"
+ *
+ * These tests used to assign to `base-3`, one of six identifiers the view
+ * minted. There is no such set now: the assignable bases are the workspace's
+ * places, so a test that wants somewhere to assign to has to create it —
+ * which is also the honest shape, since that is what a player does.
+ */
+const PLACE = "Aurora Flats";
+
+/** Create a place through the shipped route and wait for it to appear. */
+async function createPlace(page: Page, name: string): Promise<void> {
+  await page.getByLabel("New place").fill(name);
+  await page.getByRole("button", { name: "Create place" }).click();
+  await expect(page.getByText(name, { exact: true })).toBeVisible();
+}
+
+/** The option value the assignment select carries for a place — its record id. */
+async function placeId(page: Page, name: string): Promise<string> {
+  return page
+    .getByRole("dialog")
+    .getByLabel("Gathered at")
+    .locator("option")
+    .filter({ hasText: name })
+    .first()
+    .getAttribute("value")
+    .then((value) => value ?? "");
+}
+
 test.describe("in the shell", () => {
   test.beforeEach(async ({ page }) => {
     await countCrossings(page);
     await page.goto("/");
+    /*
+     * A clean workspace per test. The store is shared across the origin, so
+     * places left by a previous test would make the assignable set depend on
+     * execution order.
+     */
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          const deleting = indexedDB.deleteDatabase("nms-planner");
+          deleting.onsuccess = () => {
+            resolve();
+          };
+          deleting.onerror = () => {
+            resolve();
+          };
+          deleting.onblocked = () => {
+            resolve();
+          };
+        }),
+    );
+    await page.reload({ waitUntil: "load" });
+    await createPlace(page, PLACE);
     await resolve(page, "ANTIMATTER");
+  });
+
+  /*
+   * SPEC-0011 REQ "A Place Is Authored, and a Plan References It":
+   * "A plan MUST remain resolvable when it references no places at all."
+   */
+  test("a plan resolves against a workspace with no places", async ({ page }) => {
+    await page.getByRole("button", { name: `Delete ${PLACE}` }).click();
+
+    const leaf = await aLeafName(page);
+    await page
+      .getByRole("region", CANVAS)
+      .locator(".node-card")
+      .filter({ hasText: leaf })
+      .first()
+      .click();
+
+    const select = page.getByRole("dialog").getByLabel("Gathered at");
+    await expect(select).toBeVisible();
+    // Unassigned and nothing else, with the state named rather than blank.
+    await expect(select.locator("option")).toHaveCount(1);
+    await expect(page.getByRole("dialog")).toContainText("No places yet");
   });
 
   test("a leaf offers a base, and a non-leaf does not", async ({ page }) => {
@@ -243,9 +432,12 @@ test.describe("in the shell", () => {
     const select = page.getByRole("dialog").getByLabel("Gathered at");
     await select.focus();
     await expect(select).toBeFocused();
-    await select.selectOption("base-3");
+    const id = await placeId(page, PLACE);
+    await select.selectOption(id);
 
-    await expect(select).toHaveValue("base-3");
+    await expect(select).toHaveValue(id);
+    /* The value is the place record's own id, not an identifier minted here. */
+    expect(id).not.toBe("");
   });
 
   test("an assigned leaf takes its base's colour on the border", async ({ page }) => {
@@ -260,10 +452,14 @@ test.describe("in the shell", () => {
     await expect(card).toHaveAttribute("data-identity", "unassigned");
 
     await card.click();
-    await page.getByRole("dialog").getByLabel("Gathered at").selectOption("base-3");
+    await page
+      .getByRole("dialog")
+      .getByLabel("Gathered at")
+      .selectOption(await placeId(page, PLACE));
     await page.keyboard.press("Escape");
 
-    await expect(card).toHaveAttribute("data-identity", "3");
+    /* The first place in the workspace draws with the first colour slot. */
+    await expect(card).toHaveAttribute("data-identity", "1");
     const after = await card.evaluate((el) => getComputedStyle(el).borderTopColor);
     expect(after, "the border did not take the base's colour").not.toBe(before);
   });
@@ -276,10 +472,14 @@ test.describe("in the shell", () => {
       .filter({ hasText: leaf })
       .first()
       .click();
-    await page.getByRole("dialog").getByLabel("Gathered at").selectOption("base-3");
+    await page
+      .getByRole("dialog")
+      .getByLabel("Gathered at")
+      .selectOption(await placeId(page, PLACE));
 
     const live = page.locator('[aria-live="polite"]');
-    await expect(live).toContainText(`${leaf} assigned to Base 3`);
+    /* The player's own name for the place, not a slot number. */
+    await expect(live).toContainText(`${leaf} assigned to ${PLACE}`);
   });
 
   test("clearing an assignment is announced too, and returns the dashed frame", async ({
@@ -294,7 +494,7 @@ test.describe("in the shell", () => {
 
     await card.click();
     const select = page.getByRole("dialog").getByLabel("Gathered at");
-    await select.selectOption("base-3");
+    await select.selectOption(await placeId(page, PLACE));
     await select.selectOption("");
 
     await expect(page.locator('[aria-live="polite"]')).toContainText(
@@ -318,7 +518,10 @@ test.describe("in the shell", () => {
       .filter({ hasText: leaf })
       .first()
       .click();
-    await page.getByRole("dialog").getByLabel("Gathered at").selectOption("base-3");
+    await page
+      .getByRole("dialog")
+      .getByLabel("Gathered at")
+      .selectOption(await placeId(page, PLACE));
     await page.keyboard.press("Escape");
 
     expect((await crossings(page)).resolve).toBe(before);

--- a/web/tests/card/composition.spec.ts
+++ b/web/tests/card/composition.spec.ts
@@ -155,3 +155,50 @@ test("a base with no identity slot says so rather than inventing one", async ({
   // The dashed frame AND the badge. base.css: never the frame alone.
   await expect(card.locator(".status-badge")).toContainText("Unassigned");
 });
+
+/* ----------------------------------------------------------------------
+ * A place with no site configuration
+ * ------------------------------------------------------------------- */
+
+const UNCONFIGURED = '[data-base="New Place"]';
+
+/*
+ * SPEC-0011 REQ "A Place Is Creatable by Hand":
+ * WHEN a leaf is assigned to a place that has no site configuration
+ * THEN the card presents the missing configuration as absent, and does not
+ * present it as a configured value of zero.
+ */
+test("an unconfigured site is rendered as absent, not as a zero", async ({ page }) => {
+  const section = page.locator(`${UNCONFIGURED} [data-section="unsited"]`);
+  await expect(section).toHaveCount(1);
+  await expect(section).toContainText("Site not configured");
+
+  /* The demand survives — what is missing is the sizing, not the requirement. */
+  await expect(section.locator('[data-row="unsited"]')).toHaveCount(1);
+  await expect(section).toContainText("500");
+
+  /*
+   * And no extractor section at all. A card that sized the row against the
+   * zeros would render one showing 0 extractors at class "", which is the
+   * configured-value-of-zero the requirement rules out.
+   */
+  await expect(page.locator(`${UNCONFIGURED} [data-section="extractor"]`)).toHaveCount(0);
+});
+
+test("an unconfigured place still says what to plant", async ({ page }) => {
+  /*
+   * Extraction is the only producer that needs the site. Losing the farm
+   * too would make an unconfigured place a card that tells the player
+   * nothing, which is a different and worse thing than one with a gap in it.
+   */
+  await expect(page.locator(`${UNCONFIGURED} [data-section="farm"]`)).toHaveCount(1);
+  await expect(
+    page.locator(`${UNCONFIGURED} [data-section="farm"] .card-row`),
+  ).toHaveCount(1);
+});
+
+test("a configured base carries no unsited section", async ({ page }) => {
+  for (const base of [FULL, SPARSE]) {
+    await expect(page.locator(`${base} [data-section="unsited"]`)).toHaveCount(0);
+  }
+});

--- a/web/tests/fixtures/assignment-harness.tsx
+++ b/web/tests/fixtures/assignment-harness.tsx
@@ -55,7 +55,20 @@ declare global {
 
 const requests: RollupRequest[] = [];
 
+/*
+ * The places the workspace holds, as ids.
+ *
+ * Governing: SPEC-0011 REQ "An Assignment Naming an Absent Place Is
+ * Unassigned"
+ *
+ * Held in state so a test can delete one and observe what happens to a leaf
+ * assigned there — which is the case the requirement exists for and the one
+ * a store-backed fixture would make harder to stage, not easier.
+ */
+const PLACES = ["place-2", "place-5"];
+
 function Harness(): ReactNode {
+  const [placeIds, setPlaceIds] = useState<readonly string[]>(PLACES);
   const [client] = useState(() => ({
     rollup: async (request: RollupRequest): Promise<unknown> => {
       requests.push(request);
@@ -63,10 +76,11 @@ function Harness(): ReactNode {
     },
   }));
 
-  const { assignments, assign, dispatches } = useLeafAssignment({
+  const { assignments, unresolved, assign, dispatches } = useLeafAssignment({
     client,
     plan: PLAN,
     constants: CONSTANTS,
+    placeIds,
   });
 
   /*
@@ -86,10 +100,11 @@ function Harness(): ReactNode {
       <p data-assigned={assignments["COBALT"] ?? ""}>
         cobalt: {assignments["COBALT"] ?? "none"}
       </p>
+      <p data-unresolved={unresolved.join(",")}>unresolved: {unresolved.join(",")}</p>
       <button
         type="button"
         onClick={() => {
-          assign("COBALT", "base-2");
+          assign("COBALT", "place-2");
         }}
       >
         assign cobalt
@@ -97,7 +112,7 @@ function Harness(): ReactNode {
       <button
         type="button"
         onClick={() => {
-          assign("COBALT", "base-5");
+          assign("COBALT", "place-5");
         }}
       >
         reassign cobalt
@@ -109,6 +124,14 @@ function Harness(): ReactNode {
         }}
       >
         clear cobalt
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setPlaceIds((current) => current.filter((id) => id !== "place-2"));
+        }}
+      >
+        delete place-2
       </button>
     </main>
   );

--- a/web/tests/fixtures/card-config-harness.tsx
+++ b/web/tests/fixtures/card-config-harness.tsx
@@ -90,6 +90,8 @@ const base: BaseBuild = {
   nutrientProcessors: exact("0"),
   pelletFeeders: exact("0"),
   noBuild: [],
+  configured: true,
+  unsited: [],
   verified: true,
 };
 

--- a/web/tests/fixtures/card-harness.tsx
+++ b/web/tests/fixtures/card-harness.tsx
@@ -108,6 +108,8 @@ const full: BaseBuild = {
   /* Base-level. Rendered once even though the kitchen carries three steps. */
   nutrientProcessors: exact("2"),
   pelletFeeders: exact("1"),
+  configured: true,
+  unsited: [],
   noBuild: [
     {
       itemId: "condensedcarbon",
@@ -143,6 +145,55 @@ const sparse: BaseBuild = {
   nutrientProcessors: exact("0"),
   pelletFeeders: exact("0"),
   noBuild: [],
+  configured: true,
+  unsited: [],
+  verified: true,
+};
+
+/*
+ * A place created with a name and nothing else.
+ *
+ * Governing: SPEC-0011 REQ "A Place Is Creatable by Hand"
+ *
+ * The site's values are the zeros an unconfigured base carries, and they are
+ * present precisely so a test can prove the card does not render them: the
+ * requirement is that the absence read as absence "rather than as a
+ * configured value of zero", and a fixture omitting the zeros could not
+ * catch a card that showed them.
+ *
+ * The farm alongside is the other half. Extraction needs the site; a crop's
+ * yield does not, so an unconfigured place still says what to plant.
+ */
+const unconfigured: BaseBuild = {
+  base: "New Place",
+  site: { extractorClass: "", fillSeconds: exact("0") },
+  configured: false,
+  farms: [
+    {
+      itemId: "starbulb",
+      name: "Star Bulb",
+      required: exact("100"),
+      plants: exact("4"),
+      biodomes: exact("1"),
+      yieldPerPlant: { min: exact("25"), max: exact("25") },
+      growthSeconds: exact("1800"),
+      verified: true,
+    },
+  ],
+  extractors: [],
+  ranches: [],
+  kitchen: [],
+  nutrientProcessors: exact("0"),
+  pelletFeeders: exact("0"),
+  noBuild: [],
+  unsited: [
+    {
+      itemId: "cobalt",
+      name: "Cobalt",
+      required: exact("500"),
+      verified: true,
+    },
+  ],
   verified: true,
 };
 
@@ -153,5 +204,6 @@ createRoot(root).render(
   <StrictMode>
     <BasePlannerCard base={full} identity={2} selected={true} />
     <BasePlannerCard base={sparse} />
+    <BasePlannerCard base={unconfigured} />
   </StrictMode>,
 );

--- a/web/tests/fixtures/card-power-harness.tsx
+++ b/web/tests/fixtures/card-power-harness.tsx
@@ -72,6 +72,8 @@ function baseNamed(name: string): BaseBuild {
     nutrientProcessors: exact("0"),
     pelletFeeders: exact("0"),
     noBuild: [],
+    configured: true,
+    unsited: [],
     verified: true,
   };
 }

--- a/web/tests/fixtures/card-provenance-harness.tsx
+++ b/web/tests/fixtures/card-provenance-harness.tsx
@@ -87,6 +87,8 @@ function baseWith(name: string, rowsVerified: boolean, baseVerified: boolean): B
     ],
     nutrientProcessors: exact("1"),
     pelletFeeders: exact("1"),
+    configured: true,
+    unsited: [],
     noBuild: [
       {
         itemId: "condensedcarbon",

--- a/web/tests/fixtures/fake/shim.js
+++ b/web/tests/fixtures/fake/shim.js
@@ -27,7 +27,7 @@ globalThis.Go = class {
 
     if (script.neverPublish === true) return;
 
-    const version = script.contractVersion ?? "1.2.0";
+    const version = script.contractVersion ?? "1.3.0";
     let readyAfter = script.notReadyTimes ?? 0;
 
     const envelope = (body) => JSON.stringify({ contractVersion: version, ...body });

--- a/web/tests/fixtures/store-harness.ts
+++ b/web/tests/fixtures/store-harness.ts
@@ -25,6 +25,7 @@ declare global {
         database: string,
         preferences: Record<string, string | boolean>,
       ) => Promise<StoreResult<void>>;
+      deletePlace: (database: string, id: string) => Promise<StoreResult<void>>;
       deleteAll: (database: string) => Promise<StoreResult<void>>;
       close: (database: string) => void;
       /** Write a record straight past the store, to plant a bad version. */
@@ -61,6 +62,7 @@ window.__store = {
   putPlace: async (database, place) => get(database).putPlace(place),
   putPreferences: async (database, preferences) =>
     get(database).putPreferences(preferences),
+  deletePlace: async (database, id) => get(database).deletePlace(id),
   deleteAll: async (database) => get(database).deleteAll(),
   close: (database) => {
     get(database).close();

--- a/web/tests/shell/places.spec.ts
+++ b/web/tests/shell/places.spec.ts
@@ -1,0 +1,194 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+/*
+ * Governing: ADR-0010 (places are authored first, and a plan assigns leaves
+ * to places that exist), SPEC-0011 REQ "A Place Is Creatable by Hand", REQ
+ * "A Place Is Authored, and a Plan References It", SPEC-0009 REQ "A Place Is
+ * One Record Type, Whatever Its Kind"
+ *
+ * Against the real application at "/", not a fixture. The requirement is
+ * that "the bases surface MUST provide a route to create a place without a
+ * save file" — a route that exists only in a harness is not a route, and
+ * this is the one story where the shipped page is the claim.
+ *
+ * The identity assertion is made against IndexedDB rather than against the
+ * screen. "No second identifier for a place exists anywhere in the store or
+ * the domain" is checkable by reading the schema, and reading it is what
+ * distinguishes a record whose id the plan uses from one carrying a plan-
+ * scoped key beside it.
+ */
+
+const DATABASE = "nms-planner";
+
+/** Every place record on disk, read past the application. */
+async function storedPlaces(page: Page): Promise<Record<string, unknown>[]> {
+  return page.evaluate(
+    (database) =>
+      new Promise<Record<string, unknown>[]>((resolve, reject) => {
+        const opening = indexedDB.open(database);
+        opening.onsuccess = () => {
+          const db = opening.result;
+          if (!db.objectStoreNames.contains("places")) {
+            db.close();
+            resolve([]);
+            return;
+          }
+          const transaction = db.transaction(["places"], "readonly");
+          const all = transaction.objectStore("places").getAll();
+          transaction.oncomplete = () => {
+            db.close();
+            resolve(all.result as Record<string, unknown>[]);
+          };
+          transaction.onerror = () => {
+            db.close();
+            reject(transaction.error ?? new Error("read failed"));
+          };
+        };
+        opening.onerror = () => {
+          reject(opening.error ?? new Error("open failed"));
+        };
+      }),
+    DATABASE,
+  );
+}
+
+async function createPlace(page: Page, name: string): Promise<void> {
+  await page.getByLabel("New place").fill(name);
+  await page.getByRole("button", { name: "Create place" }).click();
+  await expect(page.getByText(name, { exact: true })).toBeVisible();
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+  // A clean workspace per test: the store is shared across the origin.
+  await page.evaluate(
+    (database) =>
+      new Promise<void>((resolve) => {
+        const deleting = indexedDB.deleteDatabase(database);
+        deleting.onsuccess = () => {
+          resolve();
+        };
+        deleting.onerror = () => {
+          resolve();
+        };
+        deleting.onblocked = () => {
+          resolve();
+        };
+      }),
+    DATABASE,
+  );
+  await page.reload({ waitUntil: "load" });
+});
+
+/*
+ * SPEC-0011 REQ "A Place Is Creatable by Hand":
+ * WHEN a place is created with a name and nothing else
+ * THEN it persists across a reload and a plan can assign a leaf to it.
+ */
+test("a name is the whole minimum, and it survives a reload", async ({ page }) => {
+  await createPlace(page, "Aurora Flats");
+
+  await page.reload({ waitUntil: "load" });
+  await expect(page.getByText("Aurora Flats", { exact: true })).toBeVisible();
+
+  const records = await storedPlaces(page);
+  expect(records).toHaveLength(1);
+  expect(records[0]?.["name"]).toBe("Aurora Flats");
+  /*
+   * Nothing else was asked for and nothing else was invented. A kind is
+   * written because SPEC-0009 makes it part of the record; a site
+   * configuration is not, which is what makes the place assignable while
+   * unconfigured.
+   */
+  expect(records[0]?.["kind"]).toBe("base");
+  expect(records[0]?.["notes"]).toBeUndefined();
+  expect(records[0]?.["tags"]).toBeUndefined();
+});
+
+/*
+ * SPEC-0011 REQ "A Place Is Authored, and a Plan References It":
+ * "The application MUST NOT mint a second identifier for a place."
+ *
+ * Read from the schema rather than inferred from behaviour: a second
+ * identifier would be a field beside `id`, and the assertion is that the
+ * record carries exactly the fields SPEC-0009 defines and no key that looks
+ * like a plan-scoped alias.
+ */
+test("a place record carries one identifier and no alias for it", async ({ page }) => {
+  await createPlace(page, "Aurora Flats");
+
+  const records = await storedPlaces(page);
+  const record = records[0];
+  expect(record).toBeDefined();
+  if (!record) return;
+
+  expect(typeof record["id"]).toBe("string");
+  expect(String(record["id"])).not.toBe("");
+
+  const identifierish = Object.keys(record).filter(
+    (key) => key !== "id" && /(^|[a-z])(id|Id|ID|key|Key|slug|Slug)$/.test(key),
+  );
+  expect(
+    identifierish,
+    `a second identifier appeared: ${identifierish.join(", ")}`,
+  ).toHaveLength(0);
+});
+
+test("two places created in one session get different ids", async ({ page }) => {
+  await createPlace(page, "Aurora Flats");
+  await createPlace(page, "Cinder Reach");
+
+  const ids = (await storedPlaces(page)).map((record) => record["id"]);
+  expect(new Set(ids).size).toBe(2);
+});
+
+/*
+ * SPEC-0011 REQ "An Assignment Naming an Absent Place Is Unassigned":
+ * deleting a place removes the record and nothing else. The plan is the
+ * expensive artifact and it is not the store's to edit.
+ */
+test("deleting a place removes it and leaves the workspace usable", async ({ page }) => {
+  await createPlace(page, "Aurora Flats");
+  await createPlace(page, "Cinder Reach");
+
+  await page.getByRole("button", { name: "Delete Aurora Flats" }).click();
+
+  await expect(page.getByText("Aurora Flats", { exact: true })).toHaveCount(0);
+  await expect(page.getByText("Cinder Reach", { exact: true })).toBeVisible();
+
+  const names = (await storedPlaces(page)).map((record) => record["name"]);
+  expect(names).toEqual(["Cinder Reach"]);
+});
+
+test("an empty name creates nothing", async ({ page }) => {
+  await page.getByLabel("New place").fill("   ");
+  await expect(page.getByRole("button", { name: "Create place" })).toBeDisabled();
+  expect(await storedPlaces(page)).toHaveLength(0);
+});
+
+/*
+ * SPEC-0011 Accessibility Requirements, and SPEC-0005's baseline: the route
+ * has to be operable without a pointing device, since it is the only way to
+ * bring a place into existence.
+ */
+test("a place is creatable with the keyboard alone", async ({ page }) => {
+  await page.getByLabel("New place").focus();
+  await page.keyboard.type("Keyboard Only");
+  await page.keyboard.press("Enter");
+
+  await expect(page.getByText("Keyboard Only", { exact: true })).toBeVisible();
+  expect((await storedPlaces(page)).map((record) => record["name"])).toEqual([
+    "Keyboard Only",
+  ]);
+});
+
+test("the places panel has no accessibility violations", async ({ page }) => {
+  await createPlace(page, "Aurora Flats");
+
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+
+  expect(results.violations).toEqual([]);
+});

--- a/web/tests/shell/places.spec.ts
+++ b/web/tests/shell/places.spec.ts
@@ -144,6 +144,44 @@ test("two places created in one session get different ids", async ({ page }) => 
 });
 
 /*
+ * SPEC-0011 REQ "A Place Is Authored, and a Plan References It":
+ * "The application MUST NOT ... derive a place's identity from a plan's
+ * assignments." The same argument rules out deriving it from the name, and
+ * that is the derivation actually within reach here — a slug of the name is
+ * the obvious shortcut and it reads correctly until one of these two cases.
+ *
+ * Two places with the same name are two places. A name-derived id makes
+ * them one: the second write lands on the first record's key and overwrites
+ * it, so the player creates a place and watches another disappear.
+ */
+test("two places with the same name are two places", async ({ page }) => {
+  await page.getByLabel("New place").fill("Aurora Flats");
+  await page.getByRole("button", { name: "Create place" }).click();
+  await page.getByLabel("New place").fill("Aurora Flats");
+  await page.getByRole("button", { name: "Create place" }).click();
+
+  await expect(page.getByText("Aurora Flats", { exact: true })).toHaveCount(2);
+
+  const records = await storedPlaces(page);
+  expect(records, "the second place overwrote the first").toHaveLength(2);
+  expect(new Set(records.map((record) => record["id"])).size).toBe(2);
+});
+
+/*
+ * And the id carries no trace of the name, because a rename must not change
+ * it. An id derived from the name changes when the player renames the
+ * place, which silently reassigns every leaf that pointed at it — the exact
+ * fragmentation ADR-0010 rejected the side-table for.
+ */
+test("a place id is not derived from its name", async ({ page }) => {
+  await createPlace(page, "Aurora Flats");
+
+  const id = String((await storedPlaces(page))[0]?.["id"]);
+  expect(id.toLowerCase()).not.toContain("aurora");
+  expect(id.toLowerCase()).not.toContain("flats");
+});
+
+/*
  * SPEC-0011 REQ "An Assignment Naming an Absent Place Is Unassigned":
  * deleting a place removes the record and nothing else. The plan is the
  * expensive artifact and it is not the store's to edit.

--- a/web/tests/shell/places.spec.ts
+++ b/web/tests/shell/places.spec.ts
@@ -154,6 +154,41 @@ test("two places created in one session get different ids", async ({ page }) => 
  * them one: the second write lands on the first record's key and overwrites
  * it, so the player creates a place and watches another disappear.
  */
+/*
+ * The form is one element, not one per store state.
+ *
+ * `StoredPlaces` renders an empty state and a populated state. Rendering the
+ * create form inside each branch put it at a different child position in
+ * each, and React reconciles a fragment's children by position — so creating
+ * the *first* place moved the form from index 1 to index 0 and remounted it,
+ * discarding the name in its `useState`.
+ *
+ * That is the first-run path, every time: type the first place, submit,
+ * start typing the second, and lose it the moment the write settles. The
+ * button then sits disabled on an empty field with nothing to say why.
+ *
+ * Asserted on element identity rather than on the typed text, because the
+ * text can be lost for other reasons and a remount is the specific fault:
+ * a form that survives cannot have been remounted, and one that does not
+ * cannot have kept its state.
+ */
+test("the create form is not remounted when the first place appears", async ({
+  page,
+}) => {
+  const field = page.getByLabel("New place");
+
+  await field.evaluate((element) => {
+    (element as HTMLElement & { dataset: DOMStringMap }).dataset["probe"] = "first";
+  });
+
+  await createPlace(page, "Aurora Flats");
+
+  await expect(
+    field,
+    "the create form was remounted, so anything typed into it was discarded",
+  ).toHaveAttribute("data-probe", "first");
+});
+
 test("two places with the same name are two places", async ({ page }) => {
   await page.getByLabel("New place").fill("Aurora Flats");
   await page.getByRole("button", { name: "Create place" }).click();

--- a/web/tests/store/durable-store.spec.ts
+++ b/web/tests/store/durable-store.spec.ts
@@ -477,6 +477,101 @@ test("deletion removes everything and leaves the designed empty state", async ({
   expect(after.places).toBe(0);
 });
 
+/*
+ * SPEC-0011 REQ "An Assignment Naming an Absent Place Is Unassigned":
+ * WHEN three leaves are assigned to a place and that place is deleted
+ * THEN the plan survives, the three leaves appear in the unassigned group,
+ * and no dangling identifier is rendered.
+ *
+ * The store's half is the first clause: removing one place leaves the rest
+ * of the workspace exactly as it was. The second clause is the view's and is
+ * asserted in tests/canvas/assignment.spec.ts, where the assignment lives.
+ */
+test("deleting one place leaves the others and the workspace intact", async ({
+  page,
+}) => {
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  const after = await page.evaluate(async (db) => {
+    await window.__store.putPlace(db, { id: "keep-1", kind: "base", name: "Alpha" });
+    await window.__store.putPlace(db, { id: "gone", kind: "base", name: "Beta" });
+    await window.__store.putPlace(db, { id: "keep-2", kind: "freighter" });
+    await window.__store.putPreferences(db, { groupSeparator: "," });
+
+    const deleted = await window.__store.deletePlace(db, "gone");
+    const loaded = await window.__store.load(db);
+    return {
+      deleted,
+      ids: loaded.kind === "ok" ? loaded.value.places.map((place) => place.id) : [],
+      separator:
+        loaded.kind === "ok"
+          ? loaded.value.workspace.preferences?.["groupSeparator"]
+          : null,
+    };
+  }, database);
+
+  expect(after.deleted.kind).toBe("ok");
+  expect(after.ids.toSorted()).toEqual(["keep-1", "keep-2"]);
+  // The workspace record survives with it: deleting a place is not a reset.
+  expect(after.separator).toBe(",");
+});
+
+test("deleting a place that is not there succeeds", async ({ page }) => {
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  /*
+   * The caller asked for a state and that state already holds. Reporting a
+   * failure would make a double click an error, and would make deletion the
+   * one operation a player has to get right first time.
+   */
+  const deleted = await page.evaluate(
+    (db) => window.__store.deletePlace(db, "never-existed"),
+    database,
+  );
+  expect(deleted.kind).toBe("ok");
+});
+
+/*
+ * SPEC-0011 REQ "A Place Is Creatable by Hand":
+ * WHEN a place is created with a name and nothing else
+ * THEN it persists across a reload.
+ *
+ * The store's half of "a name is the whole minimum": every other field is
+ * optional, so a record carrying only an id, a kind and a name is a complete
+ * place rather than a partial one.
+ */
+test("a place with only a name persists across a reload", async ({ page }) => {
+  const database = freshDatabase();
+  await openStore(page, database);
+
+  await page.evaluate(
+    (db) => window.__store.putPlace(db, { id: "named", kind: "base", name: "Alpha" }),
+    database,
+  );
+  await page.evaluate((db) => {
+    window.__store.close(db);
+  }, database);
+
+  await page.reload({ waitUntil: "load" });
+  await expect(page.locator("body")).toHaveAttribute("data-ready", "true");
+  await openStore(page, database);
+
+  const loaded = await page.evaluate((db) => window.__store.load(db), database);
+  expect(loaded.kind).toBe("ok");
+  if (loaded.kind !== "ok") return;
+
+  const place = loaded.value.places[0];
+  expect(place?.name).toBe("Alpha");
+  expect(place?.id).toBe("named");
+  // Nothing was invented to fill the fields the player did not supply.
+  expect(place?.notes).toBeUndefined();
+  expect(place?.tags).toBeUndefined();
+  expect(place?.ticks).toBeUndefined();
+  expect(place?.stocked).toBeUndefined();
+});
+
 test("preferences round-trip without becoming place records", async ({ page }) => {
   const database = freshDatabase();
   await openStore(page, database);


### PR DESCRIPTION
Closes #145
Part of #143

Implements SPEC-0011 REQ "A Place Is Authored, and a Plan References It", REQ "An Assignment Naming an Absent Place Is Unassigned", REQ "A Place Is Creatable by Hand".

`BaseID` stops meaning "a key this plan invented" and starts meaning "a place that exists". The doc comment in `internal/domain/rollup.go` says so, and the view stops minting the six identifiers that made it untrue.

## Identity

`web/src/canvas/bases.ts` derived `base-1` through `base-6` with placeholder labels, on the stated grounds that a base's real name came from a bases map with no spec and no surface. SPEC-0011 forbids exactly that — "The application MUST NOT mint a second identifier for a place" — so the assignable set is now the workspace's places and `Base.id` is the SPEC-0009 record's own `id`.

The identity slot survives as what it always was: which of six colour tokens a place draws with. It repeats past six places, because a colour is paint and an id is not.

## Creation

A place is creatable from the Saved places panel with a name and nothing else, which is the whole minimum the requirement sets. The form is a real `<form>`, so Enter submits and the route does not sit behind a pointing device.

The id comes from `crypto.randomUUID()` rather than the name. A name-derived id changes when the player renames a place, silently reassigning every leaf that pointed at it — the fragmentation ADR-0010 rejected the side-table for.

## Unassignment

`web/src/state/assignments.ts` resolves held assignments against the places that exist, **on read rather than on delete**. That is what makes the rule hold for "every source of an assignment": a hash authored on another device names places this one never had, and there is no deletion event to hang a prune on.

Deleting a place removes the record and nothing else. The assignment is kept, the leaf is presented unassigned, and restoring the place restores it — so deleting a place cannot destroy a plan. The resolved map is what crosses the boundary, so a deleted place's id never reaches the domain and no base that exists nowhere is ever rendered.

## An unconfigured place is assignable, and that changed the domain

`GroupLeaves` refused any base named in an assignment that had no site configuration. SPEC-0011 makes that base assignable, so the binary becomes three states.

Both halves of the old rule survive. **Nothing is defaulted** — an extractor class picked for the caller is still a number they never chose, so an unconfigured base sizes *no* extractors rather than sizing them at class `""`; it reports them as `Unsited` demands instead. **A site that is supplied is still validated**, because "not configured yet" and "configured wrongly" are different mistakes.

Only extraction needs the site. A crop's yield and a fauna's rate are the item's own facts, so farms and ranches size normally: an unconfigured place still says what to plant.

The card renders that gap as a gap — an "Awaiting site configuration" section carrying the demand and the words, never a count of zero. The extractor-class select gains a "Not configured" option while the class is empty, because a select whose value matches nothing falls back to its first option and would have read as class C.

## Boundary contract 1.2.0 → 1.3.0

`configured` and `unsited` are additive, but with a sharper edge than the previous two bumps: a consumer that does not know about `configured` reads a base with a zero site as one configured at class `""` for zero seconds — the configured-value-of-zero the requirement exists to prevent. The decoder requires the field rather than guessing, and a test asserts the refusal.

## Also

`DurableStore.deletePlace`, which SPEC-0009 did not have — its deletion story is workspace-wide and this rule needs one place at a time.

Six mutations added to the mutation check, covering the three rules a behavioural test cannot pin down alone: a name-derived id renders identically until a rename, a resolver that keeps everything looks right until a place is deleted, and a card that shows the site's zeros looks like a configured base.

## Verification

| Check | Result |
|---|---|
| `go test ./internal/...` | pass |
| Frontend suite | 326 passed |
| Typecheck, lint, `check:tokens` | clean |
| Mutation check | the first run found one unwatched rule; see below |

The mutation check earned its place here. Replacing `crypto.randomUUID()` with a slug of the name left the suite green — the comment beside it argued why that is wrong, and nothing was watching. Two tests now cover it, and I confirmed by applying the mutation by hand that both go red while the other seven in the file stay green: two places named the same are two places (a slug makes them one, and the second write overwrites the first), and the id carries no trace of the name.

The full mutation re-run was interrupted locally; CI runs the same gate and exits non-zero on any unwatched rule.

## Follow-up not in scope

Five shell assignment tests that assigned to `base-3` now create a place through the shipped route first. That is the honest shape — it is what a player does — but it means those tests exercise creation as a precondition, and a failure there will surface as an assignment failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsufroW5o7HXQ46hpnZvQa)_