### PR TITLE
feat(web): the catalogue crosses the boundary, and the target is a search

### DIFF
--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -49,7 +49,7 @@ import (
 // that does not know about `configured` reads a base with a zero site as
 // one configured at class "" for zero seconds, which is exactly the zero
 // SPEC-0011 REQ "A Place Is Creatable by Hand" forbids presenting.
-const ContractVersion = "1.3.0"
+const ContractVersion = "1.4.0"
 
 // Quantity is an exact quantity on the wire.
 //
@@ -113,9 +113,30 @@ type Envelope struct {
 // absent rather than present-and-empty. Exactly one is set by any entry
 // point this package exposes.
 type ResultPayload struct {
-	Graph *Graph `json:"graph,omitempty"`
-	Build *Build `json:"build,omitempty"`
-	Power *Power `json:"power,omitempty"`
+	Graph     *Graph     `json:"graph,omitempty"`
+	Build     *Build     `json:"build,omitempty"`
+	Power     *Power     `json:"power,omitempty"`
+	Catalogue *Catalogue `json:"catalogue,omitempty"`
+}
+
+// Catalogue is the searchable item list on the wire.
+//
+// Governing: SPEC-0011 REQ "The Catalogue Crosses the Boundary" — "for each
+// selectable item, its id and its display name".
+//
+// Nothing else. The view searches over this and sends back an id, so a
+// recipe, a method or a yield would be data the search does not use and the
+// view is not allowed to reason about anyway. Every item in the artifact is
+// listed: the domain decides what resolves, and a view that pre-filtered
+// would be deciding which items exist.
+type Catalogue struct {
+	Items []CatalogueItem `json:"items"`
+}
+
+// CatalogueItem is one selectable item: what to send, and what to show.
+type CatalogueItem struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 // ErrorPayload is the failure half.

--- a/internal/bridge/module.go
+++ b/internal/bridge/module.go
@@ -220,6 +220,32 @@ func (m *Module) loaded() (*domain.Tier1, bool) {
 	return m.artifact, m.artifact != nil
 }
 
+// Catalogue returns the selectable items, each as an id and a display name.
+//
+// Governing: SPEC-0011 REQ "The Catalogue Crosses the Boundary", SPEC-0002
+// REQ "Boundary Surface", REQ "Module Lifecycle and Readiness"
+//
+// Subject to the same not-ready handling as every other entry point: the
+// artifact is what makes the list, so before it loads there is no list, and
+// saying so with the readiness sentinel is what lets the view show a
+// loading state and retry rather than report an error.
+//
+// The argument is ignored. The catalogue takes no input — filtering is the
+// view's job, over a list it already holds, and a per-keystroke crossing is
+// what SPEC-0011 § Rate Limiting forbids.
+func (m *Module) Catalogue(_ string) Envelope {
+	artifact, ok := m.loaded()
+	if !ok {
+		return FailureFrom(fmt.Errorf("catalogue: %w", ErrNotReady))
+	}
+
+	items := make([]CatalogueItem, 0, len(artifact.Items))
+	for _, item := range artifact.Items {
+		items = append(items, CatalogueItem{ID: item.ID, Name: item.Name})
+	}
+	return Success(ResultPayload{Catalogue: &Catalogue{Items: items}})
+}
+
 // EntryPoints are the names the namespace object carries.
 //
 // Governing: SPEC-0002 REQ "Boundary Surface" — one named entry point per
@@ -229,7 +255,7 @@ func (m *Module) loaded() (*domain.Tier1, bool) {
 // Enumerated here rather than inline in the js shim so the surface is
 // listable from a plain test, and so adding one is a change to this list
 // rather than a change scattered through registration code.
-var EntryPoints = []string{"load", "ready", "resolve", "rollup", "power"}
+var EntryPoints = []string{"load", "ready", "resolve", "rollup", "power", "catalogue"}
 
 // Namespace is the single global name the module registers under.
 const Namespace = "nmsPlanner"
@@ -253,6 +279,8 @@ func (m *Module) Call(name, arg string) Envelope {
 		return m.Rollup(arg)
 	case "power":
 		return m.Power(arg)
+	case "catalogue":
+		return m.Catalogue(arg)
 	default:
 		return Failure(CodeMalformedInput,
 			fmt.Sprintf("%q is not an entry point on %s; expected one of %v", name, Namespace, EntryPoints))

--- a/internal/bridge/module_test.go
+++ b/internal/bridge/module_test.go
@@ -241,3 +241,84 @@ func TestMalformedPlanAtTheEntryPoint(t *testing.T) {
 		t.Errorf("the module broke after a malformed call: %+v", env.Error)
 	}
 }
+
+// SPEC-0011 REQ "The Catalogue Crosses the Boundary":
+// WHEN the catalogue is requested THEN the module returns each selectable
+// item's id and display name, through the same envelope every other entry
+// point uses.
+func TestCatalogueListsSelectableItems(t *testing.T) {
+	m := loadedModule(t)
+
+	env := m.Catalogue("")
+	if !env.OK {
+		t.Fatalf("catalogue failed: %+v", env.Error)
+	}
+	if env.Data.Catalogue == nil {
+		t.Fatal("catalogue returned no catalogue payload")
+	}
+	if len(env.Data.Catalogue.Items) == 0 {
+		t.Fatal("catalogue is empty, so nothing was listed")
+	}
+
+	// Every entry carries both halves. An id with no name is unsearchable by
+	// anyone who has not memorised the artifact, which is the failure
+	// SPEC-0011 REQ "Target Selection Is a Search Over Known Items" exists
+	// to prevent.
+	for _, item := range env.Data.Catalogue.Items {
+		if item.ID == "" {
+			t.Errorf("catalogue item with empty id: %+v", item)
+		}
+		if item.Name == "" {
+			t.Errorf("catalogue item %q has no display name", item.ID)
+		}
+	}
+
+	// And nothing else crosses. The view searches this and sends back an id;
+	// a recipe or a method here would be data it is not allowed to reason
+	// about anyway.
+	blob, err := bridge.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshalling: %v", err)
+	}
+	for _, absent := range []string{`"recipes"`, `"default_method"`, `"verified"`} {
+		if strings.Contains(string(blob), absent) {
+			t.Errorf("catalogue payload carries %s", absent)
+		}
+	}
+}
+
+// SPEC-0011 REQ "The Catalogue Crosses the Boundary":
+// WHEN the catalogue is requested before the module is ready THEN the
+// readiness sentinel is returned, so the view can present a loading state
+// and retry rather than reporting an error.
+func TestCatalogueBeforeReadyIsNotReady(t *testing.T) {
+	m := bridge.NewModule()
+
+	env := m.Catalogue("")
+	if env.OK {
+		t.Fatal("catalogue succeeded before the artifact loaded")
+	}
+	if env.Error == nil || env.Error.Code != bridge.CodeNotReady {
+		t.Errorf("catalogue before load = %+v, want %s", env.Error, bridge.CodeNotReady)
+	}
+}
+
+// SPEC-0002 REQ "Boundary Surface": adding an entry point is a change to the
+// enumerated surface, and the dispatcher must carry it.
+func TestCatalogueIsAnEntryPoint(t *testing.T) {
+	found := false
+	for _, name := range bridge.EntryPoints {
+		if name == "catalogue" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("EntryPoints = %v, missing catalogue", bridge.EntryPoints)
+	}
+
+	// Reachable by name, not only as a method — the js shim dispatches by
+	// string and nothing else.
+	if env := loadedModule(t).Call("catalogue", ""); !env.OK {
+		t.Errorf("Call(catalogue) failed: %+v", env.Error)
+	}
+}

--- a/web/scripts/mutation-check.sh
+++ b/web/scripts/mutation-check.sh
@@ -62,7 +62,10 @@ PLANSTATE="src/boundary/plan.ts"
 MUTABLE="$MUTABLE $LAYOUT $TREE $METHODS $CONTROL $ASSIGN $BASES $PLANNERCARD $POWERBLOCK"
 SURFACES="src/shell/surfaces.ts"
 
-MUTABLE="$MUTABLE $HASH $PLANSTATE $SURFACES"
+SEARCH="src/shell/TargetSearch.tsx"
+CATALOGUE="src/boundary/catalogue.ts"
+
+MUTABLE="$MUTABLE $HASH $PLANSTATE $SURFACES $SEARCH $CATALOGUE"
 MUTABLE="$MUTABLE $RESOLVE $STORED"
 
 # shellcheck disable=SC2086
@@ -704,6 +707,38 @@ check "switching surface leaves focus on the switcher" \
   tests/shell/surfaces.spec.ts "$SHELL" \
   "    surfaceRegion.current?.focus();" \
   "    void surfaceRegion.current;"
+
+# ----------------------------------------------------------------------
+# The target search.
+#
+# The first is the story in one line: the control it replaced accepted only
+# an item id, so a player who knew "Stasis Device" and not ULTRAPROD2 could
+# not load it. A search that matched ids alone would be that control again
+# with a listbox attached.
+# ----------------------------------------------------------------------
+
+check "the search stops matching display names" \
+  tests/shell/target-search.spec.ts "$CATALOGUE" \
+  "      item.name.toLowerCase().includes(needle) || item.id.toLowerCase().includes(needle)," \
+  "      item.id.toLowerCase().includes(needle),"
+
+check "a compiled-in item list appears in the view" \
+  tests/shell/target-search.spec.ts "$SEARCH" \
+  "/** How many results to render. The real catalogue is thousands of items. */" \
+  "const FALLBACK_ITEMS = [\"ULTRAPROD2\"];\n/** How many results to render. The real catalogue is thousands of items. */"
+
+# Caught by the shell's reading-order assertion, not by the search's own
+# spec: a scrollable container is focusable in Chrome whether or not the
+# search cares, and it is the tab order that notices.
+check "the results list goes back into the tab order" \
+  tests/shell/a11y-baseline.spec.ts "$SEARCH" \
+  "        tabIndex={-1}" \
+  "        tabIndex={0}"
+
+check "the result count becomes a second status region" \
+  tests/shell/target-search.spec.ts "$SEARCH" \
+  '<p id={countId} className="label target-count" aria-live="polite">' \
+  '<p id={countId} className="label target-count" role="status" aria-live="polite">'
 
 echo
 if [ "$failures" -gt 0 ]; then

--- a/web/src/boundary/catalogue.ts
+++ b/web/src/boundary/catalogue.ts
@@ -1,0 +1,66 @@
+/*
+ * The searchable item catalogue, decoded.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0011 REQ "The Catalogue
+ * Crosses the Boundary", REQ "Target Selection Is a Search Over Known
+ * Items", SPEC-0005 REQ "Boundary Client"
+ *
+ * Two fields per item and no more. The view searches names and ids and
+ * sends back an id; anything else here would be domain data the view is not
+ * allowed to reason about.
+ *
+ * All-or-nothing, like every other decoder in this directory. A catalogue
+ * missing one item silently is a search that cannot reach it, and "the item
+ * is not in the game" and "the item fell out of the payload" look identical
+ * from the search box.
+ */
+
+import { list, object, text } from "./decode";
+
+export interface CatalogueItem {
+  readonly id: string;
+  /** What a player recognises. Primary in the results; the id is secondary. */
+  readonly name: string;
+}
+
+function decodeItem(value: unknown): CatalogueItem | null {
+  const raw = object(value);
+  if (!raw) return null;
+
+  const id = text(raw["id"]);
+  const name = text(raw["name"]);
+  if (id === null || name === null) return null;
+
+  return { id, name };
+}
+
+/** Pull `data.catalogue.items` out of a result payload, or return null. */
+export function selectCatalogue(data: unknown): readonly CatalogueItem[] | null {
+  const payload = object(data);
+  const raw = payload === null ? null : object(payload["catalogue"]);
+  if (!raw) return null;
+  if (!Array.isArray(raw["items"])) return null;
+
+  return list(raw["items"], decodeItem);
+}
+
+/*
+ * Matching, kept out of the component so it can be tested without a page.
+ *
+ * SPEC-0011: the search "MUST match against both display name and id, MUST
+ * tolerate partial and inexact input". Case-folded substring over both
+ * fields is the whole of it — a fuzzier ranking would be inventing an order
+ * the spec does not ask for, and an exact match would be the id field this
+ * requirement exists to replace.
+ */
+export function matches(
+  items: readonly CatalogueItem[],
+  query: string,
+): readonly CatalogueItem[] {
+  const needle = query.trim().toLowerCase();
+  if (needle === "") return items;
+  return items.filter(
+    (item) =>
+      item.name.toLowerCase().includes(needle) || item.id.toLowerCase().includes(needle),
+  );
+}

--- a/web/src/boundary/client.ts
+++ b/web/src/boundary/client.ts
@@ -20,6 +20,7 @@
  */
 
 import type { PlannerModule } from "./contract";
+import { selectCatalogue, type CatalogueItem } from "./catalogue";
 import { decodeEnvelope, isNotReady, type Outcome } from "./envelope";
 import { selectBuild, type Build } from "./build";
 import { selectGraph, type ResolvedGraph } from "./graph";
@@ -125,6 +126,16 @@ export class BoundaryClient {
    * exactly as it costs one a rollup produced, and requiring a plan here
    * would invent a coupling the engine does not have.
    */
+  /**
+   * The searchable item catalogue.
+   *
+   * Called once, not per keystroke — SPEC-0011 § Rate Limiting. The caller
+   * holds the list and filters locally.
+   */
+  async catalogue(): Promise<Outcome<readonly CatalogueItem[]>> {
+    return this.#call((planner) => planner.catalogue(""), selectCatalogue);
+  }
+
   async power(request: PowerRequest): Promise<Outcome<Power>> {
     return this.#call((planner) => planner.power(powerToWire(request)), selectPower);
   }

--- a/web/src/boundary/contract.ts
+++ b/web/src/boundary/contract.ts
@@ -17,7 +17,16 @@
  * with the `contractVersion` on every envelope; a mismatch is reported
  * naming both and no payload is read.
  */
-export const EXPECTED_CONTRACT_VERSION = "1.3.0";
+/*
+ * Bumped to 1.4.0 by SPEC-0011's catalogue entry point.
+ *
+ * Additive — `resolve`, `rollup` and `power` are unchanged — but still a
+ * contract change, because a view built against 1.4.0 calls an entry point
+ * a 1.3.0 module does not carry. SPEC-0002's mismatch rule is what handles
+ * the skew: the view reports the mismatch and refuses the payload rather
+ * than calling into a namespace and getting an undefined back.
+ */
+export const EXPECTED_CONTRACT_VERSION = "1.4.0";
 
 /*
  * The stable code set from internal/bridge/errors.go.
@@ -87,4 +96,12 @@ export interface PlannerModule {
   resolve(planJSON: string): string;
   rollup(requestJSON: string): string;
   power(requestJSON: string): string;
+  /**
+   * The searchable item catalogue. Takes no input.
+   *
+   * Filtering is the view's job over a list it already holds — SPEC-0011
+   * § Rate Limiting forbids a crossing per keystroke — so there is nothing
+   * to send.
+   */
+  catalogue(argument: string): string;
 }

--- a/web/src/boundary/index.ts
+++ b/web/src/boundary/index.ts
@@ -10,6 +10,7 @@
  */
 
 export { BoundaryClient, type Readiness } from "./client";
+export { matches, type CatalogueItem } from "./catalogue";
 export {
   BoundaryModule,
   DEFAULT_PATHS,

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -50,6 +50,8 @@ const TreeCanvas = lazy(async () => ({
 }));
 import { DataCustody } from "./DataCustody";
 import { StoredPlaces } from "./StoredPlaces";
+import { TargetSearch } from "./TargetSearch";
+import { useCatalogue, type CatalogueState } from "./useCatalogue";
 import { SURFACES } from "./surfaces";
 import { ViewPreferences } from "./ViewPreferences";
 
@@ -118,10 +120,15 @@ function describeResolution(resolution: Resolution, groupSeparator: string): str
   }
 }
 
-function PlanForm({ onRecompute }: { onRecompute: () => void }): ReactNode {
+function PlanForm({
+  onRecompute,
+  catalogue,
+}: {
+  readonly onRecompute: () => void;
+  readonly catalogue: CatalogueState;
+}): ReactNode {
   const state = useViewState();
   const dispatch = useViewDispatch();
-  const targetId = useId();
   const quantityId = useId();
 
   const quantityLooksUsable = isQuantity(state.inputs.quantity);
@@ -135,15 +142,17 @@ function PlanForm({ onRecompute }: { onRecompute: () => void }): ReactNode {
       }}
     >
       <div className="control-row">
-        <label className="label" htmlFor={targetId}>
-          Target
-        </label>
-        <input
-          id={targetId}
-          className="control"
+        {/*
+          A search, not an id field. SPEC-0011: the control "MUST be a search
+          over known items, not a field accepting only an internal item id",
+          and the list arrives through the boundary rather than being
+          compiled in.
+        */}
+        <TargetSearch
+          catalogue={catalogue}
           value={state.inputs.target}
-          onChange={(event) => {
-            dispatch({ type: "setInput", field: "target", value: event.target.value });
+          onSelect={(itemId) => {
+            dispatch({ type: "setInput", field: "target", value: itemId });
           }}
         />
 
@@ -307,6 +316,7 @@ function Chrome({
     methods,
   );
   const stored = useStoredData(store);
+  const catalogue = useCatalogue(client);
 
   /*
    * The announcement is keyed to the result token, which changes exactly when
@@ -510,7 +520,7 @@ function Chrome({
             tabIndex={-1}
             ref={surfaceRegion}
           >
-            <PlanForm onRecompute={onRecompute} />
+            <PlanForm onRecompute={onRecompute} catalogue={catalogue} />
             <section className="panel" aria-label="Figures">
               <Figures resolution={resolution} />
             </section>

--- a/web/src/shell/TargetSearch.tsx
+++ b/web/src/shell/TargetSearch.tsx
@@ -105,7 +105,7 @@ export function TargetSearch({
      */
     return (
       <div className="target-search">
-        <span className="label">Target</span>{" "}
+        <span className="label">Target</span>
         <StatusBadge status="pending" detail="loading the item list" />
       </div>
     );
@@ -152,12 +152,17 @@ export function TargetSearch({
       />
 
       {/*
-        The count, announced as it changes. SPEC-0011 Accessibility
-        Requirements: "its result count is announced as it changes" — a
-        sighted player watches the list shrink, and this is the same
-        information for someone who cannot.
+        The count, announced as it changes — SPEC-0011 Accessibility
+        Requirements. A sighted player watches the list shrink; this is the
+        same information for someone who cannot.
+
+        Its own polite region, and deliberately not `role="status"`. The
+        shell's announcer is the status region and speaks about recomputes;
+        this speaks about a search. Sharing one made the search talk over
+        the domain — a test asserting the announcer is silent until a
+        recompute caught it immediately.
       */}
-      <p id={countId} className="label" aria-live="polite">
+      <p id={countId} className="label target-count" aria-live="polite">
         {found.length === 0
           ? "No items match"
           : `${String(found.length)} item${found.length === 1 ? "" : "s"} match${
@@ -187,6 +192,15 @@ export function TargetSearch({
         className="target-results"
         role="listbox"
         aria-label="Items"
+        /*
+         * Out of the tab order. The list scrolls, and Chrome makes a
+         * scrollable container focusable so it can be scrolled by keyboard —
+         * correct in general, and wrong here: it put a stop between the
+         * combobox and the quantity field, at a position below both, which
+         * the shell's reading-order assertion caught. In a combobox, focus
+         * stays on the input and the arrow keys move through the options.
+         */
+        tabIndex={-1}
         hidden={!open}
       >
         {shown.map((item, index) => (

--- a/web/src/shell/TargetSearch.tsx
+++ b/web/src/shell/TargetSearch.tsx
@@ -1,0 +1,219 @@
+import { useId, useMemo, useRef, useState, type ReactNode } from "react";
+
+import { matches, type CatalogueItem } from "../boundary";
+import { StatusBadge } from "./StatusBadge";
+import type { CatalogueState } from "./useCatalogue";
+
+/*
+ * Choosing what to build, by name.
+ *
+ * Governing: ADR-0004 (React view layer), ADR-0010 (places first and the
+ * shell), SPEC-0011 REQ "Target Selection Is a Search Over Known Items",
+ * Accessibility Requirements → Keyboard Navigation
+ *
+ * The control this replaces was a bare `<input>` whose value went to the
+ * domain as an item id, so the only way to load anything was to already
+ * know a string like `ULTRAPROD2`. That is the criterion this story is
+ * measured by: "a player who has never seen an item id can reach any
+ * selectable item".
+ *
+ * The list comes through the boundary and is held by the caller. Nothing
+ * here reads the Tier 1 artifact and there is no item literal in this file
+ * — SPEC-0011 forbids both, and `tests/shell/target-search.spec.ts` checks
+ * the second mechanically, because a compiled-in copy is the shortcut that
+ * works right up until the artifact changes.
+ *
+ * Filtering is local. SPEC-0011 § Rate Limiting: the search "MUST NOT issue
+ * a catalogue call per keystroke", and the list cannot change while the
+ * page is open.
+ *
+ * The name is primary and the id secondary, in that order in the DOM, so a
+ * screen reader reads what a player recognises first.
+ */
+
+export interface TargetSearchProps {
+  readonly catalogue: CatalogueState;
+  /** The item id currently chosen, or "" when nothing is. */
+  readonly value: string;
+  readonly onSelect: (itemId: string) => void;
+}
+
+/** How many results to render. The real catalogue is thousands of items. */
+const VISIBLE = 20;
+
+export function TargetSearch({
+  catalogue,
+  value,
+  onSelect,
+}: TargetSearchProps): ReactNode {
+  const inputId = useId();
+  const listId = useId();
+  const countId = useId();
+
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const items = catalogue.status === "ready" ? catalogue.items : [];
+  const found = useMemo(() => matches(items, query), [items, query]);
+  const shown = found.slice(0, VISIBLE);
+
+  const choose = (item: CatalogueItem): void => {
+    onSelect(item.id);
+    setQuery(item.name);
+    setOpen(false);
+    setActive(0);
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key === "Escape") {
+      /*
+       * Dismiss without selecting, which SPEC-0011 names as one of the
+       * three things the combobox must do by keyboard. The query is left
+       * alone: clearing it would be a second, unasked-for effect.
+       */
+      setOpen(false);
+      return;
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      if (!open) {
+        setOpen(true);
+        return;
+      }
+      if (shown.length === 0) return;
+      const step = event.key === "ArrowDown" ? 1 : -1;
+      setActive((current) => (current + step + shown.length) % shown.length);
+      return;
+    }
+    if (event.key === "Enter" && open) {
+      const item = shown[active];
+      if (item) {
+        event.preventDefault();
+        choose(item);
+      }
+    }
+  };
+
+  if (catalogue.status === "loading") {
+    /*
+     * A pending state, not an error and not an empty search. SPEC-0011
+     * requires the view "present a loading state and retry once readiness
+     * resolves, rather than reporting an error" — an empty combobox would
+     * be telling the player no item matches anything.
+     */
+    return (
+      <div className="target-search">
+        <span className="label">Target</span>{" "}
+        <StatusBadge status="pending" detail="loading the item list" />
+      </div>
+    );
+  }
+
+  if (catalogue.status === "failed") {
+    return (
+      <div className="target-search">
+        <span className="label">Target</span>{" "}
+        <StatusBadge status="danger" detail={catalogue.reason} />
+      </div>
+    );
+  }
+
+  const activeId =
+    shown[active] === undefined ? undefined : `${listId}-${String(active)}`;
+
+  return (
+    <div className="target-search">
+      <label className="label" htmlFor={inputId}>
+        Target
+      </label>
+      <input
+        id={inputId}
+        ref={inputRef}
+        className="control"
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-autocomplete="list"
+        aria-describedby={countId}
+        {...(activeId === undefined ? {} : { "aria-activedescendant": activeId })}
+        value={query}
+        onChange={(event) => {
+          setQuery(event.target.value);
+          setOpen(true);
+          setActive(0);
+        }}
+        onFocus={() => {
+          setOpen(true);
+        }}
+        onKeyDown={onKeyDown}
+      />
+
+      {/*
+        The count, announced as it changes. SPEC-0011 Accessibility
+        Requirements: "its result count is announced as it changes" — a
+        sighted player watches the list shrink, and this is the same
+        information for someone who cannot.
+      */}
+      <p id={countId} className="label" aria-live="polite">
+        {found.length === 0
+          ? "No items match"
+          : `${String(found.length)} item${found.length === 1 ? "" : "s"} match${
+              found.length === 1 ? "es" : ""
+            }`}
+        {found.length > VISIBLE ? `, showing ${String(VISIBLE)}` : ""}
+      </p>
+
+      {/*
+        The listbox is always in the DOM and hidden when closed, because
+        `aria-controls` on the input has to resolve to something — an
+        idref pointing at nothing is an axe violation and, worse, tells a
+        screen reader the combobox controls a region that is not there.
+
+        Options are `<li role="option">`, not buttons. In the combobox
+        pattern focus stays on the input and moves through
+        `aria-activedescendant`; a focusable option would put a second tab
+        stop per result in the shell's tab order, which is exactly what the
+        "tab order follows visual layout" assertion notices.
+
+        `onMouseDown` with preventDefault rather than `onClick`: a click on
+        an option blurs the input first, which closes the list, and the
+        click then lands on nothing.
+      */}
+      <ul
+        id={listId}
+        className="target-results"
+        role="listbox"
+        aria-label="Items"
+        hidden={!open}
+      >
+        {shown.map((item, index) => (
+          <li
+            key={item.id}
+            id={`${listId}-${String(index)}`}
+            role="option"
+            /*
+             * The id as an attribute, not only as rendered text. A test
+             * choosing "ANTIMATTER" by text also matches "Antimatter
+             * Housing", which is a real item — so the selection was
+             * ambiguous and silently resolved the wrong tree.
+             */
+            data-item-id={item.id}
+            aria-selected={item.id === value}
+            className={`target-result${index === active ? " target-result-active" : ""}`}
+            onMouseDown={(event) => {
+              event.preventDefault();
+              choose(item);
+            }}
+          >
+            {/* Name first, id second — what a player recognises leads. */}
+            <span className="target-result-name">{item.name}</span>{" "}
+            <span className="label target-result-id">{item.id}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/shell/useCatalogue.ts
+++ b/web/src/shell/useCatalogue.ts
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState } from "react";
+
+import type { BoundaryClient, CatalogueItem } from "../boundary";
+
+/*
+ * The item catalogue, fetched once.
+ *
+ * Governing: ADR-0004 (React view layer), SPEC-0011 REQ "The Catalogue
+ * Crosses the Boundary", REQ "Target Selection Is a Search Over Known
+ * Items", § Rate Limiting, SPEC-0005 REQ "Module Loading"
+ *
+ * Once, not per keystroke. SPEC-0011 § Rate Limiting is explicit that "the
+ * search MUST NOT issue a catalogue call per keystroke", and the list does
+ * not change while the page is open — the artifact is loaded once and the
+ * catalogue is a projection of it.
+ *
+ * The retry is the readiness contract, not a general one. SPEC-0011: "WHEN
+ * the catalogue is requested before the module is ready THEN the view
+ * presents a loading state and retries once readiness resolves, rather than
+ * reporting an error." So a NOT_READY answer waits for readiness and asks
+ * again; anything else is a real failure and is reported as one.
+ */
+
+export type CatalogueState =
+  /** Asked, and waiting. Not an error, and not an empty list. */
+  | { readonly status: "loading" }
+  | { readonly status: "ready"; readonly items: readonly CatalogueItem[] }
+  /** The module answered, and it was not a readiness problem. */
+  | { readonly status: "failed"; readonly reason: string };
+
+const LOADING: CatalogueState = Object.freeze({ status: "loading" });
+
+async function fetchCatalogue(client: BoundaryClient): Promise<CatalogueState> {
+  const outcome = await client.catalogue();
+  if (outcome.kind === "ok") return { status: "ready", items: outcome.value };
+
+  /*
+   * A version mismatch is never retried. This story bumps the contract to
+   * add the entry point, so a view built against 1.4.0 against an older
+   * module is exactly the skew SPEC-0002's mismatch rule exists for — the
+   * answer is to report it, not to ask a module that does not carry the
+   * entry point a second time.
+   */
+  if (outcome.kind === "version-mismatch") {
+    return { status: "failed", reason: outcome.message };
+  }
+
+  /*
+   * NOT_READY is the module saying "ask again", which is what `start`
+   * waits for. Every other code is something going wrong, and retrying it
+   * would loop.
+   */
+  if (outcome.code !== "NOT_READY") {
+    return { status: "failed", reason: outcome.message };
+  }
+
+  await client.start();
+  const second = await client.catalogue();
+  return second.kind === "ok"
+    ? { status: "ready", items: second.value }
+    : { status: "failed", reason: second.message };
+}
+
+export function useCatalogue(client: BoundaryClient): CatalogueState {
+  const [state, setState] = useState<CatalogueState>(LOADING);
+
+  /*
+   * The in-flight promise, not a "have I asked" flag.
+   *
+   * A boolean guard deadlocks under StrictMode: the first effect starts the
+   * fetch, its cleanup marks the result unwanted, and the second effect
+   * sees the flag already set and never fetches — so nothing ever settles
+   * and the control sits on its loading state forever. Caching the promise
+   * gives one crossing and lets every mount subscribe to it.
+   */
+  const pending = useRef<Promise<CatalogueState> | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    pending.current ??= fetchCatalogue(client);
+    void pending.current.then((next) => {
+      if (live) setState(next);
+    });
+    return () => {
+      live = false;
+    };
+  }, [client]);
+
+  return state;
+}

--- a/web/src/styles/shell.css
+++ b/web/src/styles/shell.css
@@ -167,3 +167,59 @@
 .surface:focus {
   outline: none;
 }
+
+/*
+ * The target search.
+ *
+ * Governing: SPEC-0011 REQ "Target Selection Is a Search Over Known Items"
+ *
+ * The results list is positioned rather than inline so it does not push the
+ * form around as the count changes, and the active option is marked by more
+ * than colour — the border is what carries it if colour is removed.
+ */
+.target-search {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.target-results {
+  position: absolute;
+  z-index: 1;
+  margin: 0;
+  padding: var(--space-1);
+  border: var(--border-width) solid var(--border);
+  border-radius: var(--radius-panel);
+  background-color: var(--panel-raised);
+  inset-block-start: 100%;
+  inset-inline: 0;
+  list-style: none;
+  max-block-size: 18rem;
+  overflow-y: auto;
+}
+
+.target-result {
+  display: flex;
+  align-items: baseline;
+  padding: var(--control-pad-y-sm) var(--space-2);
+  border: var(--border-width) solid transparent;
+  border-radius: var(--radius-control);
+  cursor: pointer;
+  gap: var(--space-2);
+}
+
+/*
+ * The active option is marked by a border as well as a colour, so the
+ * distinction survives colour being removed — the same rule the status
+ * badges follow.
+ */
+.target-result-active {
+  border-color: var(--ok);
+  background-color: var(--input-bg);
+  color: var(--text-bright);
+}
+
+.target-result-id {
+  color: var(--text-muted);
+}

--- a/web/src/styles/shell.css
+++ b/web/src/styles/shell.css
@@ -177,11 +177,31 @@
  * form around as the count changes, and the active option is marked by more
  * than colour — the border is what carries it if colour is removed.
  */
+
+/*
+ * A row, not a column.
+ *
+ * The label and the input sit side by side like every other control in the
+ * form. A column put the input lower than its neighbours, so tabbing from
+ * it to the quantity field moved up and to the right — which the shell's
+ * "tab order follows visual layout" assertion correctly called out as
+ * against reading order.
+ *
+ * The count and the results are taken out of flow for the same reason:
+ * either one in flow changes the row's height as the player types.
+ */
 .target-search {
   position: relative;
   display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.target-count {
+  position: absolute;
+  inset-block-start: 100%;
+  inset-inline-start: 0;
+  white-space: nowrap;
 }
 
 .target-results {

--- a/web/tests/boundary/integration.spec.ts
+++ b/web/tests/boundary/integration.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+import { EXPECTED_CONTRACT_VERSION } from "../../src/boundary/contract";
+
 /*
  * Governing: ADR-0003 (Go domain, thin adapter), ADR-0004 (React view layer),
  * SPEC-0005 REQ "Boundary Client", REQ "The View Computes No Domain Values"
@@ -130,7 +132,7 @@ test("the real module's contract version is the one this view was built for", as
     return (globalThis as unknown as { nmsPlanner: { contractVersion: string } })
       .nmsPlanner.contractVersion;
   });
-  expect(version).toBe("1.3.0");
+  expect(version).toBe(EXPECTED_CONTRACT_VERSION);
 });
 
 test("changing an input produces a fresh crossing rather than a derived figure", async ({

--- a/web/tests/boundary/lifecycle.spec.ts
+++ b/web/tests/boundary/lifecycle.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+import { EXPECTED_CONTRACT_VERSION } from "../../src/boundary/contract";
+
 /*
  * Governing: ADR-0004 (React view layer), SPEC-0005 REQ "Boundary Client",
  * REQ "Module Loading"
@@ -78,7 +80,7 @@ test("a module reporting another contract version is refused, naming both", asyn
 
   expect(outcome.kind).toBe("version-mismatch");
   expect(outcome.received).toBe("9.9.9");
-  expect(outcome.expected).toBe("1.3.0");
+  expect(outcome.expected).toBe(EXPECTED_CONTRACT_VERSION);
 });
 
 test("a contract mismatch does not even fetch the artifact", async ({ page }) => {

--- a/web/tests/canvas/assignment.spec.ts
+++ b/web/tests/canvas/assignment.spec.ts
@@ -493,7 +493,7 @@ test.describe("in the shell", () => {
       .getByLabel("Gathered at")
       .selectOption(await placeId(page, PLACE));
 
-    const live = page.locator('[aria-live="polite"]');
+    const live = page.getByRole("status");
     /* The player's own name for the place, not a slot number. */
     await expect(live).toContainText(`${leaf} assigned to ${PLACE}`);
   });
@@ -513,9 +513,7 @@ test.describe("in the shell", () => {
     await select.selectOption(await placeId(page, PLACE));
     await select.selectOption("");
 
-    await expect(page.locator('[aria-live="polite"]')).toContainText(
-      "no longer assigned",
-    );
+    await expect(page.getByRole("status")).toContainText("no longer assigned");
     await page.keyboard.press("Escape");
     await expect(card).toHaveAttribute("data-identity", "unassigned");
   });

--- a/web/tests/canvas/assignment.spec.ts
+++ b/web/tests/canvas/assignment.spec.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { expect, test, type Page } from "@playwright/test";
 
-import { openPlanner, openSurface } from "../helpers/surfaces";
+import { openPlanner, openSurface, chooseTarget } from "../helpers/surfaces";
 
 import { basesFrom, slotFor, UNNAMED_PLACE } from "../../src/canvas/bases";
 import type { PlaceRecord } from "../../src/store";
@@ -38,7 +38,7 @@ const CANVAS = { name: "Dependency tree" } as const;
 const FIXTURE = "/tests/fixtures/assignment.html";
 
 async function resolve(page: Page, target: string): Promise<void> {
-  await page.getByLabel("Target").fill(target);
+  await chooseTarget(page, target);
   await page.getByRole("button", { name: "Recompute" }).click();
   await expect(
     page.getByRole("region", CANVAS).locator(".node-card").first(),

--- a/web/tests/canvas/degraded.spec.ts
+++ b/web/tests/canvas/degraded.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { openPlanner } from "../helpers/surfaces";
+import { openPlanner, chooseTarget } from "../helpers/surfaces";
 
 /*
  * What the canvas does when it cannot draw.
@@ -25,7 +25,7 @@ const CANVAS = { name: "Dependency tree" } as const;
 const ELK_CHUNK = "**/*elk*";
 
 async function recompute(page: Page, target: string): Promise<void> {
-  await page.getByLabel("Target").fill(target);
+  await chooseTarget(page, target);
   await page.getByRole("button", { name: "Recompute" }).click();
   /* The figure list, which does not depend on the layout engine. */
   await expect(page.getByRole("heading", { level: 3 })).toBeVisible({ timeout: 20_000 });

--- a/web/tests/canvas/edges.spec.ts
+++ b/web/tests/canvas/edges.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { openPlanner } from "../helpers/surfaces";
+import { openPlanner, chooseTarget } from "../helpers/surfaces";
 
 import { toCanvasModel } from "../../src/canvas/graph-model";
 import { asQuantity } from "../../src/boundary/quantity";
@@ -32,7 +32,7 @@ function q(value: string): Quantity {
 }
 
 async function resolve(page: Page, target: string): Promise<void> {
-  await page.getByLabel("Target").fill(target);
+  await chooseTarget(page, target);
   await page.getByRole("button", { name: "Recompute" }).click();
   await expect(
     page.getByRole("region", CANVAS).locator(".node-card").first(),

--- a/web/tests/canvas/layout.spec.ts
+++ b/web/tests/canvas/layout.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { openPlanner } from "../helpers/surfaces";
+import { openPlanner, chooseTarget } from "../helpers/surfaces";
 
 import { toCanvasModel, toLayoutInput } from "../../src/canvas/graph-model";
 import { NODE_HEIGHT, NODE_WIDTH, toElkGraph } from "../../src/canvas/layout";
@@ -198,7 +198,7 @@ test("changing the target quantity does not move a single node", async ({ page }
    */
   await page.goto("/");
   await openPlanner(page);
-  await page.getByLabel("Target").fill("ULTRAPROD2");
+  await chooseTarget(page, "ULTRAPROD2");
 
   const atOne = await positionsFor(page, "1");
   expect(atOne.length, "no nodes were placed").toBe(36);
@@ -221,7 +221,7 @@ test("the totals did change, so the comparison above means something", async ({
    */
   await page.goto("/");
   await openPlanner(page);
-  await page.getByLabel("Target").fill("ULTRAPROD2");
+  await chooseTarget(page, "ULTRAPROD2");
 
   await positionsFor(page, "1");
   const first = await page

--- a/web/tests/canvas/method-control.spec.ts
+++ b/web/tests/canvas/method-control.spec.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { expect, test, type Page } from "@playwright/test";
 
-import { openPlanner } from "../helpers/surfaces";
+import { openPlanner, chooseTarget } from "../helpers/surfaces";
 
 import { METHOD_ORDER, methodOptions } from "../../src/canvas/methods";
 import { countCrossings, crossings } from "../helpers/crossings";
@@ -29,7 +29,7 @@ import { countCrossings, crossings } from "../helpers/crossings";
 const CANVAS = { name: "Dependency tree" } as const;
 
 async function resolve(page: Page, target: string): Promise<void> {
-  await page.getByLabel("Target").fill(target);
+  await chooseTarget(page, target);
   await page.getByRole("button", { name: "Recompute" }).click();
   await expect(
     page.getByRole("region", CANVAS).locator(".node-card").first(),

--- a/web/tests/canvas/method-control.spec.ts
+++ b/web/tests/canvas/method-control.spec.ts
@@ -309,7 +309,7 @@ test.describe("in the shell", () => {
       .filter({ hasText: swap.to })
       .click();
 
-    const live = page.locator('[aria-live="polite"]');
+    const live = page.getByRole("status");
     await expect(live).toContainText(`${swap.name} set to ${swap.to}`, {
       timeout: 20_000,
     });

--- a/web/tests/canvas/node-card.spec.ts
+++ b/web/tests/canvas/node-card.spec.ts
@@ -1,7 +1,7 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test, type Locator, type Page } from "@playwright/test";
 
-import { openPlanner } from "../helpers/surfaces";
+import { openPlanner, chooseTarget } from "../helpers/surfaces";
 
 /*
  * What a node says about itself.
@@ -27,7 +27,7 @@ const CANVAS = { name: "Dependency tree" } as const;
 const FIXTURE = "/tests/fixtures/node-card.html";
 
 async function resolve(page: Page, target: string): Promise<void> {
-  await page.getByLabel("Target").fill(target);
+  await chooseTarget(page, target);
   await page.getByRole("button", { name: "Recompute" }).click();
   await expect(
     page.getByRole("region", CANVAS).locator(".node-card").first(),

--- a/web/tests/canvas/rendering.spec.ts
+++ b/web/tests/canvas/rendering.spec.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { expect, test, type Page } from "@playwright/test";
 
-import { openPlanner, openSurface } from "../helpers/surfaces";
+import { openPlanner, openSurface, chooseTarget } from "../helpers/surfaces";
 
 import { countCrossings, crossings, payloadOrder } from "../helpers/crossings";
 
@@ -24,7 +24,7 @@ const CANVAS = { name: "Dependency tree" } as const;
 const LARGE_TARGET = "ULTRAPROD2";
 
 async function resolve(page: Page, target: string): Promise<void> {
-  await page.getByLabel("Target").fill(target);
+  await chooseTarget(page, target);
   await page.getByRole("button", { name: "Recompute" }).click();
   await expect(page.getByRole("region", CANVAS)).toBeVisible({ timeout: 30_000 });
   await expect(

--- a/web/tests/fixtures/fake/shim.js
+++ b/web/tests/fixtures/fake/shim.js
@@ -27,7 +27,7 @@ globalThis.Go = class {
 
     if (script.neverPublish === true) return;
 
-    const version = script.contractVersion ?? "1.3.0";
+    const version = script.contractVersion ?? "1.4.0";
     let readyAfter = script.notReadyTimes ?? 0;
 
     const envelope = (body) => JSON.stringify({ contractVersion: version, ...body });
@@ -72,6 +72,16 @@ globalThis.Go = class {
       },
       rollup: () => failure("MALFORMED_INPUT", "not scripted"),
       power: () => failure("MALFORMED_INPUT", "not scripted"),
+      /*
+       * The catalogue entry point exists on the fake for the same reason
+       * the others do: the client calls it on mount now, and a fake missing
+       * an entry point fails as "undefined is not a function" rather than
+       * as whatever the test was actually about.
+       */
+      catalogue: () =>
+        script.catalogue === undefined
+          ? envelope({ ok: true, data: { catalogue: { items: [] } } })
+          : script.catalogue(),
     };
   }
 };

--- a/web/tests/helpers/crossings.ts
+++ b/web/tests/helpers/crossings.ts
@@ -25,11 +25,13 @@ export interface Crossings {
   readonly resolve: number;
   readonly rollup: number;
   readonly power: number;
+  /** SPEC-0011 § Rate Limiting: not one per keystroke. */
+  readonly catalogue: number;
 }
 
 declare global {
   interface Window {
-    __crossings: { resolve: number; rollup: number; power: number };
+    __crossings: { resolve: number; rollup: number; power: number; catalogue: number };
     /** The raw payload of the last resolve, for order comparisons. */
     __lastResolve: unknown;
   }
@@ -37,7 +39,7 @@ declare global {
 
 export async function countCrossings(page: Page): Promise<void> {
   await page.addInitScript(() => {
-    window.__crossings = { resolve: 0, rollup: 0, power: 0 };
+    window.__crossings = { resolve: 0, rollup: 0, power: 0, catalogue: 0 };
     window.__lastResolve = null;
 
     let real: unknown = undefined;

--- a/web/tests/helpers/surfaces.ts
+++ b/web/tests/helpers/surfaces.ts
@@ -43,9 +43,20 @@ export async function chooseTarget(page: Page, itemId: string): Promise<void> {
   await expect(search).toBeVisible({ timeout: 30_000 });
   await search.fill(itemId);
 
-  const option = page.getByRole("option").filter({ hasText: itemId }).first();
-  await expect(option, `no catalogue item matched ${itemId}`).toBeVisible({
+  /*
+   * Selected by attribute, not by text. The catalogue is the real 2,237-item
+   * artifact: searching "ANTIMATTER" matches five items, four of them by
+   * name — "Antimatter Housing", "Antimatter Observation Orb" and two
+   * trails. A `hasText` filter takes whichever comes first in artifact
+   * order, which is `AM_HOUSING`, so the tree resolved for the wrong item
+   * and every assertion after it looked for nodes that were never coming.
+   */
+  const option = page.locator(`[role="option"][data-item-id="${itemId}"]`);
+  await expect(option, `no catalogue item has id ${itemId}`).toBeVisible({
     timeout: 30_000,
   });
   await option.click();
+
+  /* And it took. A silent miss here is a wrong tree three assertions later. */
+  await expect(search).not.toHaveValue("");
 }

--- a/web/tests/helpers/surfaces.ts
+++ b/web/tests/helpers/surfaces.ts
@@ -24,3 +24,28 @@ export async function openSurface(page: Page, name: string): Promise<void> {
 export async function openPlanner(page: Page): Promise<void> {
   await openSurface(page, "Planner");
 }
+
+/*
+ * Choosing a target through the search.
+ *
+ * Governing: SPEC-0011 REQ "Target Selection Is a Search Over Known Items"
+ *
+ * The control used to be a bare input, so a test could `fill` an item id and
+ * be done. It is a combobox now and selection is a deliberate act — typing
+ * filters, choosing commits — which is the whole point of the requirement:
+ * a player who has never seen an id can still reach the item.
+ *
+ * Filtering by the id rather than the name because that is what the callers
+ * already had, and the search matches both.
+ */
+export async function chooseTarget(page: Page, itemId: string): Promise<void> {
+  const search = page.getByRole("combobox", { name: "Target" });
+  await expect(search).toBeVisible({ timeout: 30_000 });
+  await search.fill(itemId);
+
+  const option = page.getByRole("option").filter({ hasText: itemId }).first();
+  await expect(option, `no catalogue item matched ${itemId}`).toBeVisible({
+    timeout: 30_000,
+  });
+  await option.click();
+}

--- a/web/tests/shell/a11y-baseline.spec.ts
+++ b/web/tests/shell/a11y-baseline.spec.ts
@@ -229,44 +229,73 @@ test("Escape dismisses from anywhere inside the dialog, not only from its first 
   await expect(page.getByRole("dialog")).toBeHidden();
 });
 
-test("no composite widget exists without arrow-key navigation", async ({ page }) => {
+test("the composite widget that exists is navigable by arrow keys", async ({ page }) => {
   /*
-   * SPEC-0005 requires arrow keys within composite widgets. The shell has no
-   * composite widget yet, so a test driving arrow keys would assert nothing
-   * and pass forever.
+   * This replaces a guard, as that guard asked to be replaced.
    *
-   * This is the honest form: it enumerates the roles that carry an arrow-key
-   * obligation and fails the moment one appears, so the requirement is
-   * enforced at the point it becomes real rather than remembered later. The
-   * tree canvas (SPEC-0006) and its method and recipe controls are where that
-   * is expected to happen.
+   * SPEC-0005 requires arrow keys within composite widgets. The shell had
+   * none, so the honest form was a test that enumerated the roles carrying
+   * that obligation and failed the moment one appeared — "replace this guard
+   * with a test that drives the arrow keys". SPEC-0011's target search is
+   * the combobox that made it real.
+   */
+  await openPlanner(page);
+  const search = page.getByRole("combobox", { name: "Target" });
+  await expect(search).toBeVisible({ timeout: 30_000 });
+
+  await search.fill("carbon");
+  const options = page.getByRole("option");
+  await expect(options.first()).toBeVisible();
+
+  /* Down moves the active option, and the input keeps focus throughout. */
+  const firstActive = await search.getAttribute("aria-activedescendant");
+  await page.keyboard.press("ArrowDown");
+  const secondActive = await search.getAttribute("aria-activedescendant");
+  expect(secondActive, "ArrowDown did not move the active option").not.toBe(firstActive);
+  await expect(search).toBeFocused();
+
+  /* Up comes back. */
+  await page.keyboard.press("ArrowUp");
+  expect(await search.getAttribute("aria-activedescendant")).toBe(firstActive);
+
+  /* Enter commits the active option without a pointer. */
+  await page.keyboard.press("Enter");
+  await expect(search).not.toHaveValue("carbon");
+  await expect(page.getByRole("option")).toHaveCount(0);
+});
+
+test("no other composite widget has appeared without arrow-key navigation", async ({
+  page,
+}) => {
+  /*
+   * The original guard, narrowed rather than deleted. The combobox and its
+   * listbox now have the test above; every other role carrying an arrow-key
+   * obligation still has none, so the guard still earns its place for them.
    */
   await resolveAPlan(page);
   await page.locator(".figure-row").first().click();
   await expect(page.getByRole("dialog")).toBeVisible();
 
-  const COMPOSITE_ROLES = [
+  const UNCOVERED_ROLES = [
     "tablist",
     "menu",
     "menubar",
-    "listbox",
     "tree",
     "grid",
     "radiogroup",
     "toolbar",
-    "combobox",
   ];
 
   const present = await page.evaluate(
     (roles) =>
       roles.filter((role) => document.querySelector(`[role="${role}"]`) !== null),
-    COMPOSITE_ROLES,
+    UNCOVERED_ROLES,
   );
 
   expect(
     present,
     "a composite widget appeared — SPEC-0005 requires arrow-key navigation within it, " +
-      "so replace this guard with a test that drives the arrow keys",
+      "so replace this entry with a test that drives the arrow keys",
   ).toEqual([]);
 });
 

--- a/web/tests/shell/a11y-baseline.spec.ts
+++ b/web/tests/shell/a11y-baseline.spec.ts
@@ -1,7 +1,7 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test, type Page } from "@playwright/test";
 
-import { openPlanner } from "../helpers/surfaces";
+import { openPlanner, chooseTarget } from "../helpers/surfaces";
 
 import { ICON_ONLY_CONTROL_AUDIT } from "../helpers/accessible-name";
 import { STATUSES } from "../../src/shell/StatusBadge";
@@ -34,7 +34,7 @@ import { STATUSES } from "../../src/shell/StatusBadge";
 const SHELL = "/";
 
 async function resolveAPlan(page: Page): Promise<void> {
-  await page.getByLabel("Target").fill("ANTIMATTER");
+  await chooseTarget(page, "ANTIMATTER");
   await page.getByRole("button", { name: "Recompute" }).click();
   await expect(page.getByRole("heading", { level: 3 })).toBeVisible({ timeout: 20_000 });
 }

--- a/web/tests/shell/a11y-primitives.spec.ts
+++ b/web/tests/shell/a11y-primitives.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { openPlanner } from "../helpers/surfaces";
+import { openPlanner, chooseTarget } from "../helpers/surfaces";
 
 import { STATUSES } from "../../src/shell/StatusBadge";
 
@@ -16,7 +16,7 @@ import { STATUSES } from "../../src/shell/StatusBadge";
 async function openTheFirstNodePopover(page: Page): Promise<void> {
   await page.goto("/");
   await openPlanner(page);
-  await page.getByLabel("Target").fill("ANTIMATTER");
+  await chooseTarget(page, "ANTIMATTER");
   await page.getByRole("button", { name: "Recompute" }).click();
   await expect(page.getByRole("heading", { level: 3 })).toBeVisible({ timeout: 20_000 });
 
@@ -115,7 +115,7 @@ test("the live region announces on recompute and not on render", async ({ page }
    */
   await expect(region).toHaveText("");
 
-  await page.getByLabel("Target").fill("ANTIMATTER");
+  await chooseTarget(page, "ANTIMATTER");
   await expect(region).toHaveText("");
 
   await page.getByRole("button", { name: "Recompute" }).click();
@@ -125,7 +125,7 @@ test("the live region announces on recompute and not on render", async ({ page }
 test("the announcement names what changed", async ({ page }) => {
   await page.goto("/");
   await openPlanner(page);
-  await page.getByLabel("Target").fill("ANTIMATTER");
+  await chooseTarget(page, "ANTIMATTER");
   await page.getByRole("button", { name: "Recompute" }).click();
 
   const region = page.getByRole("status");
@@ -141,7 +141,7 @@ test("a preference change does not announce", async ({ page }) => {
    */
   await page.goto("/");
   await openPlanner(page);
-  await page.getByLabel("Target").fill("ANTIMATTER");
+  await chooseTarget(page, "ANTIMATTER");
   await page.getByRole("button", { name: "Recompute" }).click();
 
   const region = page.getByRole("status");

--- a/web/tests/shell/shell.spec.ts
+++ b/web/tests/shell/shell.spec.ts
@@ -87,16 +87,23 @@ test("the shell passes a WCAG 2.1 AA audit with figures on screen", async ({ pag
   ).toEqual([]);
 });
 
-test("figures are pending rather than zero while the module loads", async ({ page }) => {
+test("nothing is shown as zero while the module loads", async ({ page }) => {
   /*
    * SPEC-0005 REQ "Module Loading": "figures dependent on it are shown as
    * pending, not as zero". A zero is a claim about the plan; a pending is a
    * claim about the module, and only one of them is true here.
    *
-   * The binary is held for a second so the pending state is actually on
-   * screen to be asserted. Without the delay the module loads faster than
-   * the assertion runs and the test passes by never observing the state it
-   * is about.
+   * The observation point moved with SPEC-0011. This used to hold the binary
+   * for a second, type an item id into a bare input and assert the figures
+   * read "Pending" — but target selection is a search over the catalogue
+   * now, and the catalogue comes from the module, so there is no longer a
+   * window in which a plan can be submitted while the module is still
+   * loading. That window is not missing coverage; it is unreachable.
+   *
+   * What is still reachable, and is the requirement's actual content, is
+   * that nothing fabricates a figure while the module is on its way. So the
+   * binary is still held, and the assertions are that the surface says it is
+   * waiting and that no zero appears anywhere on it.
    */
   await page.route("**/planner.wasm", async (route) => {
     await new Promise((resume) => setTimeout(resume, 1000));
@@ -105,16 +112,22 @@ test("figures are pending rather than zero while the module loads", async ({ pag
   await page.goto("/");
   await openPlanner(page);
 
-  await chooseTarget(page, "ANTIMATTER");
-  await page.getByRole("button", { name: "Recompute" }).click();
+  const main = page.getByRole("main");
 
-  const figures = page.getByLabel("Figures");
-  await expect(figures).toContainText("Pending");
-  await expect(figures).not.toContainText("0");
+  /* Waiting, and saying so. */
+  await expect(main.getByText(/Pending/i).first()).toBeVisible();
+
+  /*
+   * And no fabricated figure anywhere while it waits — not in the figures
+   * region, not on a card, nowhere.
+   */
+  await expect(main.getByText(/^0$/)).toHaveCount(0);
 
   /* And it resolves, so "pending forever" cannot pass this either. */
+  await chooseTarget(page, "ANTIMATTER");
+  await page.getByRole("button", { name: "Recompute" }).click();
   await expect(page.getByRole("heading", { level: 3 })).toBeVisible({ timeout: 20_000 });
-  await expect(figures).not.toContainText("Pending");
+  await expect(page.getByLabel("Figures")).not.toContainText("Pending");
 });
 
 test("changing an input takes the stale figures away rather than adjusting them", async ({

--- a/web/tests/shell/shell.spec.ts
+++ b/web/tests/shell/shell.spec.ts
@@ -1,7 +1,7 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test, type Page } from "@playwright/test";
 
-import { openPlanner } from "../helpers/surfaces";
+import { openPlanner, chooseTarget } from "../helpers/surfaces";
 
 /*
  * Governing: ADR-0004 (React view layer), SPEC-0005 Accessibility
@@ -13,7 +13,7 @@ import { openPlanner } from "../helpers/surfaces";
  */
 
 async function resolveAPlan(page: Page, target = "ANTIMATTER"): Promise<void> {
-  await page.getByLabel("Target").fill(target);
+  await chooseTarget(page, target);
   await page.getByRole("button", { name: "Recompute" }).click();
   await expect(page.getByRole("heading", { level: 3 })).toBeVisible({ timeout: 20_000 });
 
@@ -105,7 +105,7 @@ test("figures are pending rather than zero while the module loads", async ({ pag
   await page.goto("/");
   await openPlanner(page);
 
-  await page.getByLabel("Target").fill("ANTIMATTER");
+  await chooseTarget(page, "ANTIMATTER");
   await page.getByRole("button", { name: "Recompute" }).click();
 
   const figures = page.getByLabel("Figures");

--- a/web/tests/shell/stored-preferences.spec.ts
+++ b/web/tests/shell/stored-preferences.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { openPlanner, openSurface } from "../helpers/surfaces";
+import { openPlanner, openSurface, chooseTarget } from "../helpers/surfaces";
 
 import { fromStored, toStored, differ } from "../../src/state/preferences";
 import { INITIAL_VIEW_STATE } from "../../src/state/view-state";
@@ -275,7 +275,7 @@ test("a place with no stocked quantity renders absent, not zero", async ({ page 
    * player does: choose what to build, then look at what they have.
    */
   await openPlanner(page);
-  await page.getByLabel("Target").fill("ANTIMATTER");
+  await chooseTarget(page, "ANTIMATTER");
   await openSurface(page, "Bases");
 
   const row = page
@@ -320,7 +320,7 @@ test("a stocked zero is shown as zero, because the player entered it", async ({
    * player does: choose what to build, then look at what they have.
    */
   await openPlanner(page);
-  await page.getByLabel("Target").fill("ANTIMATTER");
+  await chooseTarget(page, "ANTIMATTER");
   await openSurface(page, "Bases");
 
   const row = page

--- a/web/tests/shell/surfaces.spec.ts
+++ b/web/tests/shell/surfaces.spec.ts
@@ -134,8 +134,14 @@ test("a surface that needs the module presents its own state rather than disappe
 
   const planner = page.getByRole("region", { name: "Planner", exact: true });
   await expect(planner).toBeVisible();
-  /* Its own controls are there; it is the figures that have nothing yet. */
-  await expect(planner.getByLabel("Target")).toBeVisible();
+  /*
+   * Its own state, which is the requirement — not necessarily its finished
+   * controls. With the module blocked the catalogue cannot arrive, so the
+   * target search shows its pending state rather than a combobox over an
+   * empty list, and the surface says so instead of vanishing.
+   */
+  await expect(planner.locator(".target-search")).toBeVisible();
+  await expect(planner.getByRole("button", { name: "Recompute" })).toBeVisible();
 });
 
 test("no router package is installed", () => {

--- a/web/tests/shell/target-search.spec.ts
+++ b/web/tests/shell/target-search.spec.ts
@@ -1,0 +1,177 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { expect, test, type Page } from "@playwright/test";
+
+import { matches, type CatalogueItem } from "../../src/boundary";
+import { countCrossings, crossings } from "../helpers/crossings";
+import { openPlanner } from "../helpers/surfaces";
+
+/*
+ * Governing: ADR-0004 (React view layer), ADR-0010 (places first and the
+ * shell), SPEC-0011 REQ "Target Selection Is a Search Over Known Items",
+ * REQ "The Catalogue Crosses the Boundary", § Rate Limiting
+ *
+ * The criterion this story is measured by is one sentence: "a player who
+ * has never seen an item id can reach any selectable item". The control it
+ * replaces was a bare input whose value went to the domain as an id, so the
+ * only way to load anything was to already know a string like ULTRAPROD2.
+ */
+
+const SEARCH = { name: "Target" } as const;
+
+async function openSearch(page: Page): Promise<void> {
+  await countCrossings(page);
+  await page.goto("/");
+  await openPlanner(page);
+  await expect(page.getByRole("combobox", SEARCH)).toBeVisible({ timeout: 30_000 });
+}
+
+/* ----------------------------------------------------------------------
+ * Matching, as a pure function
+ * ------------------------------------------------------------------- */
+
+const CATALOGUE: readonly CatalogueItem[] = [
+  { id: "ANTIMATTER", name: "Antimatter" },
+  { id: "AM_HOUSING", name: "Antimatter Housing" },
+  { id: "ULTRAPROD2", name: "Stasis Device" },
+  { id: "CAVE2", name: "Cobalt" },
+];
+
+test("the search matches a display name, which is the whole point", () => {
+  /*
+   * The failure being fixed: a player who knows the item as "Stasis Device"
+   * had no way to reach `ULTRAPROD2`.
+   */
+  expect(matches(CATALOGUE, "stasis").map((item) => item.id)).toEqual(["ULTRAPROD2"]);
+});
+
+test("the search still matches an id, for anyone who has one", () => {
+  expect(matches(CATALOGUE, "ULTRAPROD2").map((item) => item.id)).toEqual(["ULTRAPROD2"]);
+});
+
+test("matching is partial and case-insensitive", () => {
+  expect(matches(CATALOGUE, "ANTI").length).toBe(2);
+  expect(matches(CATALOGUE, "anti").length).toBe(2);
+  expect(matches(CATALOGUE, "  Device ").map((item) => item.id)).toEqual(["ULTRAPROD2"]);
+});
+
+test("an empty query is every item, not no items", () => {
+  /*
+   * A combobox that showed nothing until you typed would be the id field
+   * again for anyone who does not know what to type.
+   */
+  expect(matches(CATALOGUE, "").length).toBe(CATALOGUE.length);
+});
+
+/* ----------------------------------------------------------------------
+ * No compiled-in list
+ * ------------------------------------------------------------------- */
+
+test("no view source carries an item list of its own", () => {
+  /*
+   * SPEC-0011: the searchable list "MUST arrive through the module
+   * boundary… and MUST NOT ship a compiled-in copy of the item list". The
+   * criterion asks for this mechanically, "the way tests/card/discipline
+   * .spec.ts checks for arithmetic", because a compiled-in copy is the
+   * shortcut that works right up until the artifact changes and then lies.
+   *
+   * Real item ids, from the shipped artifact. A view file mentioning one is
+   * either hard-coding the catalogue or reasoning about a specific item,
+   * and both are the same mistake.
+   */
+  const REAL_IDS = ["ULTRAPROD2", "AM_HOUSING", "CAVE2"];
+
+  const roots = ["shell", "canvas", "card", "state"].map((name) =>
+    path.join(import.meta.dirname, "..", "..", "src", name),
+  );
+
+  let scanned = 0;
+  for (const root of roots) {
+    for (const file of readdirSync(root)) {
+      if (!file.endsWith(".ts") && !file.endsWith(".tsx")) continue;
+      scanned += 1;
+      const code = readFileSync(path.join(root, file), "utf8").replace(
+        /\/\*[\s\S]*?\*\/|\/\/[^\n]*/g,
+        "",
+      );
+      for (const id of REAL_IDS) {
+        expect(code.includes(id), `${file} hard-codes the item ${id}`).toBe(false);
+      }
+    }
+  }
+  expect(scanned, "no view sources were scanned").toBeGreaterThan(10);
+});
+
+/* ----------------------------------------------------------------------
+ * In the shell
+ * ------------------------------------------------------------------- */
+
+test("a player who has never seen an id can reach an item by name", async ({ page }) => {
+  await openSearch(page);
+
+  await page.getByRole("combobox", SEARCH).fill("stasis device");
+  const option = page.locator('[role="option"][data-item-id="ULTRAPROD2"]');
+  await expect(option, "the item was unreachable by its display name").toBeVisible();
+
+  /* The name leads and the id follows, so what a player recognises is first. */
+  await expect(option.locator(".target-result-name")).toHaveText("Stasis Device");
+  await expect(option.locator(".target-result-id")).toHaveText("ULTRAPROD2");
+
+  await option.click();
+  await page.getByRole("button", { name: "Recompute" }).click();
+  await expect(page.getByRole("heading", { level: 3 })).toBeVisible({ timeout: 30_000 });
+});
+
+test("typing does not cross the boundary once per keystroke", async ({ page }) => {
+  /*
+   * SPEC-0011 § Rate Limiting. The list cannot change while the page is
+   * open, so one crossing is the right number however much is typed.
+   */
+  await openSearch(page);
+  const before = (await crossings(page)).catalogue;
+  expect(before, "the catalogue was never fetched").toBeGreaterThan(0);
+
+  await page.getByRole("combobox", SEARCH).pressSequentially("chromatic", { delay: 20 });
+  await expect(page.getByRole("option").first()).toBeVisible();
+
+  expect(
+    (await crossings(page)).catalogue,
+    "the search re-fetched the catalogue while the player typed",
+  ).toBe(before);
+});
+
+test("the result count is announced, and separately from the shell's announcer", async ({
+  page,
+}) => {
+  await openSearch(page);
+  const search = page.getByRole("combobox", SEARCH);
+
+  await search.fill("chromatic");
+  const count = page.locator(".target-count");
+  await expect(count).toContainText(/match/i);
+
+  const narrow = await count.innerText();
+  await search.fill("chromatic metal");
+  await expect(count).not.toHaveText(narrow);
+
+  /*
+   * And it is not the shell's status region. Two announcers sharing one
+   * role means the search talks over the domain's recompute.
+   */
+  await expect(page.getByRole("status")).toHaveCount(1);
+  await expect(page.getByRole("status")).not.toContainText("match");
+});
+
+test("Escape dismisses without selecting", async ({ page }) => {
+  await openSearch(page);
+  const search = page.getByRole("combobox", SEARCH);
+
+  await search.fill("cobalt");
+  await expect(page.getByRole("option").first()).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("option")).toHaveCount(0);
+  /* Dismissed, not cleared — clearing would be a second, unasked-for effect. */
+  await expect(search).toHaveValue("cobalt");
+});


### PR DESCRIPTION
Closes #147. Part of #143.

Implements SPEC-0011 REQ "The Catalogue Crosses the Boundary", REQ "Target Selection Is a Search Over Known Items".

> Stacked on #161 → #160. Merge order: **#160 → #161 → this**.

The target control was a bare input whose value went to the domain as an item id, so the only way to load anything was to already know a string like `ULTRAPROD2`. It is a search now, over a catalogue that arrives through the module boundary, matching display names and ids, with the name leading.

## The Go half

`catalogue` is an entry point returning each selectable item's id and display name, listed in `EntryPoints`, reachable through `Call` by name, and subject to the same readiness sentinel as every other stage. Three Go tests cover the payload shape, the not-ready path, and dispatch by name.

The payload carries **only** id and name — asserted by marshalling the envelope and checking `recipes`, `default_method` and `verified` are absent, because anything more would be domain data the view is not allowed to reason about.

**The contract moves to 1.4.0.** Additive, but still a contract change: a view built against 1.4.0 calls an entry point a 1.3.0 module does not carry. SPEC-0002's mismatch rule handles the skew, and `useCatalogue` never retries a mismatch — asking a module that lacks the entry point a second time only loops.

## The view half

A decoder, a client method, a hook that fetches once (not per keystroke, per SPEC-0011 § Rate Limiting), and a combobox that matches names *and* ids, tolerates partial input, shows the name first and the id second, filters locally, moves through results with the arrow keys, dismisses with Escape, and announces its result count as it changes.

`tests/shell/target-search.spec.ts` is new — nine tests covering reach-by-name, the name leading, one crossing regardless of keystrokes, the count announcement, and Escape dismissing without clearing. One of them is mechanical rather than behavioural: it scans `src/{shell,canvas,card,state}` for real artifact ids, because "the view carries no item list of its own" is an absence, and an absence has to be checked at the source or not at all.

## Five defects found on the way, all mine

**A StrictMode deadlock.** A boolean "have I asked" guard is incompatible with the double-mount: the first effect starts the fetch, its cleanup marks the result unwanted, and the second sees the flag set and never fetches — so nothing settles and the control sits on its loading state forever. The in-flight promise is cached instead, so one crossing happens and both mounts subscribe to it.

**Two ARIA faults in my own markup.** Options were nested `<button>`s, which puts a tab stop per result into the shell's tab order. And `aria-controls` pointed at a listbox that only existed while open — an idref to nothing. The listbox is always present and `hidden`; options are list items and focus stays on the input via `aria-activedescendant`.

**A third tab stop I did not predict.** The listbox scrolls, and Chrome makes scrollable containers focusable whether or not they have a role that wants focus — so it took a tab stop anyway, below both the controls it sits between. The shell's reading-order assertion caught it. `tabIndex={-1}`.

**Two racing live regions.** The result count was a second `aria-live` region, so every test locating the shell's announcer matched two elements. The count keeps its own polite region and is deliberately not `role="status"`; tests locate the announcer by role.

**Choosing a target by text is ambiguous against the real artifact.** `"ANTIMATTER"` matches five of the 2,237 items, four of them by name, and the first in artifact order is `AM_HOUSING` — so tests silently resolved the wrong tree and every assertion after it looked for nodes that were never going to be there. Options carry `data-item-id` and the helper selects on it.

## Two existing tests changed rather than worked around

The composite-widget guard asked in its own failure message to be replaced by a test that drives the arrow keys, once a composite widget existed. This is that widget, so it is replaced by a real arrow-key test and the guard is narrowed to the roles still uncovered (`tablist`, `menu`, `menubar`, `tree`, `grid`, `radiogroup`, `toolbar`).

The figures-pending test observed a window that no longer exists: it selected a target before the module was ready, and target selection now needs the catalogue, which needs the module. It asserts the requirement's actual content instead — that nothing is fabricated as a zero while the module loads — with a comment recording why the old observation point is unreachable.

## Mutations

Four added, all verified to turn the suite red:

| Mutation | Watched by |
|---|---|
| the search stops matching display names | `target-search.spec.ts` |
| a compiled-in item list appears in the view | `target-search.spec.ts` |
| the results list goes back into the tab order | `a11y-baseline.spec.ts` |
| the result count becomes a second status region | `target-search.spec.ts` |

The third initially named the wrong spec and did not go red — the tab order is watched by the shell's reading-order assertion, not by the search's own file. Retargeted, and the whole 68-mutation suite passes.

**Green:** 363 web tests, all Go tests, and the six gates (`lint`, `lint:css`, `typecheck`, `format:check`, `check:tokens`, `build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
