### PR TITLE
feat(web): the shell opens on bases, with surfaces as view state

### DIFF
--- a/web/scripts/mutation-check.sh
+++ b/web/scripts/mutation-check.sh
@@ -60,7 +60,9 @@ HASH="src/boundary/plan-hash.ts"
 PLANSTATE="src/boundary/plan.ts"
 
 MUTABLE="$MUTABLE $LAYOUT $TREE $METHODS $CONTROL $ASSIGN $BASES $PLANNERCARD $POWERBLOCK"
-MUTABLE="$MUTABLE $HASH $PLANSTATE"
+SURFACES="src/shell/surfaces.ts"
+
+MUTABLE="$MUTABLE $HASH $PLANSTATE $SURFACES"
 MUTABLE="$MUTABLE $RESOLVE $STORED"
 
 # shellcheck disable=SC2086
@@ -679,6 +681,29 @@ check "the plan decoder starts accepting a player's ticks" \
   "      assignments: assignments.overrides,
       ...(raw[\"ticks\"] === undefined ? {} : { ticks: raw[\"ticks\"] }),
     },"
+
+# ----------------------------------------------------------------------
+# The shell's surfaces.
+#
+# The second mutation is the one the requirement is really about: a
+# switcher that hid a surface until its data arrived would look correct on
+# a fast connection and move controls under someone's cursor on a slow one.
+# ----------------------------------------------------------------------
+
+check "the shell opens on the planner instead of bases" \
+  tests/shell/surfaces.spec.ts "$SURFACES" \
+  'export const ENTRY_SURFACE: SurfaceId = "bases";' \
+  'export const ENTRY_SURFACE: SurfaceId = "planner";'
+
+check "a surface leaves the switcher while the module is unavailable" \
+  tests/shell/surfaces.spec.ts "$SHELL" \
+  "          {SURFACES.map((surface) => (" \
+  "          {SURFACES.filter((shown) => !shown.needsModule).map((surface) => ("
+
+check "switching surface leaves focus on the switcher" \
+  tests/shell/surfaces.spec.ts "$SHELL" \
+  "    surfaceRegion.current?.focus();" \
+  "    void surfaceRegion.current;"
 
 echo
 if [ "$failures" -gt 0 ]; then

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -2,6 +2,7 @@ import {
   lazy,
   Suspense,
   useCallback,
+  useEffect,
   useId,
   useMemo,
   useRef,
@@ -49,6 +50,7 @@ const TreeCanvas = lazy(async () => ({
 }));
 import { DataCustody } from "./DataCustody";
 import { StoredPlaces } from "./StoredPlaces";
+import { SURFACES } from "./surfaces";
 import { ViewPreferences } from "./ViewPreferences";
 
 /*
@@ -253,6 +255,29 @@ function Chrome({
   readonly store: DurableStore;
 }): ReactNode {
   const state = useViewState();
+  const dispatch = useViewDispatch();
+
+  /*
+   * Focus follows the surface change.
+   *
+   * SPEC-0011 Focus Management: "Switching surface MUST move focus to the
+   * newly selected surface's region rather than leaving it on the switcher,
+   * and MUST NOT drop focus to the document body."
+   *
+   * Skipped on the first render. Moving focus into the page on load steals
+   * it from wherever the browser put it and is the behaviour screen-reader
+   * users report as a page that "jumps" — the requirement is about a
+   * change, and the first render is not one.
+   */
+  const surfaceRegion = useRef<HTMLElement | null>(null);
+  const shownSurface = useRef<string | null>(null);
+  useEffect(() => {
+    const first = shownSurface.current === null;
+    const changed = shownSurface.current !== state.surface;
+    shownSurface.current = state.surface;
+    if (first || !changed) return;
+    surfaceRegion.current?.focus();
+  }, [state.surface]);
 
   /*
    * Per-node method overrides: plan state, held here rather than in
@@ -395,85 +420,125 @@ function Chrome({
         <h2>NMS Base Planner</h2>
       </header>
 
+      {/*
+        The one navigation landmark. SPEC-0011: the shell "MUST expose
+        exactly one `role="navigation"` landmark, named, containing the
+        surface controls. Adding a surface MUST NOT add a second navigation
+        landmark", and SPEC-0010 defers to this one rather than adding its
+        own.
+
+        Every surface is listed unconditionally, including one that needs a
+        module which may still be downloading. A switcher that shrank while
+        the binary loaded would move controls under someone's cursor
+        mid-click, which is why SPEC-0011 requires the set not change under
+        the player.
+      */}
       <nav className="shell-nav" aria-label="Surfaces">
         <ul className="control-row">
-          <li>
-            <button
-              type="button"
-              className="control control-sm interactive"
-              aria-current="page"
-            >
-              Plan
-            </button>
-          </li>
+          {SURFACES.map((surface) => (
+            <li key={surface.id}>
+              <button
+                type="button"
+                className="control control-sm interactive"
+                aria-current={state.surface === surface.id ? "page" : undefined}
+                onClick={() => {
+                  dispatch({ type: "selectSurface", surface: surface.id });
+                }}
+              >
+                {surface.label}
+              </button>
+            </li>
+          ))}
         </ul>
       </nav>
 
       <main className="shell-main">
-        <PlanForm onRecompute={onRecompute} />
-        <section className="panel" aria-label="Figures">
-          <Figures resolution={resolution} />
-        </section>
-
         {/*
-          The canvas sits beside the figure list rather than replacing it,
-          for one story.
+          One surface at a time, chosen from view state.
 
-          SPEC-0006 puts the canvas where the flat list is, and that is
-          where it will end up. But the list's rows are currently what the
-          SPEC-0005 accessibility suite drives — the focus trap, the
-          selection ring and the live region's invoker are all tested
-          through `.figure-row` — and the canvas card has no control to open
-          until the method-selection story lands. Removing the list now
-          would leave those requirements untested in between, which is a
-          worse trade than a surface that shows its figures twice for a
-          release or two.
+          SPEC-0011 REQ "The Shell Opens on Bases and Renders Without the
+          Domain": the entry surface is bases, and it "MUST be complete and
+          operable with the module unavailable, unreachable, or still
+          loading". Nothing in this branch crosses the boundary — places
+          come from the durable store — so it renders whether the binary
+          arrives or not.
+
+          Each surface region is the focus target for a surface change and
+          carries tabIndex={-1} so it can take focus programmatically
+          without becoming a tab stop of its own.
         */}
-        {resolution.status === "resolved" && (
-          <section className="panel" aria-label="Tree">
-            <Suspense
-              fallback={<StatusBadge status="pending" detail="loading the canvas" />}
+        {state.surface === "bases" ? (
+          <section
+            className="surface"
+            aria-label="Bases"
+            tabIndex={-1}
+            ref={surfaceRegion}
+          >
+            <section className="panel" aria-label="Saved places">
+              <StoredPlaces data={stored} target={state.inputs.target} />
+            </section>
+
+            <section className="panel" aria-label="Your data">
+              <DataCustody data={stored} />
+            </section>
+
+            {/*
+              `data-saving` reports whether a preference write is still in
+              flight. It carries no user-facing claim — SPEC-0009 REQ
+              "Storage Is Evictable" governs what may be *said* about stored
+              data, and that indication belongs to the data-custody story
+              rather than here.
+
+              Issue numbers are spelled without the leading hash in this
+              file. check-tokens.sh matches a hash followed by three to
+              eight hex digits, and plenty of issue numbers are exactly
+              that — so the reference reads as a colour literal and fails
+              the gate.
+            */}
+            <section
+              className="panel"
+              aria-label="Preferences"
+              data-saving={String(stored.saving)}
             >
-              <TreeCanvas
-                graph={resolution.graph}
-                onSelectMethod={onSelectMethod}
-                assignments={assignments}
-                onAssign={onAssign}
-                bases={bases}
-              />
-            </Suspense>
+              <ViewPreferences />
+            </section>
+          </section>
+        ) : (
+          <section
+            className="surface"
+            aria-label="Planner"
+            tabIndex={-1}
+            ref={surfaceRegion}
+          >
+            <PlanForm onRecompute={onRecompute} />
+            <section className="panel" aria-label="Figures">
+              <Figures resolution={resolution} />
+            </section>
+
+            {/*
+              The canvas sits beside the figure list rather than replacing
+              it. The list's rows are what the SPEC-0005 accessibility suite
+              drives — the focus trap, the selection ring and the live
+              region's invoker all run through `.figure-row` — so removing
+              it would leave those requirements untested.
+            */}
+            {resolution.status === "resolved" && (
+              <section className="panel" aria-label="Tree">
+                <Suspense
+                  fallback={<StatusBadge status="pending" detail="loading the canvas" />}
+                >
+                  <TreeCanvas
+                    graph={resolution.graph}
+                    onSelectMethod={onSelectMethod}
+                    assignments={assignments}
+                    onAssign={onAssign}
+                    bases={bases}
+                  />
+                </Suspense>
+              </section>
+            )}
           </section>
         )}
-
-        <section className="panel" aria-label="Saved places">
-          <StoredPlaces data={stored} target={state.inputs.target} />
-        </section>
-
-        <section className="panel" aria-label="Your data">
-          <DataCustody data={stored} />
-        </section>
-
-        {/*
-          `data-saving` reports whether a preference write is still in
-          flight. It carries no user-facing claim — SPEC-0009 REQ "Storage
-          Is Evictable" governs what may be *said* about stored data, and
-          that indication belongs to the data-custody story rather than
-          here.
-
-          Issue numbers are spelled without the leading hash in this file.
-          check-tokens.sh matches a hash followed by three to eight hex
-          digits, and plenty of issue numbers are exactly that — so the
-          reference reads as a colour literal and fails the gate. Caught in
-          CI after passing locally, and then again by the comment written to
-          explain it, which had quoted the offending form.
-        */}
-        <section
-          className="panel"
-          aria-label="Preferences"
-          data-saving={String(stored.saving)}
-        >
-          <ViewPreferences />
-        </section>
       </main>
 
       <footer className="shell-footer">

--- a/web/src/shell/surfaces.ts
+++ b/web/src/shell/surfaces.ts
@@ -1,0 +1,54 @@
+/*
+ * The surfaces the shell switches between.
+ *
+ * Governing: ADR-0010 (places first and the shell), SPEC-0011 REQ "The
+ * Shell Opens on Bases and Renders Without the Domain", REQ "Surfaces Are
+ * Shell View State", SPEC-0005 REQ "Module Loading"
+ *
+ * A list rather than a router. SPEC-0011: "Surface selection MUST be view
+ * state the shell holds. The application MUST NOT introduce a router
+ * library." Two surfaces and no URL segment do not need one, and a router
+ * would put a second owner of navigation state next to the URL hash, which
+ * ADR-0002 already owns for the plan.
+ *
+ * `needsModule` is what makes the switcher stable. SPEC-0011 requires that
+ * "a surface whose data is unavailable MUST present its own empty or
+ * loading state rather than being absent from the switcher, so the set of
+ * surfaces does not change under the player" — a list that shrank while the
+ * WASM binary was still downloading would move controls under someone's
+ * cursor mid-click.
+ */
+
+export const SURFACES = [
+  {
+    id: "bases",
+    label: "Bases",
+    /**
+     * The entry surface, and the one that must render with no module.
+     *
+     * SPEC-0011: a player "MUST be able to create a place, name it, and see
+     * it listed with the module never having loaded". Places live in the
+     * durable store; nothing here crosses the boundary.
+     */
+    needsModule: false,
+  },
+  {
+    id: "planner",
+    label: "Planner",
+    /**
+     * Every figure on this surface comes from the domain, so it has nothing
+     * to show until the module answers. It stays in the switcher regardless
+     * and presents its own pending state when selected.
+     */
+    needsModule: true,
+  },
+] as const;
+
+export type SurfaceId = (typeof SURFACES)[number]["id"];
+
+/** The entry surface. SPEC-0011: "The entry surface MUST be the bases surface." */
+export const ENTRY_SURFACE: SurfaceId = "bases";
+
+export function isSurfaceId(value: unknown): value is SurfaceId {
+  return SURFACES.some((surface) => surface.id === value);
+}

--- a/web/src/state/view-state.ts
+++ b/web/src/state/view-state.ts
@@ -20,7 +20,24 @@
  * makes of it at the moment of a crossing, and it is not kept.
  */
 
+import { ENTRY_SURFACE, type SurfaceId } from "../shell/surfaces";
+
 export interface ViewState {
+  /**
+   * Which surface is showing.
+   *
+   * Interface state, and the sixth key this type has ever had. SPEC-0011
+   * REQ "Surfaces Are Shell View State" puts surface selection here rather
+   * than in a router, and it is the same kind of thing as `selection`: what
+   * the player is looking at, not what the domain computed.
+   *
+   * The shape test in tests/shell/view-state.spec.ts asserts the key set,
+   * so this field arrived as a visible diff — which is what that test is
+   * for. What it forbids is a field a plan, a graph or a derived quantity
+   * could occupy, and a surface id is a closed union of two strings.
+   */
+  readonly surface: SurfaceId;
+
   /** Which node the user has selected, if any. */
   readonly selection: string | null;
 
@@ -51,6 +68,7 @@ export interface ViewState {
 }
 
 export const INITIAL_VIEW_STATE: ViewState = Object.freeze({
+  surface: ENTRY_SURFACE,
   selection: null,
   collapsed: Object.freeze({}),
   inputs: Object.freeze({ target: "", quantity: "1" }),
@@ -59,6 +77,7 @@ export const INITIAL_VIEW_STATE: ViewState = Object.freeze({
 });
 
 export type ViewAction =
+  | { readonly type: "selectSurface"; readonly surface: SurfaceId }
   | { readonly type: "select"; readonly nodeId: string | null }
   | { readonly type: "toggleCollapse"; readonly sectionId: string }
   | {
@@ -77,6 +96,9 @@ export type ViewAction =
 
 export function viewReducer(state: ViewState, action: ViewAction): ViewState {
   switch (action.type) {
+    case "selectSurface":
+      return { ...state, surface: action.surface };
+
     case "select":
       return { ...state, selection: action.nodeId };
 

--- a/web/src/styles/shell.css
+++ b/web/src/styles/shell.css
@@ -142,3 +142,28 @@
 .status-pending {
   color: var(--text-muted);
 }
+
+/*
+ * A surface region.
+ *
+ * Governing: SPEC-0011 REQ "Surfaces Are Shell View State", Focus Management
+ *
+ * Layout only, and it must generate a box. `display: contents` was the
+ * first attempt and is wrong here: an element that generates no box is not
+ * visible to the model Playwright's `toBeVisible` and a screen reader's
+ * region navigation both use, so the region announced itself as absent.
+ *
+ * It carries `tabIndex={-1}` so a surface change can move focus into it,
+ * and the outline is suppressed because that focus is programmatic — a
+ * region that flashed a focus ring on every switch would be showing the
+ * player a ring they cannot have moved to.
+ */
+.surface {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.surface:focus {
+  outline: none;
+}

--- a/web/tests/canvas/assignment.spec.ts
+++ b/web/tests/canvas/assignment.spec.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 
 import { expect, test, type Page } from "@playwright/test";
 
+import { openPlanner, openSurface } from "../helpers/surfaces";
+
 import { basesFrom, slotFor, UNNAMED_PLACE } from "../../src/canvas/bases";
 import type { PlaceRecord } from "../../src/store";
 import { countCrossings, crossings } from "../helpers/crossings";
@@ -361,7 +363,14 @@ test.describe("in the shell", () => {
         }),
     );
     await page.reload({ waitUntil: "load" });
+    /*
+     * The reload lands on the entry surface, because the selected surface is
+     * view state and is deliberately not persisted — a link to the app opens
+     * where SPEC-0011 says it opens. So the place is created on bases, which
+     * is where the control lives, and the planner is selected afterwards.
+     */
     await createPlace(page, PLACE);
+    await openPlanner(page);
     await resolve(page, "ANTIMATTER");
   });
 
@@ -370,7 +379,14 @@ test.describe("in the shell", () => {
    * "A plan MUST remain resolvable when it references no places at all."
    */
   test("a plan resolves against a workspace with no places", async ({ page }) => {
+    /*
+     * Deleting a place is a bases control, so this leaves the planner and
+     * comes back — which is also the only route a player has to the state
+     * this test is about.
+     */
+    await openSurface(page, "Bases");
     await page.getByRole("button", { name: `Delete ${PLACE}` }).click();
+    await openPlanner(page);
 
     const leaf = await aLeafName(page);
     await page

--- a/web/tests/canvas/degraded.spec.ts
+++ b/web/tests/canvas/degraded.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+import { openPlanner } from "../helpers/surfaces";
+
 /*
  * What the canvas does when it cannot draw.
  *
@@ -34,6 +36,7 @@ test("without its layout engine the canvas says so instead of piling the nodes u
 }) => {
   await page.route(ELK_CHUNK, (route) => route.abort());
   await page.goto("/");
+  await openPlanner(page);
   await recompute(page, "ANTIMATTER");
 
   const canvas = page.getByRole("region", CANVAS);
@@ -53,6 +56,7 @@ test("the figures are unaffected, and the canvas does not claim they are wrong",
 }) => {
   await page.route(ELK_CHUNK, (route) => route.abort());
   await page.goto("/");
+  await openPlanner(page);
   await recompute(page, "ANTIMATTER");
 
   const canvas = page.getByRole("region", CANVAS);
@@ -76,6 +80,7 @@ test("the message is announced, not only drawn", async ({ page }) => {
    */
   await page.route(ELK_CHUNK, (route) => route.abort());
   await page.goto("/");
+  await openPlanner(page);
   await recompute(page, "ANTIMATTER");
 
   const message = page.getByRole("status").filter({ hasText: /could not be laid out/i });
@@ -92,6 +97,7 @@ test("with the engine available the canvas draws, so the tests above are about t
    * first test would pass for the wrong reason and this one would fail.
    */
   await page.goto("/");
+  await openPlanner(page);
   await recompute(page, "ANTIMATTER");
 
   const canvas = page.getByRole("region", CANVAS);

--- a/web/tests/canvas/edges.spec.ts
+++ b/web/tests/canvas/edges.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+import { openPlanner } from "../helpers/surfaces";
+
 import { toCanvasModel } from "../../src/canvas/graph-model";
 import { asQuantity } from "../../src/boundary/quantity";
 import { countCrossings, payloadEdges } from "../helpers/crossings";
@@ -40,6 +42,7 @@ async function resolve(page: Page, target: string): Promise<void> {
 test.beforeEach(async ({ page }) => {
   await countCrossings(page);
   await page.goto("/");
+  await openPlanner(page);
 });
 
 /* ----------------------------------------------------------------------

--- a/web/tests/canvas/layout.spec.ts
+++ b/web/tests/canvas/layout.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+import { openPlanner } from "../helpers/surfaces";
+
 import { toCanvasModel, toLayoutInput } from "../../src/canvas/graph-model";
 import { NODE_HEIGHT, NODE_WIDTH, toElkGraph } from "../../src/canvas/layout";
 import { asQuantity } from "../../src/boundary/quantity";
@@ -195,6 +197,7 @@ test("changing the target quantity does not move a single node", async ({ page }
    * a sub-pixel amount for a small quantity change and pass a tolerance.
    */
   await page.goto("/");
+  await openPlanner(page);
   await page.getByLabel("Target").fill("ULTRAPROD2");
 
   const atOne = await positionsFor(page, "1");
@@ -217,6 +220,7 @@ test("the totals did change, so the comparison above means something", async ({
    * broken application.
    */
   await page.goto("/");
+  await openPlanner(page);
   await page.getByLabel("Target").fill("ULTRAPROD2");
 
   await positionsFor(page, "1");

--- a/web/tests/canvas/method-control.spec.ts
+++ b/web/tests/canvas/method-control.spec.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 
 import { expect, test, type Page } from "@playwright/test";
 
+import { openPlanner } from "../helpers/surfaces";
+
 import { METHOD_ORDER, methodOptions } from "../../src/canvas/methods";
 import { countCrossings, crossings } from "../helpers/crossings";
 
@@ -193,6 +195,7 @@ test.describe("in the shell", () => {
   test.beforeEach(async ({ page }) => {
     await countCrossings(page);
     await page.goto("/");
+    await openPlanner(page);
     await resolve(page, "ANTIMATTER");
   });
 

--- a/web/tests/canvas/node-card.spec.ts
+++ b/web/tests/canvas/node-card.spec.ts
@@ -1,6 +1,8 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test, type Locator, type Page } from "@playwright/test";
 
+import { openPlanner } from "../helpers/surfaces";
+
 /*
  * What a node says about itself.
  *
@@ -46,6 +48,7 @@ function card(page: Page, name: string): Locator {
 test.describe("the real payload", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
+    await openPlanner(page);
   });
 
   test("the method is a glyph and a word, not a colour", async ({ page }) => {

--- a/web/tests/canvas/rendering.spec.ts
+++ b/web/tests/canvas/rendering.spec.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 
 import { expect, test, type Page } from "@playwright/test";
 
+import { openPlanner, openSurface } from "../helpers/surfaces";
+
 import { countCrossings, crossings, payloadOrder } from "../helpers/crossings";
 
 /*
@@ -33,6 +35,7 @@ async function resolve(page: Page, target: string): Promise<void> {
 test.beforeEach(async ({ page }) => {
   await countCrossings(page);
   await page.goto("/");
+  await openPlanner(page);
 });
 
 test("one crossing renders the whole tree", async ({ page }) => {
@@ -215,7 +218,14 @@ test("the canvas formats totals the way the player asked, like the list beside i
   ).toBeGreaterThan(0);
   expect(grouped(await cardFigures.allInnerTexts()).length).toBeGreaterThan(0);
 
+  /*
+   * The preference lives on bases and the figures on the planner, so
+   * changing it is a two-surface flow. That is the shape of the product now:
+   * a display preference is player-owned state and sits with the rest of it.
+   */
+  await openSurface(page, "Bases");
   await page.getByLabel("Group digits").uncheck();
+  await openPlanner(page);
 
   await expect
     .poll(async () => grouped(await listFigures.allInnerTexts()).length)

--- a/web/tests/helpers/surfaces.ts
+++ b/web/tests/helpers/surfaces.ts
@@ -1,0 +1,26 @@
+/*
+ * Reaching a surface in the shell.
+ *
+ * Governing: SPEC-0011 REQ "The Shell Opens on Bases and Renders Without
+ * the Domain", REQ "Surfaces Are Shell View State"
+ *
+ * The entry surface is bases, so a test that wants the plan form has to
+ * switch first. This exists so that fact lives in one place: when the
+ * surface set changes again, the suite follows from here rather than from
+ * ten separate `goto` calls.
+ */
+
+import { expect, type Page } from "@playwright/test";
+
+export async function openSurface(page: Page, name: string): Promise<void> {
+  await page
+    .getByRole("navigation", { name: "Surfaces" })
+    .getByRole("button", { name, exact: true })
+    .click();
+  await expect(page.getByRole("region", { name, exact: true })).toBeVisible();
+}
+
+/** The surface carrying the target control, the figures and the canvas. */
+export async function openPlanner(page: Page): Promise<void> {
+  await openSurface(page, "Planner");
+}

--- a/web/tests/shell/a11y-baseline.spec.ts
+++ b/web/tests/shell/a11y-baseline.spec.ts
@@ -1,6 +1,8 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test, type Page } from "@playwright/test";
 
+import { openPlanner } from "../helpers/surfaces";
+
 import { ICON_ONLY_CONTROL_AUDIT } from "../helpers/accessible-name";
 import { STATUSES } from "../../src/shell/StatusBadge";
 
@@ -39,6 +41,7 @@ async function resolveAPlan(page: Page): Promise<void> {
 
 test.beforeEach(async ({ page }) => {
   await page.goto(SHELL);
+  await openPlanner(page);
 });
 
 /* ----------------------------------------------------------------------

--- a/web/tests/shell/a11y-primitives.spec.ts
+++ b/web/tests/shell/a11y-primitives.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+import { openPlanner } from "../helpers/surfaces";
+
 import { STATUSES } from "../../src/shell/StatusBadge";
 
 /*
@@ -13,6 +15,7 @@ import { STATUSES } from "../../src/shell/StatusBadge";
 
 async function openTheFirstNodePopover(page: Page): Promise<void> {
   await page.goto("/");
+  await openPlanner(page);
   await page.getByLabel("Target").fill("ANTIMATTER");
   await page.getByRole("button", { name: "Recompute" }).click();
   await expect(page.getByRole("heading", { level: 3 })).toBeVisible({ timeout: 20_000 });
@@ -100,6 +103,7 @@ test("Tab stays inside the popover while it is open", async ({ page }) => {
 
 test("the live region announces on recompute and not on render", async ({ page }) => {
   await page.goto("/");
+  await openPlanner(page);
 
   const region = page.getByRole("status");
   await expect(region).toBeAttached();
@@ -120,6 +124,7 @@ test("the live region announces on recompute and not on render", async ({ page }
 
 test("the announcement names what changed", async ({ page }) => {
   await page.goto("/");
+  await openPlanner(page);
   await page.getByLabel("Target").fill("ANTIMATTER");
   await page.getByRole("button", { name: "Recompute" }).click();
 
@@ -135,6 +140,7 @@ test("a preference change does not announce", async ({ page }) => {
    * that do not correspond to a computation.
    */
   await page.goto("/");
+  await openPlanner(page);
   await page.getByLabel("Target").fill("ANTIMATTER");
   await page.getByRole("button", { name: "Recompute" }).click();
 
@@ -159,6 +165,7 @@ test("every status carries a signal other than its colour", async ({ page }) => 
   expect(STATUSES.length).toBeGreaterThan(0);
 
   await page.goto("/");
+  await openPlanner(page);
   await page.getByLabel("Quantity").fill("not a quantity");
 
   const badge = page.locator(".status-badge").first();

--- a/web/tests/shell/shell.spec.ts
+++ b/web/tests/shell/shell.spec.ts
@@ -1,6 +1,8 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test, type Page } from "@playwright/test";
 
+import { openPlanner } from "../helpers/surfaces";
+
 /*
  * Governing: ADR-0004 (React view layer), SPEC-0005 Accessibility
  * Requirements
@@ -36,6 +38,7 @@ async function resolveAPlan(page: Page, target = "ANTIMATTER"): Promise<void> {
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/");
+  await openPlanner(page);
 });
 
 test("all four landmarks are present, once each", async ({ page }) => {
@@ -100,6 +103,7 @@ test("figures are pending rather than zero while the module loads", async ({ pag
     await route.continue();
   });
   await page.goto("/");
+  await openPlanner(page);
 
   await page.getByLabel("Target").fill("ANTIMATTER");
   await page.getByRole("button", { name: "Recompute" }).click();

--- a/web/tests/shell/stored-preferences.spec.ts
+++ b/web/tests/shell/stored-preferences.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+import { openPlanner, openSurface } from "../helpers/surfaces";
+
 import { fromStored, toStored, differ } from "../../src/state/preferences";
 import { INITIAL_VIEW_STATE } from "../../src/state/view-state";
 import {
@@ -267,7 +269,14 @@ test("a place with no stocked quantity renders absent, not zero", async ({ page 
   ]);
   await page.reload();
 
+  /*
+   * The target control lives on the planner surface and the saved-place
+   * list on bases, so this is a two-surface flow now — which is what a
+   * player does: choose what to build, then look at what they have.
+   */
+  await openPlanner(page);
   await page.getByLabel("Target").fill("ANTIMATTER");
+  await openSurface(page, "Bases");
 
   const row = page
     .getByRole("region", { name: "Saved places" })
@@ -305,7 +314,14 @@ test("a stocked zero is shown as zero, because the player entered it", async ({
   ]);
   await page.reload();
 
+  /*
+   * The target control lives on the planner surface and the saved-place
+   * list on bases, so this is a two-surface flow now — which is what a
+   * player does: choose what to build, then look at what they have.
+   */
+  await openPlanner(page);
   await page.getByLabel("Target").fill("ANTIMATTER");
+  await openSurface(page, "Bases");
 
   const row = page
     .getByRole("region", { name: "Saved places" })

--- a/web/tests/shell/surfaces.spec.ts
+++ b/web/tests/shell/surfaces.spec.ts
@@ -1,0 +1,219 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+import { SURFACES } from "../../src/shell/surfaces";
+import { openSurface } from "../helpers/surfaces";
+
+/*
+ * Governing: ADR-0010 (places first and the shell), SPEC-0011 REQ "The
+ * Shell Opens on Bases and Renders Without the Domain", REQ "Surfaces Are
+ * Shell View State", Accessibility Requirements → ARIA Landmarks, Focus
+ * Management
+ *
+ * The claim with the most in it is the entry one. SPEC-0005 already loads
+ * the module lazily, so the shell *can* be interactive before it arrives —
+ * what SPEC-0011 adds is that the entry surface must be complete rather
+ * than merely present, "with no error and no loading state standing in for
+ * its content". A spinner on entry fails the requirement even though the
+ * page is technically interactive.
+ */
+
+/** The binary, blocked so the module never arrives. */
+const WASM = "**/planner.wasm";
+
+async function withoutModule(page: Page): Promise<void> {
+  await page.route(WASM, (route) => route.abort());
+}
+
+/* ----------------------------------------------------------------------
+ * Entry
+ * ------------------------------------------------------------------- */
+
+test("the shell opens on bases", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("region", { name: "Bases", exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("navigation", { name: "Surfaces" }).getByRole("button", {
+      name: "Bases",
+      exact: true,
+    }),
+  ).toHaveAttribute("aria-current", "page");
+});
+
+test("entry with no module is complete, interactive, and not an error", async ({
+  page,
+}) => {
+  /*
+   * The acceptance criterion is blunt about the failure mode: "A spinner on
+   * entry fails this." So this asserts the content is there *and* that no
+   * pending or error treatment is standing in for it.
+   */
+  await withoutModule(page);
+  await page.goto("/");
+
+  const bases = page.getByRole("region", { name: "Bases", exact: true });
+  await expect(bases).toBeVisible();
+
+  /* Its own controls work with the module never having arrived. */
+  await expect(bases.getByRole("region", { name: "Saved places" })).toBeVisible();
+  await expect(bases.getByRole("region", { name: "Your data" })).toBeVisible();
+  await expect(bases.getByLabel("Group digits")).toBeEnabled();
+
+  /* No loading state in place of content, and no error about the module. */
+  await expect(bases.getByText(/Pending/i)).toHaveCount(0);
+  await expect(bases.getByText(/could not|failed|unavailable|error/i)).toHaveCount(0);
+});
+
+test("entry with an empty workspace invites a place rather than showing zeroes", async ({
+  page,
+}) => {
+  await withoutModule(page);
+  await page.goto("/");
+
+  const saved = page.getByRole("region", { name: "Saved places" });
+  await expect(saved).toBeVisible();
+  await expect(saved.getByText(/nothing saved|no places|add a place/i)).toBeVisible();
+
+  /*
+   * Not a screen of zeroes. A count of 0 places is a true statement and the
+   * wrong thing to show someone who has never used the application.
+   */
+  await expect(saved.getByText(/^0$/)).toHaveCount(0);
+});
+
+/* ----------------------------------------------------------------------
+ * The switcher
+ * ------------------------------------------------------------------- */
+
+test("exactly one named navigation landmark exists on every surface", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  for (const surface of SURFACES) {
+    await openSurface(page, surface.label);
+    await expect(
+      page.getByRole("navigation"),
+      `${surface.label} has more than one navigation landmark`,
+    ).toHaveCount(1);
+    await expect(page.getByRole("navigation")).toHaveAttribute("aria-label", "Surfaces");
+  }
+});
+
+test("the switcher lists every surface with the module unavailable", async ({ page }) => {
+  /*
+   * SPEC-0011: "a surface whose data is unavailable MUST present its own
+   * empty or loading state rather than being absent from the switcher, so
+   * the set of surfaces does not change under the player." A switcher that
+   * shrank while the binary downloaded would move controls under someone's
+   * cursor mid-click.
+   */
+  await withoutModule(page);
+  await page.goto("/");
+
+  const nav = page.getByRole("navigation", { name: "Surfaces" });
+  await expect(nav.getByRole("button")).toHaveCount(SURFACES.length);
+
+  for (const surface of SURFACES) {
+    await expect(
+      nav.getByRole("button", { name: surface.label, exact: true }),
+      `${surface.label} vanished from the switcher`,
+    ).toBeVisible();
+  }
+});
+
+test("a surface that needs the module presents its own state rather than disappearing", async ({
+  page,
+}) => {
+  await withoutModule(page);
+  await page.goto("/");
+  await openSurface(page, "Planner");
+
+  const planner = page.getByRole("region", { name: "Planner", exact: true });
+  await expect(planner).toBeVisible();
+  /* Its own controls are there; it is the figures that have nothing yet. */
+  await expect(planner.getByLabel("Target")).toBeVisible();
+});
+
+test("no router package is installed", () => {
+  /*
+   * SPEC-0011: "The application MUST NOT introduce a router library."
+   * Checked against the manifest rather than by grepping imports — a router
+   * added and not yet imported is still a router in the tree.
+   */
+  const manifest = JSON.parse(
+    readFileSync(path.join(import.meta.dirname, "..", "..", "package.json"), "utf8"),
+  ) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+
+  const installed = [
+    ...Object.keys(manifest.dependencies ?? {}),
+    ...Object.keys(manifest.devDependencies ?? {}),
+  ];
+  expect(installed.length, "the manifest was not read").toBeGreaterThan(0);
+
+  for (const name of installed) {
+    expect(/router|wouter|\breach\b/i.test(name), `${name} is a router`).toBe(false);
+  }
+});
+
+/* ----------------------------------------------------------------------
+ * Focus
+ * ------------------------------------------------------------------- */
+
+test("switching surface moves focus into the new surface, not the switcher or the body", async ({
+  page,
+}) => {
+  /*
+   * SPEC-0011 Focus Management. Both halves matter: leaving focus on the
+   * switcher means a keyboard user tabs from the top of the page again, and
+   * dropping it to the body loses their place entirely.
+   */
+  await page.goto("/");
+
+  await page
+    .getByRole("navigation", { name: "Surfaces" })
+    .getByRole("button", { name: "Planner", exact: true })
+    .press("Enter");
+
+  await expect(page.getByRole("region", { name: "Planner", exact: true })).toBeFocused();
+
+  const active = await page.evaluate(() => document.activeElement?.tagName ?? "");
+  expect(active, "focus fell to the body").not.toBe("BODY");
+});
+
+test("entry does not steal focus", async ({ page }) => {
+  /*
+   * The companion to the test above. The requirement is about a *change*,
+   * and moving focus into the page on load is the behaviour that reads as a
+   * page jumping out from under someone.
+   */
+  await page.goto("/");
+  const active = await page.evaluate(
+    () => document.activeElement?.getAttribute("aria-label") ?? "",
+  );
+  expect(active).not.toBe("Bases");
+});
+
+/* ----------------------------------------------------------------------
+ * Accessibility over the whole switcher
+ * ------------------------------------------------------------------- */
+
+test("every surface passes a WCAG 2.1 AA audit", async ({ page }) => {
+  await page.goto("/");
+
+  for (const surface of SURFACES) {
+    await openSurface(page, surface.label);
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .analyze();
+    expect(
+      results.violations.map((violation) => `${surface.label}: ${violation.id}`),
+    ).toEqual([]);
+  }
+});

--- a/web/tests/shell/view-state.spec.ts
+++ b/web/tests/shell/view-state.spec.ts
@@ -48,6 +48,7 @@ test("the state's shape has nowhere to put a plan or a graph", () => {
     "inputs",
     "preferences",
     "selection",
+    "surface",
   ]);
 });
 


### PR DESCRIPTION
Closes #146
Part of #143

Implements SPEC-0011 REQ "The Shell Opens on Bases and Renders Without the Domain", REQ "Surfaces Are Shell View State".

> **Stacked on #160.** Base is `feat/148-state-ownership…`, not `main` — both touch `scripts/mutation-check.sh` at the same append point, and an append-vs-append conflict is worse than a deliberate rebase. **Merge #160 first.**

## Entry renders without the domain

Nothing on the bases surface crosses the boundary — places come from the durable store — so the criterion *"a spinner on entry fails this"* is met by the surface **having nothing to wait for**, not by waiting quickly. The test blocks `planner.wasm` outright and asserts the content is there, the controls are enabled, and no pending or error treatment is standing in for it.

## Surface selection is a sixth key on `ViewState`

It is the same kind of thing as `selection` — what the player is looking at, not what the domain computed — and it is a closed union of two strings. The shape test asserts the key set, so this arrived as a **visible diff**, which is what that test is for rather than something it forbids. No router: asserted against `package.json` rather than by grepping imports, because a router added and not yet imported is still a router in the tree.

## The switcher does not change under the player

Every surface is listed unconditionally, including one whose data has not arrived. A list that shrank while the binary downloaded would look correct on a fast connection and **move controls under someone's cursor mid-click** on a slow one. That is the second mutation below, and it is the one the requirement is really about.

## Two mistakes worth recording

**`.surface` was `display: contents` first.** That generates no box, so the region was invisible to the model *both* Playwright's `toBeVisible` and a screen reader's region navigation use. Every test waiting for it hung for the full thirty seconds. It is a flex column now, and the comment says why.

**Splitting the surfaces separates controls that were on screen together.** The target control is on Planner; the saved-place list and display preferences are on Bases. Ten specs needed a surface switch, and three are genuinely two-surface flows now — set a target, then go look at your places; change a display preference, then come back to the figures. That is what a player does, so the tests do it rather than being given a back door.

One consequence worth a second opinion: **"Group digits" now lives a surface away from the figures it groups.** It is player-owned state and sits with the rest of it, which is defensible — but if you would rather display preferences sat in the shell chrome and applied everywhere, that is a small change and better made now than later.

## Scope

Two surfaces, Bases and Planner, both of which exist in code. SPEC-0010's atlas is its own story; listing an empty surface for it would be inventing one. The cross-navigation links the criterion mentions ("view planner →") are **conditional** in the requirement — *if* such navigation exists it must be a content link in `main` — so the invariant is asserted (exactly one navigation landmark on every surface) rather than links invented without a design.

## Verification

**353 tests pass** (up from 343), 10 new. lint, lint:css, typecheck, format:check, check:tokens, build all clean. **64/64 mutations red**, three new:

| Mutation | Catches |
|---|---|
| the shell opens on the planner instead of bases | the entry requirement |
| **a surface leaves the switcher while the module is unavailable** | the stable-set requirement |
| switching surface leaves focus on the switcher | focus management |

No protected paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)