### PR TITLE
feat(web): the hash carries the plan, the store carries the player

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -34,7 +34,15 @@ Specified per surface in the three handoff.md files. Cross-cutting rules:
 - **Borders carry identity only**: 3px base-color frames; hover = brightness(1.12), focus = 2px #8ec07c outline outboard, selection = 2px #8ec07c ring **inboard via overlay element** (never inset box-shadow — it paints under positioned children). Nothing else may write to a border.
 - Every recompute (method/class/type change, deficit fix, todo check) announces via `aria-live="polite"`.
 - Color is never the sole carrier: methods have glyph+text, bases have names, warnings have ⚠+text, deficits have stated kPs + red meter segment.
-- Plan state (target, methods, assignments, todo checks) should serialize into a shareable URL hash; no localStorage.
+- Plan state (target, methods, recipes, assignments) serializes into a shareable URL hash; no localStorage.
+
+  > **Superseded in part by [ADR-0008](../adrs/ADR-0008-durable-user-data-store.md).** This line originally listed *todo checks* among the hash contents and predates the durable-store decision. Ticked build items are per-place player data, not plan state: they describe what someone has built at a base, not what they asked the planner for. Sharing a link would otherwise hand the recipient someone else's progress, and receiving one would overwrite theirs.
+  >
+  > SPEC-0011 REQ "The Hash Owns the Plan, the Store Owns the Player" fixes the boundary: the hash carries target, quantity, method and recipe selections and leaf assignments; the store carries places, annotations, ticks and view preferences.
+  >
+  > "No localStorage" still holds and is narrower than it reads. ADR-0008 lifted it for durable player data only, and that store is IndexedDB — asynchronous, structured and quota-bounded. Plan state keeps the original rule.
+
+  The same correction applies to the per-base list in **State Management** below, which predates ADR-0008 for the same reason: its `todo done-map` and `note tags + text` are store-owned, not UI state.
 
 ## State Management
 Per-base UI state (v2 prototype's `ui` map is the reference shape): power type + EM class, extractor class, added generators, section open/closed, todo done-map, note tags + text, selection. Plan-level: target, device/batch quantity. All quantities derive from the dependency graph — the prototypes' math (plants = qty÷yield, domes = plants÷16, extractors sized to ~1.5h fill, power gen = units × class-multiplied output) shows the intended rollup shape, not real constants.

--- a/web/scripts/mutation-check.sh
+++ b/web/scripts/mutation-check.sh
@@ -56,7 +56,11 @@ STORED="src/state/useStoredData.ts"
 PLANNERCARD="src/card/BasePlannerCard.tsx"
 POWERBLOCK="src/card/PowerBlock.tsx"
 
+HASH="src/boundary/plan-hash.ts"
+PLANSTATE="src/boundary/plan.ts"
+
 MUTABLE="$MUTABLE $LAYOUT $TREE $METHODS $CONTROL $ASSIGN $BASES $PLANNERCARD $POWERBLOCK"
+MUTABLE="$MUTABLE $HASH $PLANSTATE"
 MUTABLE="$MUTABLE $RESOLVE $STORED"
 
 # shellcheck disable=SC2086
@@ -652,6 +656,29 @@ check "the create form is remounted when the first place appears" \
   tests/shell/places.spec.ts "$PLACES" \
   "      <CreatePlace create={data.createPlace} />" \
   '      <CreatePlace key={data.empty ? "empty" : "populated"} create={data.createPlace} />'
+
+# ----------------------------------------------------------------------
+# Where state lives.
+#
+# Two mechanisms exist and each is individually a plausible home for the
+# same value, so the drift would be silent. The second mutation is the
+# direction that matters: a leaked note is visible the first time someone
+# reads a link, and a decoded hash quietly authoring a place record is not
+# visible at all.
+# ----------------------------------------------------------------------
+
+check "the hash stops carrying assignments" \
+  tests/boundary/state-ownership.spec.ts "$HASH" \
+  '  if (Object.keys(plan.assignments).length > 0) wire["assignments"] = plan.assignments;' \
+  "  void plan.assignments;"
+
+check "the plan decoder starts accepting a player's ticks" \
+  tests/boundary/state-ownership.spec.ts "$PLANSTATE" \
+  "      assignments: assignments.overrides,
+    }," \
+  "      assignments: assignments.overrides,
+      ...(raw[\"ticks\"] === undefined ? {} : { ticks: raw[\"ticks\"] }),
+    },"
 
 echo
 if [ "$failures" -gt 0 ]; then

--- a/web/src/boundary/plan-hash.ts
+++ b/web/src/boundary/plan-hash.ts
@@ -67,6 +67,12 @@ export function encodePlanToHash(plan: Plan): string {
   const wire: Record<string, unknown> = { target: plan.target, quantity: plan.quantity };
   if (Object.keys(plan.methods).length > 0) wire["methods"] = plan.methods;
   if (Object.keys(plan.recipes).length > 0) wire["recipes"] = plan.recipes;
+  /*
+   * Unlike `planToWire`, the hash *does* carry assignments: SPEC-0011 lists
+   * them among the plan state a shared link carries, and a link that dropped
+   * them would share a plan whose leaves land nowhere.
+   */
+  if (Object.keys(plan.assignments).length > 0) wire["assignments"] = plan.assignments;
   return `#${PARAMETER}=${toBase64Url(JSON.stringify(wire))}`;
 }
 

--- a/web/src/boundary/plan.ts
+++ b/web/src/boundary/plan.ts
@@ -21,6 +21,17 @@ export interface Plan {
   readonly methods: Readonly<Record<string, string>>;
   /** Per-node recipe overrides. */
   readonly recipes: Readonly<Record<string, string>>;
+  /**
+   * Leaf item id to base id.
+   *
+   * Plan state, and in the hash — SPEC-0011 REQ "The Hash Owns the Plan, the
+   * Store Owns the Player" lists assignments alongside target, quantity,
+   * methods and recipes as what a shared link carries. They are the one
+   * field here that never reaches `resolve`: stage 1 does not see them, and
+   * they cross to the domain on the stage-2 rollup request instead. See
+   * `planToWire`.
+   */
+  readonly assignments: Readonly<Record<string, string>>;
 }
 
 /**
@@ -32,6 +43,7 @@ export const EMPTY_PLAN: Plan = Object.freeze({
   quantity: "0" as Quantity,
   methods: Object.freeze({}),
   recipes: Object.freeze({}),
+  assignments: Object.freeze({}),
 });
 
 export function isEmptyPlan(plan: Plan): boolean {
@@ -111,9 +123,25 @@ export function validatePlan(value: unknown): PlanResult {
   const recipes = validateOverrides(raw["recipes"], "recipes");
   if (!recipes.ok) return reject(recipes.reason);
 
+  const assignments = validateOverrides(raw["assignments"], "assignments");
+  if (!assignments.ok) return reject(assignments.reason);
+
+  /*
+   * Only these five fields are read. A hash carrying `ticks`, `notes` or a
+   * place name is not rejected — it is *ignored*, and the value never
+   * reaches a Plan. SPEC-0011 forbids a hash-derived value being written to
+   * the store as though the player authored it, and the cheapest way to
+   * honour that is for the decoder to have nowhere to put one.
+   */
   return {
     ok: true,
-    plan: { target, quantity, methods: methods.overrides, recipes: recipes.overrides },
+    plan: {
+      target,
+      quantity,
+      methods: methods.overrides,
+      recipes: recipes.overrides,
+      assignments: assignments.overrides,
+    },
   };
 }
 
@@ -122,5 +150,17 @@ export function planToWire(plan: Plan): string {
   const wire: Record<string, unknown> = { target: plan.target, quantity: plan.quantity };
   if (Object.keys(plan.methods).length > 0) wire["methods"] = plan.methods;
   if (Object.keys(plan.recipes).length > 0) wire["recipes"] = plan.recipes;
+  /*
+   * `assignments` is deliberately absent.
+   *
+   * This is the wire shape `resolve` parses, and stage 1 has no concept of a
+   * base — `internal/bridge.Plan` carries target, quantity, methods and
+   * recipes and nothing else. Assignments reach the domain on the stage-2
+   * rollup request, which is where the domain reads them.
+   *
+   * Sending them anyway would be harmless today (the Go decoder ignores
+   * unknown fields on a plan) and wrong in the way that matters: it would
+   * say stage 1 takes an input it does not take.
+   */
   return JSON.stringify(wire);
 }

--- a/web/tests/boundary/plan-hash.spec.ts
+++ b/web/tests/boundary/plan-hash.spec.ts
@@ -31,6 +31,7 @@ const PLAN: Plan = {
   quantity: q("3"),
   methods: { CAVE2: "REFINE" },
   recipes: { OXYGEN: "OXYGEN_REFINE" },
+  assignments: { FERRITE_DUST: "base-2" },
 };
 
 function hashOf(value: unknown): string {

--- a/web/tests/boundary/state-ownership.spec.ts
+++ b/web/tests/boundary/state-ownership.spec.ts
@@ -1,0 +1,274 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { expect, test, type Page } from "@playwright/test";
+
+import {
+  decodePlanFromHash,
+  encodePlanToHash,
+  validatePlan,
+  type Plan,
+} from "../../src/boundary";
+import { asQuantity } from "../../src/boundary/quantity";
+
+/*
+ * Governing: ADR-0008 (durable user data lives in a local-first store),
+ * ADR-0010 (places first and the shell), SPEC-0011 REQ "The Hash Owns the
+ * Plan, the Store Owns the Player", REQ "Signing In Is Not a Sync Trigger"
+ *
+ * Two mechanisms now exist and each is individually a plausible home for the
+ * same value, which is what makes the drift silent. The boundary is: the
+ * hash carries the plan — target, quantity, methods, recipes, assignments —
+ * and the store carries the player: places, notes, ticks, preferences.
+ *
+ * The direction worth guarding hardest is the second scenario. Leaking a
+ * note into a link is visible the first time someone reads a link. A decoded
+ * hash quietly authoring a place record is not visible at all, and it is the
+ * change someone makes while trying to make sharing "work better".
+ */
+
+const STORE_FIXTURE = "/tests/fixtures/store.html";
+const DISCIPLINE_FIXTURE = "/tests/fixtures/store-discipline.html";
+
+function q(value: string): NonNullable<ReturnType<typeof asQuantity>> {
+  const quantity = asQuantity(value);
+  if (quantity === null) throw new Error(`${value} is not a quantity`);
+  return quantity;
+}
+
+const FULL_PLAN: Plan = {
+  target: "STASIS_DEVICE",
+  quantity: q("3"),
+  methods: { CAVE2: "REFINE" },
+  recipes: { OXYGEN: "OXYGEN_REFINE" },
+  assignments: { FERRITE_DUST: "base-2", COBALT: "base-5" },
+};
+
+/** A place with every player-authored field populated. */
+const PLACE = {
+  id: "aurora",
+  kind: "base" as const,
+  name: "Aurora Flats",
+  notes: "Landing pad on the north ridge. Watch the sentinels near the copper.",
+  tags: ["copper", "temperate"],
+  ticks: { "part-1": true, "part-7": true },
+  stocked: { COBALT: "120" },
+};
+
+let counter = 0;
+function freshDatabase(): string {
+  counter += 1;
+  return `ownership-${String(counter)}-${String(Math.floor(performance.now()))}`;
+}
+
+/* ----------------------------------------------------------------------
+ * The hash carries the plan, and only the plan
+ * ------------------------------------------------------------------- */
+
+test("a hash encoded while the store is full carries no player-authored value", async ({
+  page,
+}) => {
+  /*
+   * The acceptance criterion is explicit that the test "needs notes and
+   * ticks present, or it proves nothing" — a hash encoded from an empty
+   * session contains no note for the trivial reason that there was none.
+   */
+  await page.goto(STORE_FIXTURE, { waitUntil: "load" });
+  await expect(page.locator("body")).toHaveAttribute("data-ready", "true");
+
+  const database = freshDatabase();
+  const opened = await page.evaluate((db) => window.__store.open(db), database);
+  expect(opened.kind).toBe("ok");
+  const written = await page.evaluate(
+    ([db, place]) => window.__store.putPlace(db, place),
+    [database, PLACE] as const,
+  );
+  expect(written.kind, "the place was not stored, so nothing was at risk").toBe("ok");
+
+  const hash = encodePlanToHash(FULL_PLAN);
+  const decoded = Buffer.from(
+    hash.split("=")[1]?.replaceAll("-", "+").replaceAll("_", "/") ?? "",
+    "base64",
+  ).toString("utf8");
+
+  for (const leaked of [
+    PLACE.name,
+    PLACE.notes,
+    "part-1",
+    "ticks",
+    "notes",
+    "tags",
+    "stocked",
+    "aurora",
+  ]) {
+    expect(decoded, `the hash carries ${leaked}`).not.toContain(leaked);
+  }
+
+  /* And it does carry the plan, so the assertions above are not vacuous. */
+  expect(decoded).toContain("STASIS_DEVICE");
+  expect(decoded).toContain("base-2");
+});
+
+test("the hash carries assignments, because a link without them shares a plan that lands nowhere", () => {
+  const restored = decodePlanFromHash(encodePlanToHash(FULL_PLAN));
+  expect(restored.plan.assignments).toEqual(FULL_PLAN.assignments);
+  expect(restored.plan.methods).toEqual(FULL_PLAN.methods);
+  expect(restored.plan.recipes).toEqual(FULL_PLAN.recipes);
+});
+
+test("a hash carrying player-authored fields drops them rather than rejecting", () => {
+  /*
+   * Dropped, not rejected: SPEC-0005 requires an undecodable hash produce
+   * the empty plan, and a hash that is a *valid* plan plus extra keys is not
+   * undecodable. What matters is that the extra keys have nowhere to go, so
+   * the value never reaches a Plan and cannot be written anywhere.
+   */
+  const result = validatePlan({
+    target: "STASIS_DEVICE",
+    quantity: "1",
+    ticks: { "part-1": true },
+    notes: "a note someone put in a link",
+    places: [{ id: "aurora", name: "Aurora Flats" }],
+  });
+
+  expect(result.ok).toBe(true);
+  if (!result.ok) return;
+
+  expect(Object.keys(result.plan).sort()).toEqual([
+    "assignments",
+    "methods",
+    "quantity",
+    "recipes",
+    "target",
+  ]);
+  expect(JSON.stringify(result.plan)).not.toContain("part-1");
+  expect(JSON.stringify(result.plan)).not.toContain("Aurora");
+});
+
+test("the hash codec names no player-authored field", () => {
+  /*
+   * Mechanical, because the leak this guards is a field someone adds to the
+   * encoder while making a link "more useful". The codec should have no
+   * vocabulary for a note or a tick at all.
+   */
+  const codec = readFileSync(
+    path.join(import.meta.dirname, "..", "..", "src", "boundary", "plan-hash.ts"),
+    "utf8",
+  ).replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, "");
+
+  for (const owned of ["ticks", "notes", "tags", "stocked", "places", "preferences"]) {
+    expect(codec.includes(owned), `plan-hash.ts knows about ${owned}`).toBe(false);
+  }
+});
+
+/* ----------------------------------------------------------------------
+ * Decoding authors nothing
+ * ------------------------------------------------------------------- */
+
+async function storedPlaces(page: Page, database: string): Promise<unknown[]> {
+  return page.evaluate(
+    (db) =>
+      new Promise<unknown[]>((resolve) => {
+        const opening = indexedDB.open(db);
+        opening.onsuccess = () => {
+          const store = opening.result;
+          if (!store.objectStoreNames.contains("places")) {
+            store.close();
+            resolve([]);
+            return;
+          }
+          const all = store
+            .transaction("places", "readonly")
+            .objectStore("places")
+            .getAll();
+          all.onsuccess = () => {
+            store.close();
+            resolve(all.result);
+          };
+          all.onerror = () => {
+            store.close();
+            resolve([]);
+          };
+        };
+        opening.onerror = () => {
+          resolve([]);
+        };
+      }),
+    database,
+  );
+}
+
+test("decoding a hash carrying assignments authors no place record", async ({ page }) => {
+  await page.goto(STORE_FIXTURE, { waitUntil: "load" });
+  await expect(page.locator("body")).toHaveAttribute("data-ready", "true");
+
+  const database = freshDatabase();
+  await page.evaluate((db) => window.__store.open(db), database);
+  await page.evaluate(([db, place]) => window.__store.putPlace(db, place), [
+    database,
+    PLACE,
+  ] as const);
+
+  const before = await storedPlaces(page, database);
+  expect(before.length).toBe(1);
+
+  /*
+   * The assignments name bases that do not exist as records. A decoder that
+   * "helpfully" created them would be authoring player data from a link,
+   * which is the direction the requirement calls out.
+   */
+  const restored = decodePlanFromHash(encodePlanToHash(FULL_PLAN));
+  expect(restored.plan.assignments).toEqual(FULL_PLAN.assignments);
+
+  const after = await storedPlaces(page, database);
+  expect(after).toEqual(before);
+});
+
+/* ----------------------------------------------------------------------
+ * Signing in attaches an owner and transmits nothing
+ * ------------------------------------------------------------------- */
+
+test("attaching an owner transmits no place record", async ({ page }) => {
+  /*
+   * ADR-0008's boundary, carried forward by ADR-0009 §4: sign-in attaches an
+   * owner and does not, by itself, send anything. There is no sign-in yet
+   * and `ownerId` is the whole of what one would change, so this writes it
+   * and asserts the network recorder saw nothing from a store path.
+   *
+   * The store's own discipline suite proves the steady state. This is the
+   * moment the acceptance criterion asks for — the transition itself.
+   */
+  await page.goto(DISCIPLINE_FIXTURE, { waitUntil: "load" });
+  await expect(page.locator("body")).toHaveAttribute("data-ready", "true");
+  await page.evaluate(() => {
+    window.__discipline.reset();
+  });
+
+  const database = freshDatabase();
+  const seeded = await page.evaluate((db) => window.__discipline.seed(db), database);
+  for (const outcome of seeded) expect(outcome).toMatch(/:ok$/);
+
+  const outcomes = await page.evaluate(
+    (db) => window.__discipline.attachOwner(db, "player-42"),
+    database,
+  );
+  expect(outcomes, "the owner was not attached, so nothing was tested").toContain(
+    "attach:ok",
+  );
+
+  const attempts = await page.evaluate(() => window.__discipline.attempts());
+  expect(attempts, "attaching an owner reached the network").toEqual([]);
+
+  /* The places are still there, and still exactly as the player left them. */
+  const workspace = (await page.evaluate(
+    (db) => window.__discipline.raw(db, "workspace"),
+    database,
+  )) as Record<string, unknown>[];
+  expect(workspace[0]?.["ownerId"]).toBe("player-42");
+
+  const places = (await page.evaluate(
+    (db) => window.__discipline.raw(db, "places"),
+    database,
+  )) as Record<string, unknown>[];
+  expect(places.length).toBe(1);
+});

--- a/web/tests/fixtures/store-discipline-harness.ts
+++ b/web/tests/fixtures/store-discipline-harness.ts
@@ -131,6 +131,16 @@ declare global {
       exercise: (database: string) => Promise<string[]>;
       /** Write a place and preferences and leave them there, for the raw reads. */
       seed: (database: string) => Promise<string[]>;
+      /**
+       * Attach an owner to the workspace — everything a sign-in does.
+       *
+       * SPEC-0011 REQ "Signing In Is Not a Sync Trigger": completing a
+       * sign-in attaches an owner and "MUST NOT transmit any place record by
+       * itself". There is no sign-in yet, and `ownerId` is the whole of what
+       * one would change, so this writes it and the test asserts nothing
+       * went out.
+       */
+      attachOwner: (database: string, ownerId: string) => Promise<string[]>;
       /** A request from code that is not the store, as any real page has. */
       unrelated: () => Promise<void>;
       /** Every attempt seen, tagged with where it came from. */
@@ -195,6 +205,51 @@ window.__discipline = {
       }),
     );
     note("putPreferences", await store.putPreferences({ showUnverified: false }));
+    store.close();
+    return outcomes;
+  },
+
+  attachOwner: async (database, ownerId) => {
+    const store = new DurableStore({ databaseName: database });
+    const outcomes: string[] = [];
+    const note = (label: string, result: { kind: string }) => {
+      outcomes.push(`${label}:${result.kind}`);
+    };
+
+    note("open", await store.open());
+    /*
+     * Written through the raw path rather than a store method, because the
+     * store has no owner operation — ADR-0008 reserves `ownerId` and stage 1
+     * never sets it. What matters for the requirement is that the field
+     * changes and that the places already there are untouched.
+     */
+    const loaded = await store.load();
+    if (loaded.kind === "ok") {
+      await new Promise<void>((resolve, reject) => {
+        const opening = indexedDB.open(database);
+        opening.onsuccess = () => {
+          const db = opening.result;
+          const transaction = db.transaction("workspace", "readwrite");
+          transaction
+            .objectStore("workspace")
+            .put({ ...loaded.value.workspace, ownerId }, "self");
+          transaction.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          transaction.onerror = () => {
+            db.close();
+            reject(transaction.error ?? new Error("owner write failed"));
+          };
+        };
+        opening.onerror = () => {
+          reject(opening.error ?? new Error("owner open failed"));
+        };
+      });
+      outcomes.push("attach:ok");
+    }
+
+    note("reload", await store.load());
     store.close();
     return outcomes;
   },


### PR DESCRIPTION
Closes #148
Part of #143

Implements SPEC-0011 REQ "The Hash Owns the Plan, the Store Owns the Player", REQ "Signing In Is Not a Sync Trigger".

## This also settles #135

#135 asked where leaf assignments live, because `Plan` carried none, `RollupRequest` carried them *beside* the plan, and SPEC-0002 encoded neither. **SPEC-0011 answered it**: the hash carries "target, quantity, method and recipe selections, and leaf assignments". So `Plan` is the shareable unit and assignments are part of it. #135 can close as resolved by spec.

## The boundary

**The hash gains assignments.** A link that dropped them would share a plan whose leaves land nowhere.

**`planToWire` deliberately does not send them.** That is the shape `resolve` parses, and stage 1 has no concept of a base — `internal/bridge.Plan` carries target, quantity, methods and recipes and nothing else. Assignments reach the domain on the stage-2 rollup request. Sending them anyway would be *harmless* today (the Go decoder ignores unknown fields on a plan) and wrong in the way that matters: it would say stage 1 takes an input it does not take.

**The decoder reads five fields and has nowhere to put a sixth.** A hash carrying `ticks` or `notes` is not rejected — SPEC-0005 requires an *undecodable* hash yield the empty plan, and a valid plan with extra keys is not undecodable. The keys simply never reach a `Plan`. That is the cheapest way to honour *"no hash-derived value may be written to the store as though the player authored it"*: the decoder has no vocabulary for one.

## Which direction is guarded hardest

Decoding. A leaked note is visible the first time someone reads a link. **A decoded hash quietly authoring a place record is not visible at all**, and it is exactly the change someone makes while trying to make sharing "work better".

The encode test populates the store with a place carrying a name, notes, tags, ticks *and* stocked quantities before encoding — the acceptance criterion is explicit that it "needs notes and ticks present, or it proves nothing", and a hash encoded from an empty session contains no note for the trivial reason that there was none.

## Sign-in is the transition, not the steady state

The store's discipline suite already proves no store path reaches the network. What the criterion asks for is *the moment of authentication*. There is no sign-in yet and `ownerId` is the whole of what one would change, so the test writes it onto a workspace with places present and asserts the recorder saw nothing — and that the places are still there afterwards.

## The design README

Line 37 listed *todo checks* among hash contents and predates ADR-0008. Corrected **in favour of ADR-0008 with the reasoning recorded**, per the criterion, rather than the line quietly dropped: ticks describe what someone has built at a base, not what they asked the planner for, so sharing a link would hand the recipient someone else's progress and receiving one would overwrite theirs.

"No localStorage" is kept and narrowed — ADR-0008 lifted it for durable player data only, and that store is IndexedDB. Plan state keeps the original rule. The adjacent **State Management** paragraph has the same staleness and is pointed at rather than left to be rediscovered.

`docs/design/` is not a protected path; `docs/adrs` and `docs/openspec/specs` are, and neither is touched.

## Verification

**343 tests pass** (up from 315), 6 new. lint, lint:css, typecheck, format:check, check:tokens, build all clean. **61/61 mutations red**, two new:

| Mutation | Catches |
|---|---|
| the hash stops carrying assignments | a link that shares a plan landing nowhere |
| **the plan decoder starts accepting a player's ticks** | the invisible direction |

No protected paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)